### PR TITLE
feat: implement `verify` subcommand for benchmark sanity checks

### DIFF
--- a/LeanBench.lean
+++ b/LeanBench.lean
@@ -5,6 +5,7 @@ import LeanBench.Child
 import LeanBench.Run
 import LeanBench.Stats
 import LeanBench.Compare
+import LeanBench.Verify
 import LeanBench.Format
 import LeanBench.Cli
 

--- a/LeanBench/Child.lean
+++ b/LeanBench/Child.lean
@@ -128,7 +128,12 @@ def emitRow
     ] ++ "}"
   IO.println row
 
-/-- Top-level child entry point. -/
+/-- Top-level child entry point.
+
+    Catches exceptions thrown by the runner (e.g. a panicking
+    function-under-test) and emits a structured `error` row so the
+    parent — and `verify` in particular — can show the failure
+    reason rather than just an exit code. -/
 def runChildMode (benchName : Lean.Name) (param targetNanos : Nat) : IO UInt32 := do
   match ← findRuntimeEntry benchName with
   | none =>
@@ -137,9 +142,14 @@ def runChildMode (benchName : Lean.Name) (param targetNanos : Nat) : IO UInt32 :
       (some s!"unregistered benchmark: {benchName}")
     return 1
   | some entry =>
-    let loop ← entry.runner param
-    let (count, total, hash) ← autoTune loop targetNanos
-    emitRow benchName param count total hash .ok
-    return 0
+    try
+      let loop ← entry.runner param
+      let (count, total, hash) ← autoTune loop targetNanos
+      emitRow benchName param count total hash .ok
+      return (0 : UInt32)
+    catch e =>
+      let msg := s!"runner threw: {e.toString}"
+      emitRow benchName param 0 0 none (.error msg) (some msg)
+      return (1 : UInt32)
 
 end LeanBench

--- a/LeanBench/Cli.lean
+++ b/LeanBench/Cli.lean
@@ -4,6 +4,7 @@ import LeanBench.Env
 import LeanBench.Run
 import LeanBench.Child
 import LeanBench.Compare
+import LeanBench.Verify
 import LeanBench.Format
 
 /-!
@@ -18,8 +19,8 @@ runner). Subcommand layout:
 | `./bench`                                                       | parent: print all registered benchmark names |
 | `./bench list`                                                  | parent: same |
 | `./bench run NAME`                                              | parent: run one benchmark, print report |
-| `./bench compare A B C`                                         | parent: TODO v0.1 — comparison report |
-| `./bench verify`                                                | parent: TODO — `f 0` and `f 1` sanity check via children |
+| `./bench compare A B C`                                         | parent: comparison report |
+| `./bench verify [NAMES…]`                                        | parent: bounded `f 0` / `f 1` sanity check via children |
 | `./bench _child --bench NAME --param N --target-nanos T`        | child: one inner-tuned batch, print one JSONL row, exit |
 
 CLI parsing uses `Cli` (mhuisi/lean4-cli).
@@ -56,6 +57,16 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
   let report ← LeanBench.compare (names.map String.toName)
   IO.println (Format.fmtComparison report)
   return 0
+
+def runVerifyCmd (p : Cli.Parsed) : IO UInt32 := do
+  let names := p.variableArgsAs! String |>.toList |>.map Lean.Name.mkSimple
+  match ← (LeanBench.verify names |>.toBaseIO) with
+  | .error e =>
+    IO.eprintln s!"verify: {e.toString}"
+    return (1 : UInt32)
+  | .ok reports =>
+    IO.println (Format.fmtVerify reports)
+    return if reports.all (·.passed) then (0 : UInt32) else (1 : UInt32)
 
 /-! ## Subcommand handler (child side) -/
 
@@ -98,6 +109,14 @@ def compareSub : Cmd := `[Cli|
     ...names : String;     "Two or more benchmark names (variadic)."
 ]
 
+def verifySub : Cmd := `[Cli|
+  verify VIA runVerifyCmd; ["0.1.0"]
+  "Sanity-check registered benchmarks (f 0, f 1 via the child path). Verifies all benchmarks if no names are given. Exit code is non-zero on any failure."
+
+  ARGS:
+    ...names : String;     "Optional: benchmark names to verify; verify all if omitted."
+]
+
 /-- Top-level dispatcher; the user calls this as their `main`. -/
 def topCmd : Cmd := `[Cli|
   bench NOOP; ["0.1.0"]
@@ -107,6 +126,7 @@ def topCmd : Cmd := `[Cli|
     listSub;
     runSub;
     compareSub;
+    verifySub;
     childSub
 ]
 

--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -1,5 +1,6 @@
 import LeanBench.Core
 import LeanBench.Env
+import LeanBench.Verify
 
 /-!
 # `LeanBench.Format` — printers
@@ -200,6 +201,33 @@ def fmtResult (r : BenchmarkResult) : String := Id.run do
 def fmtSpec (spec : BenchmarkSpec) : String :=
   let h := if spec.hashable then "" else "  (no Hashable)"
   s!"  {spec.name}    expected complexity: {spec.complexityFormula}{h}"
+
+/-- Render one verify report. Passing reports render as a single
+    line. Failing reports render as a header line followed by one
+    indented line per failed check, so users see every distinct
+    failure (e.g. `f 0` and `f 1` may fail for different reasons). -/
+def fmtVerifyReport (r : VerifyReport) : String :=
+  if r.passed then
+    s!"  [ok ] {r.spec.name}"
+  else
+    let header := s!"  [FAIL] {r.spec.name}"
+    let failures := r.checks.filterMap (·.failure)
+    let body := failures.toList.map (fun msg => s!"         —  {msg}")
+    "\n".intercalate (header :: body)
+
+/-- Render the full verify summary for a list of reports. -/
+def fmtVerify (reports : Array VerifyReport) : String := Id.run do
+  if reports.isEmpty then
+    return "(no benchmarks registered)"
+  let mut lines : Array String := #[s!"verifying {reports.size} benchmark(s)..."]
+  for r in reports do
+    lines := lines.push (fmtVerifyReport r)
+  let failed := reports.filter (! ·.passed) |>.size
+  let summary :=
+    if failed == 0 then s!"all {reports.size} benchmark(s) passed"
+    else s!"{failed} of {reports.size} benchmark(s) failed verification"
+  lines := lines.push summary
+  return "\n".intercalate lines.toList
 
 /-- Render a `ComparisonReport` as a per-function block list plus a
     summary noting the common-param intersection. -/

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -96,19 +96,31 @@ def runOneBatch (spec : BenchmarkSpec) (param : Nat) : IO DataPoint := do
     stderr := .piped
     stdin := .null
   }
+  -- Drain stderr concurrently so a chatty child can't fill the pipe
+  -- buffer and deadlock its own write — the parent would then
+  -- misreport the child as timing out / killed at cap. Whatever the
+  -- child wrote to stderr is appended to the synthesized error row
+  -- when the child exits non-zero.
+  let stderrTask ← child.stderr.readToEnd.asTask
   let stdout ← child.stdout.readToEnd
   let exit ← child.wait
+  let stderrText : String :=
+    match stderrTask.get with
+    | .ok s => s.trimAscii.toString
+    | .error _ => ""
+  let withStderr (msg : String) : String :=
+    if stderrText.isEmpty then msg else s!"{msg}; stderr: {stderrText}"
   match exit with
   | 0 =>
     let line := stdout.trimAscii.toString
     if line.isEmpty then
-      return synthRow param (.error "child exited 0 but produced no output")
+      return synthRow param (.error (withStderr "child exited 0 but produced no output"))
     match parseChildRow line with
     | .ok row => return row
-    | .error e => return synthRow param (.error s!"parse: {e}")
+    | .error e => return synthRow param (.error (withStderr s!"parse: {e}"))
   | 124 => return synthRow param .killedAtCap
   | 137 => return synthRow param .killedAtCap
-  | other => return synthRow param (.error s!"child exited with code {other}")
+  | other => return synthRow param (.error (withStderr s!"child exited with code {other}"))
 
 /-- Doubling ladder from floor through ceiling. -/
 def paramLadder (cfg : BenchmarkConfig) : Array Nat := Id.run do

--- a/LeanBench/Setup.lean
+++ b/LeanBench/Setup.lean
@@ -27,7 +27,8 @@ It auto-generates two top-level defs and a single `register` call.
 There is intentionally **no** elaboration-time subprocess spawning;
 Codex review identified that as the worst design choice in the
 original draft (circular and phase-dependent). Compiled-code sanity
-checks live in `lean-bench verify` (a CLI subcommand) instead.
+checks live in `lean-bench verify` (a CLI subcommand) — see
+[`LeanBench.Verify`](Verify.lean).
 
 The `where { ... }` clause for overriding `BenchmarkConfig` defaults
 is on the v0.2 roadmap; in v0.1 every benchmark uses default config.

--- a/LeanBench/Verify.lean
+++ b/LeanBench/Verify.lean
@@ -1,0 +1,107 @@
+import Lean
+import LeanBench.Core
+import LeanBench.Env
+import LeanBench.Run
+
+/-!
+# `LeanBench.Verify` — registration sanity checks
+
+`lean-bench verify` is a smoke test for registered benchmarks. For
+each benchmark it spawns the same child-process dispatch that `run`
+uses, but at small parameter values (`f 0` and `f 1`) and with a
+tight inner-tuning target. The aim is to surface broken registrations
+(child fails to start, output is unparseable, hashing path crashes,
+function panics at small inputs) before a user invests in a full
+`run`.
+
+Checks performed per benchmark:
+
+1. The child process starts and emits a row that the parent can parse
+   (covered by `runOneBatch` itself returning a non-error `DataPoint`).
+2. The child reports `status: "ok"` for `param = 0` and `param = 1`.
+3. If the benchmark's return type has a `Hashable` instance, the
+   child emitted a `result_hash`.
+
+Each check is bounded by the spec's existing `maxSecondsPerCall` cap,
+so a misbehaving benchmark cannot hang `verify` indefinitely.
+-/
+
+open Lean
+
+namespace LeanBench
+
+/-- Tight inner-tuning target used by `verify`. We only need enough
+    work to amortise child startup and exercise the hashing path; we
+    don't need a stable measurement. 1ms (so `autoTune` doubles until
+    ≥500µs) is well below the default 500ms used by `run`. -/
+def verifyTargetInnerNanos : Nat := 1_000_000
+
+/-- The params we exercise per benchmark. -/
+def verifyParams : Array Nat := #[0, 1]
+
+/-- One check inside a `VerifyReport`. -/
+structure VerifyCheck where
+  /-- The parameter the child was invoked with. -/
+  param   : Nat
+  /-- The `DataPoint` the parent observed. -/
+  point   : DataPoint
+  /-- `none` iff the check passed. Otherwise a short human-readable
+      description of why it failed. -/
+  failure : Option String
+  deriving Inhabited
+
+def VerifyCheck.passed (c : VerifyCheck) : Bool := c.failure.isNone
+
+/-- The verification result for a single benchmark. -/
+structure VerifyReport where
+  spec   : BenchmarkSpec
+  checks : Array VerifyCheck
+  deriving Inhabited
+
+def VerifyReport.passed (r : VerifyReport) : Bool :=
+  r.checks.all (·.passed)
+
+/-- Decide whether one `(param, DataPoint)` observation passes the
+    sanity checks for `spec`. -/
+def classifyCheck (spec : BenchmarkSpec) (param : Nat) (dp : DataPoint) :
+    Option String :=
+  match dp.status with
+  | .ok =>
+    if spec.hashable && dp.resultHash.isNone then
+      some s!"hashable benchmark but child returned no result_hash at param={param}"
+    else
+      none
+  | .timedOut    => some s!"timed out at param={param}"
+  | .killedAtCap => some s!"killed at maxSecondsPerCall cap at param={param}"
+  | .error msg   => some s!"child error at param={param}: {msg}"
+
+/-- Verify one registered benchmark. -/
+def verifyOne (spec : BenchmarkSpec) : IO VerifyReport := do
+  -- Use the spec's own cap so users can opt into more time per call,
+  -- but shrink the inner-tuning target so verify is cheap.
+  let liteCfg := { spec.config with targetInnerNanos := verifyTargetInnerNanos }
+  let liteSpec := { spec with config := liteCfg }
+  let mut checks : Array VerifyCheck := #[]
+  for param in verifyParams do
+    let dp ← runOneBatch liteSpec param
+    let failure := classifyCheck spec param dp
+    checks := checks.push { param, point := dp, failure }
+  return { spec, checks }
+
+/-- Verify the named benchmarks (or all of them, if `names` is empty).
+
+    Throws `IO.userError` for any name that isn't registered, so the
+    caller can surface the failure cleanly to the user. -/
+def verify (names : List Lean.Name) : IO (Array VerifyReport) := do
+  let entries ← match names with
+    | []    => allRuntimeEntries
+    | names =>
+      let mut acc : Array RuntimeEntry := #[]
+      for n in names do
+        match ← findRuntimeEntry n with
+        | some e => acc := acc.push e
+        | none   => throw (.userError s!"unregistered benchmark: {n}")
+      pure acc
+  entries.mapM (fun e => verifyOne e.spec)
+
+end LeanBench

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ name = "my_benchmarks"
 root = "MyBenchmarks"
 ```
 
-Then `lake exe my_benchmarks list / run NAME / compare A B …`. See
-[doc/quickstart.md](doc/quickstart.md).
+Then `lake exe my_benchmarks list / run NAME / compare A B / verify …`.
+See [doc/quickstart.md](doc/quickstart.md).
 
 ## Status
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -90,8 +90,9 @@ branching leaking through the design.
   choice in the original draft: it makes the elaborator depend on
   the compiled binary, which is circular and phase-dependent. v0.1
   static checks only verify symbol existence, arity, and complexity
-  type. Compiled-code sanity checks live in `lean-bench verify` (a
-  CLI subcommand, not yet implemented).
+  type. Compiled-code sanity checks live in `lean-bench verify`,
+  which spawns the existing child path against `f 0` and `f 1` for
+  each registered benchmark and reports any non-`ok` rows.
 
 - **Strong verdict labels.** The verdict fits the log-log slope β of
   `C` vs `param` over the trimmed tail (leading 20% of ratios

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -51,7 +51,19 @@ $ lake exe bench run myFib
 ... result table ...
 $ lake exe bench compare myFib someOtherFib
 ... comparison report ...
+$ lake exe bench verify
+verifying 1 benchmark(s)...
+  [ok ] «myFib»
+all 1 benchmark(s) passed
 ```
+
+`verify` spawns the child path against `f 0` and `f 1` for each
+registered benchmark (or just the named ones). Use it as a fast
+smoke test that a registration is wired up correctly: child dispatch
+works, the row is parseable, and (when the return type is `Hashable`)
+the hashing path produces a hash. Each check is bounded by the
+benchmark's `maxSecondsPerCall`. Exit code is non-zero if any check
+fails.
 
 ## Optional: per-param setup with `with prep := …`
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -5,7 +5,7 @@ defaultTargets = [
   "LeanBenchExampleFib", "fib_benchmark_example",
   "LeanBenchExampleSort", "sort_benchmark_example",
   "binary_search_benchmark_example",
-  "LeanBenchTest", "roundtrip_benchmark_test",
+  "LeanBenchTest", "roundtrip_benchmark_test", "verify_benchmark_test",
 ]
 
 [[require]]
@@ -56,3 +56,8 @@ roots = ["LeanBenchTestSetupErrors"]
 name = "roundtrip_benchmark_test"
 srcDir = "test"
 root = "LeanBenchTestRoundtrip"
+
+[[lean_exe]]
+name = "verify_benchmark_test"
+srcDir = "test"
+root = "LeanBenchTestVerify"

--- a/test/LeanBenchTestVerify.lean
+++ b/test/LeanBenchTestVerify.lean
@@ -1,0 +1,188 @@
+import LeanBench
+
+/-!
+# `verify` command tests
+
+Coverage:
+
+1. `verify` against a working benchmark passes; both `f 0` and
+   `f 1` are exercised, and since the return type is `Hashable` a
+   hash is produced for every check.
+2. `verify` against a non-existent name throws a `userError` so the
+   CLI can report it cleanly.
+3. End-to-end subprocess failure: `verifyOne` against a spec whose
+   name is not registered in the runtime registry produces a failed
+   report. This exercises the real spawn → child error path → parent
+   classification pipeline, not just the synthetic `VerifyReport`
+   formatting path.
+4. `classifyCheck` distinguishes pass from fail in all four
+   meaningful (status × hashable × hash-present) combinations.
+5. The formatter marks a failing report, lists every failure, and
+   the multi-report summary line counts failures correctly.
+-/
+
+namespace LeanBench.Test.Verify
+
+/-- A trivial, fast, hashable benchmark. -/
+def trivialFn (n : Nat) : UInt64 := n.toUInt64
+
+setup_benchmark trivialFn n => n + 1
+
+end LeanBench.Test.Verify
+
+open LeanBench
+
+/-- Substring containment helper (`String.contains` is `Char`-based). -/
+private def stringContains (haystack needle : String) : Bool :=
+  ((haystack.splitOn needle).length) > 1
+
+/-- The `setup_benchmark` macro registers names as proper hierarchical
+    `Name`s (via `quote fnName`), so the test looks up the same shape. -/
+private def benchmarkName : Lean.Name :=
+  `LeanBench.Test.Verify.trivialFn
+
+/-- Build a `DataPoint` shaped like the kind a child would emit. -/
+private def mkOkPoint (param : Nat) (hash : Option UInt64 := some 0) : DataPoint :=
+  { param, innerRepeats := 1, totalNanos := 100, perCallNanos := 100.0
+  , resultHash := hash, status := .ok }
+
+private def mkErrorPoint (param : Nat) (msg : String) : DataPoint :=
+  { param, innerRepeats := 0, totalNanos := 0, perCallNanos := 0.0
+  , resultHash := none, status := .error msg }
+
+private def hashableSpec : BenchmarkSpec :=
+  { name := `dummyHashable
+  , complexityName := `dummy_complexity
+  , complexityFormula := "<dummy>"
+  , runCheckedName := `dummy_run
+  , hashable := true
+  , config := {} }
+
+private def nonHashableSpec : BenchmarkSpec :=
+  { hashableSpec with name := `dummyNoHash, hashable := false }
+
+/-- `classifyCheck` invariants. -/
+def testClassify : IO UInt32 := do
+  let okHash      := classifyCheck hashableSpec    0 (mkOkPoint 0 (some 0xdeadbeef))
+  let okNoHashH   := classifyCheck hashableSpec    0 (mkOkPoint 0 none)
+  let okNoHashNH  := classifyCheck nonHashableSpec 0 (mkOkPoint 0 none)
+  let err         := classifyCheck hashableSpec    0 (mkErrorPoint 0 "boom")
+  if okHash.isSome then
+    IO.eprintln "expected ok+hash to pass for hashable benchmark"
+    return 1
+  if okNoHashH.isNone then
+    IO.eprintln "expected ok-without-hash to fail for hashable benchmark"
+    return 1
+  if okNoHashNH.isSome then
+    IO.eprintln "expected ok-without-hash to pass for non-hashable benchmark"
+    return 1
+  if err.isNone then
+    IO.eprintln "expected error status to fail"
+    return 1
+  return 0
+
+/-- Verify of the registered `trivialFn` benchmark must pass.
+    Pin the contract: both `f 0` and `f 1` are exercised. -/
+def testHappyPath : IO UInt32 := do
+  let reports ← LeanBench.verify [benchmarkName]
+  if reports.size != 1 then
+    IO.eprintln s!"expected 1 report, got {reports.size}"
+    return 1
+  let r := reports[0]!
+  unless r.passed do
+    IO.eprintln s!"verify report unexpectedly failed: {Format.fmtVerifyReport r}"
+    return 1
+  let exercisedParams := r.checks.map (·.param)
+  unless exercisedParams == #[0, 1] do
+    IO.eprintln s!"expected params #[0, 1], got {exercisedParams}"
+    return 1
+  for c in r.checks do
+    unless c.point.resultHash.isSome do
+      IO.eprintln s!"hashable benchmark missing result_hash at param={c.param}"
+      return 1
+  return 0
+
+/-- End-to-end subprocess failure: a spec whose `name` is not in the
+    runtime registry triggers the child's "unregistered benchmark"
+    error path. The spawned child emits an error row and exits 1; the
+    parent classifies the resulting `DataPoint` as a failure. This
+    exercises the full pipeline (spawn, parse/synth, classify) for a
+    deterministic failure without needing a hanging benchmark. -/
+def testEndToEndFailure : IO UInt32 := do
+  let bogusSpec : BenchmarkSpec :=
+    { name := Lean.Name.mkSimple "definitely.not.registered"
+    , complexityName := `dummy_complexity
+    , complexityFormula := "<dummy>"
+    , runCheckedName := `dummy_run
+    , hashable := true
+    , config := {} }
+  let report ← verifyOne bogusSpec
+  if report.passed then
+    IO.eprintln s!"expected verifyOne on a fake spec to fail, got: {Format.fmtVerifyReport report}"
+    return 1
+  -- Every check should be flagged.
+  unless report.checks.all (! ·.passed) do
+    IO.eprintln s!"expected all checks to fail, got: {Format.fmtVerifyReport report}"
+    return 1
+  -- And the surfaced failure reason should mention the child failure,
+  -- not (e.g.) a hash mismatch.
+  let allMessages := report.checks.toList.filterMap (·.failure)
+  unless allMessages.any (fun msg => stringContains msg "child") do
+    IO.eprintln s!"expected failure messages to mention 'child', got: {allMessages}"
+    return 1
+  return 0
+
+/-- Verify against a name that isn't registered must throw. -/
+def testUnregistered : IO UInt32 := do
+  let result ← (LeanBench.verify [`definitelyNotRegistered]).toBaseIO
+  match result with
+  | .error _ => return 0
+  | .ok _ =>
+    IO.eprintln "expected verify to throw on unregistered benchmark"
+    return 1
+
+/-- The formatter must mark a failing report and explain why. -/
+def testFormatterFailure : IO UInt32 := do
+  let failingReport : VerifyReport :=
+    { spec := hashableSpec
+    , checks := #[
+        { param := 0
+        , point := mkErrorPoint 0 "child exited with code 1"
+        , failure := some "child error at param=0: child exited with code 1" } ] }
+  let line := Format.fmtVerifyReport failingReport
+  unless stringContains line "FAIL" do
+    IO.eprintln s!"expected FAIL marker, got: {line}"
+    return 1
+  unless stringContains line "child error" do
+    IO.eprintln s!"expected failure message, got: {line}"
+    return 1
+  let summary := Format.fmtVerify #[failingReport]
+  unless stringContains summary "1 of 1" do
+    IO.eprintln s!"expected '1 of 1' summary, got: {summary}"
+    return 1
+  return 0
+
+/-- Run all verify tests, fail-fast. -/
+def runTests : IO UInt32 := do
+  for (label, t) in
+    [("classify", testClassify),
+     ("happyPath", testHappyPath),
+     ("unregistered", testUnregistered),
+     ("endToEndFailure", testEndToEndFailure),
+     ("formatterFailure", testFormatterFailure)]
+  do
+    let code ← t
+    if code != 0 then
+      IO.eprintln s!"FAIL: {label}"
+      return code
+    IO.println s!"  ok  {label}"
+  IO.println "verify tests passed"
+  return 0
+
+/-- The same compiled binary acts as parent (test driver) and child
+    (single-batch runner spawned by `verify`). The presence of the
+    `_child` first arg distinguishes them. -/
+def main (args : List String) : IO UInt32 :=
+  match args with
+  | "_child" :: _ => LeanBench.Cli.dispatch args
+  | _ => runTests


### PR DESCRIPTION
## Summary

Implements `lean-bench verify`, the planned smoke-test subcommand for
registered benchmarks (closes #16). For each registered benchmark
(or just the named ones), it spawns the existing child path against
`f 0` and `f 1`, then asserts:

- the child process started and emitted a parseable JSONL row
- the child reported `status: "ok"`
- if the spec is `Hashable`, the child produced a `result_hash`

Each check uses a tight inner-tuning target (1ms) and the spec's own
`maxSecondsPerCall` cap, so a misbehaving registration cannot hang
the command. The CLI exit code is non-zero on any failure, and
failures render one line per failed check so that `f 0` and `f 1`
symptoms aren't masked by each other.

```
$ lake exe fib_benchmark_example verify
verifying 2 benchmark(s)...
  [ok ] «LeanBench.Examples.Fib.goodFib»
  [ok ] «LeanBench.Examples.Fib.badFib»
all 2 benchmark(s) passed
```

## Diagnosability fixes uncovered by Codex review

`verify`'s value depends on the child's failure path being
informative. Two pre-existing rough edges were tightened:

- `runChildMode` now wraps the runner in `try/catch` and emits a
  structured error row instead of just exiting non-zero, so a
  panicking function-under-test produces a readable failure message.
- `runOneBatch` drains the child's stderr concurrently. Previously a
  chatty crash could fill the pipe buffer, deadlock the child's
  write, and get misreported as a timeout/cap-kill. Captured stderr
  is now appended to synthesized error rows.

## Test plan

- [x] `verify_benchmark_test` passes (success path, unregistered-name
  error path, end-to-end subprocess failure path, `classifyCheck`
  truth table, formatter output for failures)
- [x] `roundtrip_benchmark_test` still passes
- [x] `lake exe <example> verify` produces all-green for each shipped
  example (Fib, Sort, BinarySearch)
- [x] `lake exe <example> run …` still completes a full ladder
  (regression check on the stderr/child changes)
- [x] `lake build` is green with no new warnings

🤖 Prepared with Claude Code