### PR TITLE
feat: slope-based verdict, column-aligned report, autotune probe/jump

### DIFF
--- a/LeanBench/Child.lean
+++ b/LeanBench/Child.lean
@@ -23,10 +23,35 @@ open Lean
 
 namespace LeanBench
 
-/-- Auto-tuning loop: call `runner count param` once (the loop body
-lives inside the runner so the function-under-test can be inlined
-into it), keep doubling `count` until total wall time ≥ `targetNanos
-/ 2`.
+/-- Smallest power of two `≥ n`. `0 ↦ 1`, `1 ↦ 1`, `5 ↦ 8`. -/
+private partial def nextPowerOfTwo : Nat → Nat
+  | 0 => 1
+  | n =>
+    let rec go (p : Nat) : Nat := if p ≥ n then p else go (p * 2)
+    go 1
+
+/-- Auto-tuner: probe, then jump. Pick an inner-repeat count whose
+batch wall time lands just past `targetNanos / 2`. The count is
+always a power of two — the probe doubles from 1, and the jump
+rounds its scale factor up to the next power of two — so the
+displayed `×2^k` in the report table is exact.
+
+**Phase 1 (probe).** Start `count := 1`, double until one batch
+exceeds a tiny "signal floor" (`halfTarget / 256` — ~1 ms for the
+default 250 ms half-target). That gives a stable per-call estimate
+while burning ≤ ~2 ms of ramp-up. If a probe batch already crosses
+`halfTarget`, return it — the function under test is slow enough
+that one call does the job.
+
+**Phase 2 (jump).** Extrapolate the measured per-call time, pick a
+scale factor (rounded up to the next power of two) that should
+overshoot `halfTarget` by ~10%, and run one final batch at
+`count * scale`.
+
+Cumulative wall time is therefore `probe (≤ ~2 ms) + final batch
+(≤ ~2 × halfTarget after the power-of-two round-up)` — well under
+the parent's 1 s `maxSecondsPerCall` cap for the default 500 ms
+target.
 
 Returns `(innerRepeats, totalNanos, lastResultHash)`. The hash is
 whatever the runner reports — present iff the function's return type
@@ -37,23 +62,31 @@ partial def autoTune
     (targetNanos : Nat) :
     IO (Nat × Nat × Option UInt64) := do
   let halfTarget := targetNanos / 2
+  let probeFloor := max 1 (halfTarget / 256)
   let rec runN (n : Nat) : IO (Nat × Option UInt64) := do
     let t₀ ← IO.monoNanosNow
     let hash ← runner n param
     let t₁ ← IO.monoNanosNow
     return (t₁ - t₀, hash)
   let mut count := 1
-  let mut total : Nat := 0
-  let mut hash : Option UInt64 := none
-  let (t, h) ← runN count
-  total := t
-  hash := h
-  while total < halfTarget do
+  let (t₀, h₀) ← runN count
+  let mut t := t₀
+  let mut h := h₀
+  while t < probeFloor && t < halfTarget do
     count := count * 2
     let (t', h') ← runN count
-    total := t'
-    hash := h'
-  return (count, total, hash)
+    t := t'
+    h := h'
+  if halfTarget ≤ t then
+    return (count, t, h)
+  -- Scale factor is `⌈halfTarget × 1.1 / t⌉`, rounded up to the next
+  -- power of two (so `count * scale` stays a power of two), and ≥ 2
+  -- so we never re-run the same size twice.
+  let scaleRaw : Nat := (halfTarget * 11 + 10 * t - 1) / (10 * t)
+  let scale    : Nat := max 2 (nextPowerOfTwo scaleRaw)
+  let targetCount := count * scale
+  let (tFinal, hFinal) ← runN targetCount
+  return (targetCount, tFinal, hFinal)
 
 /-- JSON-escape a string. Minimal — handles the few characters that
 matter for the fields we emit. -/

--- a/LeanBench/Cli.lean
+++ b/LeanBench/Cli.lean
@@ -44,7 +44,7 @@ def runListCmd (_ : Cli.Parsed) : IO UInt32 := do
 
 def runRunCmd (p : Cli.Parsed) : IO UInt32 := do
   let nameStr := (p.positionalArg! "name").as! String
-  let result ← LeanBench.runBenchmark (Lean.Name.mkSimple nameStr)
+  let result ← LeanBench.runBenchmark nameStr.toName
   IO.println (Format.fmtResult result)
   return 0
 
@@ -53,7 +53,7 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
   if names.isEmpty then
     IO.eprintln "compare: need at least two benchmark names"
     return 1
-  let report ← LeanBench.compare (names.map Lean.Name.mkSimple)
+  let report ← LeanBench.compare (names.map String.toName)
   IO.println (Format.fmtComparison report)
   return 0
 
@@ -63,7 +63,7 @@ def runChildCmd (p : Cli.Parsed) : IO UInt32 := do
   let benchStr := (p.flag! "bench").as! String
   let param := (p.flag! "param").as! Nat
   let targetNanos := (p.flag! "target-nanos").as! Nat
-  LeanBench.runChildMode (Lean.Name.mkSimple benchStr) param targetNanos
+  LeanBench.runChildMode benchStr.toName param targetNanos
 
 /-! ## Cmd tree definitions -/
 

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -42,14 +42,18 @@ structure DataPoint where
   status       : Status
   deriving Repr, Inhabited
 
-/-- Heuristic verdict — see SPEC v0.1: weak labels by design. -/
+/-- Heuristic verdict — see SPEC v0.1: weak labels by design. Decided
+by fitting the log-log slope β of `C = perCallNanos / complexity(n)` vs
+`param` on the trimmed tail: `|β| ≤ slopeTolerance` → consistent, else
+inconclusive. The slope itself (carrying the direction) lives on
+`BenchmarkResult.slope?`; the verdict is intentionally two-valued. -/
 inductive Verdict
   | consistentWithDeclaredComplexity
   | inconclusive
   deriving Repr, Inhabited, BEq
 
-def Verdict.toString : Verdict → String
-  | .consistentWithDeclaredComplexity => "consistentWithDeclaredComplexity"
+def Verdict.describe : Verdict → String
+  | .consistentWithDeclaredComplexity => "consistent with declared complexity"
   | .inconclusive => "inconclusive"
 
 /-- Per-benchmark configuration. Defaults are the v0.1 contract. -/
@@ -64,15 +68,35 @@ structure BenchmarkConfig where
   paramFloor        : Nat   := 0
   /-- Grace ms between SIGTERM and SIGKILL on the child. -/
   killGraceMs       : Nat   := 100
+  /-- Fraction of leading ratios to drop before computing cMin/cMax for
+      the verdict. `0.0` uses every ratio; `0.2` drops the first 20% of
+      ratio samples (the cold regime, where per-call overhead dominates
+      the declared complexity). The raw `ratios` array in the result is
+      not trimmed — only the verdict reduction sees the trimmed view.
+      Clamped so that at least 3 samples remain. -/
+  verdictWarmupFraction : Float := 0.2
+  /-- Tolerance on the log-log slope β of `C` vs `param` over the
+      trimmed tail. The verdict is "consistent with declared
+      complexity" iff `|β| ≤ slopeTolerance`, otherwise "inconclusive".
+      Default 0.15 tolerates realistic per-point noise (~5% across ~10
+      tail rungs) while still flagging a spurious polynomial factor
+      like `n log n` vs declared `n`. Widen on chronically noisy
+      hardware; tighten only if you trust the measurements. -/
+  slopeTolerance : Float := 0.15
   deriving Inhabited, Repr
 
-/-- One entry in the benchmark registry. Stored as `Name`s only;
-neither `Syntax` nor `Expr`, sidestepping serialization issues. -/
+/-- One entry in the benchmark registry. Stored as `Name`s plus a
+printable copy of the complexity formula; neither `Syntax` nor `Expr`,
+sidestepping serialization issues. -/
 structure BenchmarkSpec where
   /-- The function under test. -/
   name             : Lean.Name
   /-- Auto-generated `Nat → Nat` complexity model. -/
   complexityName   : Lean.Name
+  /-- Pretty-printed source of the complexity expression (e.g. `"2 ^ n"`),
+      captured at `setup_benchmark` time so `list` can show the formula
+      the user wrote rather than the internal helper name. -/
+  complexityFormula : String
   /-- Auto-generated `Nat → IO (Option UInt64)` runner. -/
   runCheckedName   : Lean.Name
   /-- True iff the function's return type has a `Hashable` instance;
@@ -88,13 +112,26 @@ abbrev Ratio := Nat × Float
 /-- Result of a single benchmark invocation. -/
 structure BenchmarkResult where
   function   : Lean.Name
-  complexity : Name
+  /-- The expected-complexity formula the user declared, as printable
+      source (e.g. `"2 ^ n"`). Echoed back in the result header so
+      reports stay readable without needing the env around. -/
+  complexityFormula : String
   config     : BenchmarkConfig
   points     : Array DataPoint
   ratios     : Array Ratio
   verdict    : Verdict
   cMin?      : Option Float
   cMax?      : Option Float
+  /-- How many leading ratios were dropped by `verdictWarmupFraction`
+      before computing cMin/cMax. `0` when no trimming was applied. -/
+  verdictDroppedLeading : Nat := 0
+  /-- OLS slope β of `log C` vs `log param` over the trimmed tail.
+      Expected ≈ 0 when the declared complexity matches. Positive β
+      means the function grows faster than declared by roughly a factor
+      of `n^β`; negative β means slower. `none` when the trimmed tail
+      has fewer than 2 samples or degenerate `x` (shouldn't happen on
+      the doubling ladder). -/
+  slope? : Option Float := none
   /-- The harness's own per-spawn floor at the time of this run, for
       comparison against the smallest `totalNanos` recorded. -/
   spawnFloorNanos? : Option Nat := none

--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -12,63 +12,194 @@ parent side.
 namespace LeanBench
 namespace Format
 
-/-- Pretty-print a duration. -/
-def fmtNanos (n : Nat) : String :=
+/-- Format a `Float` with exactly 3 decimal places (trailing zeros
+padded, never stripped). `26.0 → "26.000"`, `20.147 → "20.147"`,
+`1.498621 → "1.499"`, `0.0005 → "0.001"`. Keeping the decimal width
+uniform is what lets `alignDecimals` keep every column's decimal
+point on the same vertical line. -/
+private def fmtFloat3 (f : Float) : String := Id.run do
+  let neg := f < 0.0
+  let abs := if neg then -f else f
+  let scaled : Nat := (abs * 1000.0).round.toUInt64.toNat
+  let whole : Nat := scaled / 1000
+  let frac  : Nat := scaled % 1000
+  let sign := if neg then "-" else ""
+  let fracRaw := toString frac
+  let padded := String.ofList (List.replicate (3 - fracRaw.length) '0') ++ fracRaw
+  return s!"{sign}{whole}.{padded}"
+
+/-- Pretty-print a duration as `(numeric, unit)` so callers can align
+the number and unit independently. -/
+def fmtNanos (n : Nat) : String × String :=
   let f : Float := n.toFloat
-  if f < 1_000.0 then
-    s!"{f} ns"
-  else if f < 1_000_000.0 then
-    s!"{f / 1_000.0} µs"
-  else if f < 1_000_000_000.0 then
-    s!"{f / 1_000_000.0} ms"
-  else
-    s!"{f / 1_000_000_000.0} s"
+  if f < 1_000.0 then (fmtFloat3 f, "ns")
+  else if f < 1_000_000.0 then (fmtFloat3 (f / 1_000.0), "µs")
+  else if f < 1_000_000_000.0 then (fmtFloat3 (f / 1_000_000.0), "ms")
+  else (fmtFloat3 (f / 1_000_000_000.0), "s")
 
-private def truncFloat (f : Float) (digits : Nat) : String := Id.run do
-  let scale : Float := (10 : Float) ^ digits.toFloat
-  let truncated : Float := (f * scale).floor / scale
-  return toString truncated
+/-- Duration as a single space-joined string, for prose lines. -/
+def fmtNanosStr (n : Nat) : String :=
+  let (num, unit) := fmtNanos n
+  s!"{num} {unit}"
 
+/-- Pad on the left with spaces to width `w` (i.e. right-align). -/
 private def leftpad (s : String) (w : Nat) : String :=
   let pad := w - s.length
   if pad > 0 then String.ofList (List.replicate pad ' ') ++ s else s
 
-/-- Pretty-print one `DataPoint` as a single row. -/
-def fmtPoint (cMaybe : Option Float) (dp : DataPoint) : String :=
-  let param := s!"{dp.param}"
-  let perCall := fmtNanos dp.perCallNanos.toUInt64.toNat
-  let inner := s!"×{dp.innerRepeats}"
-  let cStr := match cMaybe with
-    | some c => truncFloat c 3
-    | none => "—"
-  let status := match dp.status with
-    | .ok => ""
-    | .timedOut => " [timed out]"
-    | .killedAtCap => " [killed at cap]"
-    | .error msg => s!" [error: {msg}]"
-  s!"  {leftpad param 6} {leftpad perCall 12} {leftpad inner 8}  C={cStr}{status}"
+/-- Pad on the right with spaces to width `w` (i.e. left-align). -/
+private def rightpad (s : String) (w : Nat) : String :=
+  let pad := w - s.length
+  if pad > 0 then s ++ String.ofList (List.replicate pad ' ') else s
 
-/-- Render one `BenchmarkResult` as a multi-line block. -/
+/-- Given a column of numeric strings (from `fmtFloat3`), pad them so
+decimal points line up. Strings without a decimal point get trailing
+spaces in place of the missing `.frac`. The em-dash `"—"` passes
+through as an integer-only entry and lands in the integer slot. -/
+private def alignDecimals (ss : Array String) : Array String := Id.run do
+  let split : Array (String × String) := ss.map fun s =>
+    match s.splitOn "." with
+    | [i]         => (i, "")
+    | i :: f :: _ => (i, f)
+    | _           => (s, "")
+  let maxInt  := split.foldl (fun m (i, _) => max m i.length) 0
+  let maxFrac := split.foldl (fun m (_, f) => max m f.length) 0
+  return split.map fun (i, f) =>
+    let intPad := leftpad i maxInt
+    if maxFrac == 0 then
+      intPad
+    else if f.isEmpty then
+      intPad ++ String.ofList (List.replicate (maxFrac + 1) ' ')
+    else
+      intPad ++ "." ++ rightpad f maxFrac
+
+/-- A single table row, pre-formatted into aligned string parts. -/
+private structure Row where
+  param       : String
+  perCallNum  : String
+  perCallUnit : String
+  repeats     : String
+  cStr        : String
+  status      : String
+  deriving Inhabited
+
+private def statusSuffix : Status → String
+  | .ok          => ""
+  | .timedOut    => " [timed out]"
+  | .killedAtCap => " [killed at cap]"
+  | .error msg   => s!" [error: {msg}]"
+
+/-- Decimal with `_` every three digits from the right: `1123456 → "1_123_456"`. -/
+private def fmtNatUnderscores (n : Nat) : String := Id.run do
+  let s := toString n
+  let len := s.length
+  if len ≤ 3 then return s
+  let chars := s.toList
+  let mut out : String := ""
+  for i in [0 : len] do
+    if i > 0 ∧ (len - i) % 3 == 0 then
+      out := out.push '_'
+    out := out.push chars[i]!
+  return out
+
+/-- Render the inner-repeat count. The auto-tuner always picks a power
+of 2, so we show it as `×2^k`. Non-powers (shouldn't happen in
+practice) fall through to a raw decimal, and `0` — what `synthRow`
+uses for killed/errored rows — renders as an em-dash. -/
+private def fmtRepeats (n : Nat) : String :=
+  if n == 0 then "—"
+  else
+    let k := Nat.log2 n
+    if (1 <<< k) == n then s!"×2^{k}"
+    else s!"×{n}"
+
+private def rawRow (cMaybe : Option Float) (dp : DataPoint) : Row :=
+  let (num, unit) := match dp.status with
+    | .ok => fmtNanos dp.perCallNanos.toUInt64.toNat
+    | _   => ("—", "")
+  let cStr := match cMaybe with
+    | some c => fmtFloat3 c
+    | none   => "—"
+  { param       := fmtNatUnderscores dp.param
+    perCallNum  := num
+    perCallUnit := unit
+    repeats     := fmtRepeats dp.innerRepeats
+    cStr
+    status      := statusSuffix dp.status }
+
+/-- Render one `BenchmarkResult` as a multi-line block with every
+numeric value bounded to 3 decimals and every column width derived
+from the data so decimal points align. -/
 def fmtResult (r : BenchmarkResult) : String := Id.run do
-  let header := s!"{r.function}   complexity={r.complexity}"
-  -- align ratios to points by param
+  let headerLine := s!"{r.function}    expected complexity: {r.complexityFormula}"
   let ratioMap : Std.HashMap Nat Float :=
     r.ratios.foldl (fun m (p, c) => m.insert p c) {}
-  let mut lines : Array String := #[header, "  param   per-call    repeats  C"]
-  for dp in r.points do
-    lines := lines.push (fmtPoint (ratioMap.get? dp.param) dp)
-  let cMin := match r.cMin? with | some c => truncFloat c 3 | none => "—"
-  let cMax := match r.cMax? with | some c => truncFloat c 3 | none => "—"
-  lines := lines.push s!"  verdict: {r.verdict.toString} (cMin={cMin}, cMax={cMax})"
+  let droppedParams : Array Nat :=
+    (r.ratios.extract 0 r.verdictDroppedLeading).map (·.1)
+  let raws : Array Row := r.points.map fun dp =>
+    let row := rawRow (ratioMap.get? dp.param) dp
+    if droppedParams.contains dp.param then
+      { row with status := row.status ++ " †" }
+    else row
+  let alignedNums := alignDecimals (raws.map (·.perCallNum))
+  let alignedCs   := alignDecimals (raws.map (·.cStr))
+  let rows : Array Row := Id.run do
+    let mut out : Array Row := #[]
+    for i in [0 : raws.size] do
+      let r := raws[i]!
+      out := out.push { r with
+        perCallNum := alignedNums[i]!
+        cStr       := alignedCs[i]! }
+    return out
+  let wParam := rows.foldl (fun m r => max m r.param.length) "param".length
+  let wNum   := if alignedNums.size == 0 then 0 else alignedNums[0]!.length
+  let wUnit  := rows.foldl (fun m r => max m r.perCallUnit.length) 0
+  let wRep   := rows.foldl (fun m r => max m r.repeats.length) "repeats".length
+  let wC     := rows.foldl (fun m r => max m r.cStr.length) "C".length
+  let perCallColWidth := max "per-call".length (wNum + 1 + wUnit)
+  let wUnitEff := perCallColWidth - wNum - 1
+  let headerRow :=
+    "  " ++ leftpad "param" wParam ++
+    "  " ++ rightpad "per-call" perCallColWidth ++
+    "  " ++ rightpad "repeats" wRep ++
+    "  C"
+  let dataLines : Array String := rows.map fun r =>
+    let perCall := r.perCallNum ++ " " ++ rightpad r.perCallUnit wUnitEff
+    "  " ++ leftpad r.param wParam ++
+    "  " ++ perCall ++
+    "  " ++ rightpad r.repeats wRep ++
+    "  C=" ++ rightpad r.cStr wC ++ r.status
+  let mut lines : Array String := #[headerLine, headerRow]
+  for line in dataLines do
+    lines := lines.push line
+  let cMin := match r.cMin? with | some c => fmtFloat3 c | none => "—"
+  let cMax := match r.cMax? with | some c => fmtFloat3 c | none => "—"
+  let fmtSignedSlope (β : Float) : String :=
+    let mag := fmtFloat3 β.abs
+    if β < 0.0 then "-" ++ mag else "+" ++ mag
+  let slopeStr := match r.slope? with
+    | some β => fmtSignedSlope β
+    | none   => "—"
+  let hint := match r.slope? with
+    | some β =>
+      let a := β.abs
+      if a > r.config.slopeTolerance && a ≥ 0.05 then
+        let dir := if β > 0.0 then "slower" else "faster"
+        s!", looks {dir} than declared by ~n^{fmtFloat3 a}"
+      else ""
+    | none => ""
+  lines := lines.push
+    s!"  verdict: {r.verdict.describe} (cMin={cMin}, cMax={cMax}, β={slopeStr}{hint})"
   match r.spawnFloorNanos? with
-  | some n => lines := lines.push s!"  per-spawn floor (harness self-measurement): {fmtNanos n}"
-  | none => ()
+  | some n =>
+    lines := lines.push s!"  per-spawn floor (harness self-measurement): {fmtNanosStr n}"
+  | none => pure ()
   return "\n".intercalate lines.toList
 
 /-- One-line summary of a registered benchmark, used by `list`. -/
 def fmtSpec (spec : BenchmarkSpec) : String :=
-  let h := if spec.hashable then "" else " (no Hashable)"
-  s!"  {spec.name}  →  complexity = {spec.complexityName}{h}"
+  let h := if spec.hashable then "" else "  (no Hashable)"
+  s!"  {spec.name}    expected complexity: {spec.complexityFormula}{h}"
 
 /-- Render a `ComparisonReport` as a per-function block list plus a
     summary noting the common-param intersection. -/

--- a/LeanBench/Setup.lean
+++ b/LeanBench/Setup.lean
@@ -124,17 +124,26 @@ def elabSetupBenchmark : CommandElab := fun stx => do
             LeanBench.blackBox (Hashable.hash (sizeOf r))
           return none)
     -- (3) emit an `initialize` block that puts the runtime closure
-    --     into the IO.Ref registry.
-    let fnNameLit := Syntax.mkStrLit fnName.toString
-    let cNameLit := Syntax.mkStrLit cName.toString
-    let rNameLit := Syntax.mkStrLit rName.toString
+    --     into the IO.Ref registry. We `quote` the `Name`s so the
+    --     runtime registry key is a properly hierarchical `Name` —
+    --     `Name.mkSimple "a.b.c"` would instead produce an atomic name
+    --     whose `toString` wraps it in guillemets.
+    -- `reprint` preserves trailing whitespace from the source, which
+    -- would turn the `list` output into a spaced-out blank-line mess.
+    let formulaStr :=
+      (complexityTerm.raw.reprint.getD (toString complexityTerm.raw)).trimAscii.toString
+    let formulaLit := Syntax.mkStrLit formulaStr
+    let fnNameSyn : Term := quote fnName
+    let cNameSyn  : Term := quote cName
+    let rNameSyn  : Term := quote rName
     let isHashableSyn := mkIdent (if isHashable then ``true else ``false)
     elabCommand <| ← `(command|
       initialize do
         LeanBench.register
-          { name := Lean.Name.mkSimple $fnNameLit
-            complexityName := Lean.Name.mkSimple $cNameLit
-            runCheckedName := Lean.Name.mkSimple $rNameLit
+          { name := $fnNameSyn
+            complexityName := $cNameSyn
+            complexityFormula := $formulaLit
+            runCheckedName := $rNameSyn
             hashable := $isHashableSyn
             config := {} }
           $rIdent
@@ -143,6 +152,7 @@ def elabSetupBenchmark : CommandElab := fun stx => do
     let spec : BenchmarkSpec :=
       { name := fnName
         complexityName := cName
+        complexityFormula := formulaStr
         runCheckedName := rName
         hashable := isHashable
         config := {} }

--- a/LeanBench/Stats.lean
+++ b/LeanBench/Stats.lean
@@ -33,18 +33,65 @@ def ratiosFromPoints
     acc := acc.push (dp.param, dp.perCallNanos / d.toFloat)
   return acc
 
-/-- Reduce the ratios into the v0.1 weak verdict. -/
-def deriveVerdict (ratios : Array Ratio) : Verdict × Option Float × Option Float :=
+/-- OLS slope of the points `(x, y)`. `none` if there are fewer than
+    two points, or if the `x` values are (essentially) all equal. -/
+private def fitSlope (pts : Array (Float × Float)) : Option Float :=
+  if pts.size < 2 then none
+  else Id.run do
+    let n := pts.size.toFloat
+    let mut sx : Float := 0.0
+    let mut sy : Float := 0.0
+    for (x, y) in pts do
+      sx := sx + x
+      sy := sy + y
+    let xbar := sx / n
+    let ybar := sy / n
+    let mut num : Float := 0.0
+    let mut den : Float := 0.0
+    for (x, y) in pts do
+      let dx := x - xbar
+      num := num + dx * (y - ybar)
+      den := den + dx * dx
+    if den < 1e-12 then return none
+    return some (num / den)
+
+/-- Reduce the ratios into the v0.1 weak verdict.
+
+    `warmupFraction ∈ [0, 1)` is the fraction of leading ratios to drop
+    before fitting, so the cold regime (where per-spawn overhead
+    dominates the declared complexity) doesn't corrupt the slope.
+    Clamped to leave at least 3 samples.
+
+    The verdict is decided by the log-log slope β of `C` vs `param`
+    over the trimmed tail: `|β| ≤ slopeTolerance` → consistent, else
+    inconclusive. `cMin`/`cMax` are still reported as diagnostic
+    context, but no longer drive the verdict. Returns
+    `(verdict, cMin?, cMax?, slope?, droppedLeading)`. -/
+def deriveVerdict (ratios : Array Ratio)
+    (warmupFraction : Float) (slopeTolerance : Float) :
+    Verdict × Option Float × Option Float × Option Float × Nat :=
   if ratios.size < 3 then
-    (.inconclusive, none, none)
+    (.inconclusive, none, none, none, 0)
   else
-    let cs := ratios.map (·.2)
+    let raw := (ratios.size.toFloat * warmupFraction).toUInt64.toNat
+    let maxDrop := ratios.size - 3
+    let dropCount := min raw maxDrop
+    let kept := ratios.extract dropCount ratios.size
+    let cs := kept.map (·.2)
     let cMin := cs.foldl min cs[0]!
     let cMax := cs.foldl max cs[0]!
-    let v : Verdict :=
-      if cMax / cMin ≤ 4.0 then .consistentWithDeclaredComplexity
-      else .inconclusive
-    (v, some cMin, some cMax)
+    let pts : Array (Float × Float) := kept.filterMap fun (p, c) =>
+      if c > 0.0 && p ≥ 1 then
+        some (Float.log p.toFloat, Float.log c)
+      else
+        none
+    let slope? := fitSlope pts
+    let v : Verdict := match slope? with
+      | some β => if β.abs ≤ slopeTolerance then
+                    .consistentWithDeclaredComplexity
+                  else .inconclusive
+      | none   => .inconclusive
+    (v, some cMin, some cMax, slope?, dropCount)
 
 /-- Build a `BenchmarkResult` from spec + complexity closure + collected points. -/
 def summarize
@@ -53,15 +100,19 @@ def summarize
     (points : Array DataPoint) :
     BenchmarkResult :=
   let ratios := ratiosFromPoints complexity points
-  let (verdict, cMin?, cMax?) := deriveVerdict ratios
+  let (verdict, cMin?, cMax?, slope?, dropped) :=
+    deriveVerdict ratios spec.config.verdictWarmupFraction
+      spec.config.slopeTolerance
   { function := spec.name
-  , complexity := spec.complexityName
+  , complexityFormula := spec.complexityFormula
   , config := spec.config
   , points
   , ratios
   , verdict
   , cMin?
-  , cMax? }
+  , cMax?
+  , verdictDroppedLeading := dropped
+  , slope? }
 
 end Stats
 end LeanBench

--- a/README.md
+++ b/README.md
@@ -18,21 +18,25 @@ Builds the library + examples and runs a linear-Fibonacci benchmark
 over params `0, 1, 2, 4, 8, …, 134_217_728`. Tail of the output:
 
 ```
-   32768 186.988 µs  ×2048  C=5.706
-   65536 388.242 µs  ×1024  C=5.924
-  131072 748.856 µs   ×512  C=5.713
-  262144   1.499 ms   ×256  C=5.718
-  524288   3.114 ms   ×128  C=5.938
- 1048576   5.993 ms    ×64  C=5.715
- …
-verdict: consistentWithDeclaredComplexity (cMin=5.408, cMax=19.981)
+       32_768  197.481 µs     ×2^9  C= 6.027
+       65_536  374.301 µs     ×2^9  C= 5.711
+      131_072  747.345 µs     ×2^8  C= 5.702
+      262_144    1.496 ms     ×2^7  C= 5.708
+      524_288    2.989 ms     ×2^6  C= 5.702
+    1_048_576    5.979 ms     ×2^6  C= 5.702
+    …
+  verdict: consistent with declared complexity (cMin=5.702, cMax=6.863, β=-0.005)
 ```
+
+Tombstones `†` on earlier rungs mark the warmup-trim region — those
+rows aren't included in the slope fit.
 
 `goodFib` is declared as `O(n)`; observed per-call time scales
 linearly across 22 doublings (n=2 through n=134M); `C` stabilises
 near 5.7 ns per iteration once the param is large enough that the
-small fixed per-call cost (loop frame, hash, the noinline black box
-that defeats dead-code elimination) amortises.
+small fixed per-call cost amortises. `β` is the log-log slope of `C`
+vs `param` over the trimmed tail — β ≈ 0 is what a correct complexity
+declaration looks like.
 
 ## Use it in your project
 
@@ -80,10 +84,10 @@ and is on the v0.2 list — see [PLAN.md](PLAN.md).
 
 ## Design
 
-Subprocess-per-batch. The CHILD does the timing and the auto-tuned
-inner-repeat loop; the PARENT only spawns, reads JSONL stdout, and
+Subprocess-per-batch. The child does the timing and the auto-tuned
+inner-repeat loop; the parent only spawns, reads JSONL stdout, and
 SIGTERMs the child if a single batch exceeds `--max-seconds-per-call`.
-Why subprocess: Lean has no portable in-process interrupt for
+We use subprocesses because Lean has no portable in-process interrupt for
 arbitrary computation, so the only reliable way to enforce a
 wallclock cap is to give each measurement its own process.
 
@@ -96,8 +100,9 @@ Each measurement is a child process, so very fast operations have a
 per-spawn noise floor in the milliseconds. The harness measures this
 floor itself and prints it with every report.
 
-The verdict is a thresholded ratio (`cMax/cMin ≤ 4`), not a
-statistical test. Read the raw ratios.
+The verdict is a thresholded log-log slope (`|β| ≤ 0.15` over the
+trimmed tail), not a statistical test. β's sign tells you direction;
+read the raw ratios for magnitude.
 
 Linux is tested. macOS/WSL probably work; Windows doesn't (see
 Status).

--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -11,9 +11,9 @@ through its own doubling ladder, then prints:
 - the full per-function table (one block per benchmark)
 - the `commonParams` intersection (the params at which every
   function produced an `ok` row)
-- `agreement` over those params: `allAgreed`, `divergedAt …`, or
-  `hashUnavailable` (when at least one function's return type lacks
-  `Hashable`)
+- `agreement` over those params: all agreed, diverged at specific
+  (function, function, param) triples, or hash unavailable (when at
+  least one function's return type lacks `Hashable`)
 
 A function whose ladder stops early (because its complexity rises
 faster) doesn't break the comparison — its rows are preserved and
@@ -28,28 +28,41 @@ the result (so the benchmark measures real work) but writes
 ## Reading the verdict
 
 The raw `ratios` array `[(param, perCallNanos / complexity(param)), …]`
-is the source of truth. The verdict is a heuristic decoration:
+is the source of truth. The verdict is a heuristic decoration.
 
-- `consistentWithDeclaredComplexity` if `cMax / cMin ≤ 4` over ≥3
-  data points past `param = 2`
-- `inconclusive` otherwise
+The decision rule is the log-log slope β of `C` vs `param` over the
+trimmed tail (the leading `verdictWarmupFraction` of ratios — 20% by
+default — is dropped first, so the cold regime can't corrupt the fit):
 
-`inconclusive` is not "the implementation is wrong" — it just means
-the model + measurement noise doesn't support the strong claim.
-Things that produce `inconclusive`:
+- "consistent with declared complexity" if `|β| ≤ slopeTolerance`
+  (0.15 by default)
+- "inconclusive" otherwise
 
-- declared complexity is wrong (e.g. `n` for an O(n²) algorithm)
+β is printed on the verdict line alongside `cMin`/`cMax`. A correct
+complexity declaration gives β ≈ 0; positive β means the function
+grows faster than declared by roughly a factor of `n^β`, negative β
+means slower. The verdict line surfaces a "looks slower/faster than
+declared by ~n^β" hint whenever `|β|` is both outside tolerance and
+at least 0.05.
+
+An inconclusive verdict is not "the implementation is wrong" — it
+just means the model + measurement noise doesn't support the strong
+claim. Things that produce an inconclusive verdict:
+
+- declared complexity is wrong (e.g. `n` for an O(n²) algorithm — β
+  comes back near 1)
 - declared complexity is too coarse (e.g. `2^n` for an algorithm
-  whose actual cost is `1.6^n` — these differ by a polynomial
-  factor that shows up over a doubling ladder)
+  whose actual cost is `φ^n` — β comes back negative; the deviation
+  is exponential, not polynomial, so the "~n^β" shorthand is a
+  rough summary rather than an exact exponent)
 - cache effects (smooth at small n, jumps at L1 / L2 boundaries)
 - arbitrary-precision arithmetic on growing results (Lean's `Nat`
   is bignum; if `f n` returns a number with k bits, every operation
   on it costs O(k))
 
-When the verdict is `inconclusive`, look at the raw ratios. They
-tell you which way C is drifting (growing → algorithm is slower
-than declared; shrinking → declared model is too pessimistic).
+β tells you the direction; the raw ratios tell you the magnitude.
+Together they're enough to tell "off by a polynomial factor" from
+"off by a constant factor but drifting" from "just noisy".
 
 ## The per-spawn floor
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -93,12 +93,15 @@ branching leaking through the design.
   type. Compiled-code sanity checks live in `lean-bench verify` (a
   CLI subcommand, not yet implemented).
 
-- **Strong verdict labels.** `cMax/cMin ≤ 4` over ≥3 data points
-  past `param=2` triggers `consistentWithDeclaredComplexity`,
-  otherwise `inconclusive`. The raw `ratios` array is the source of
-  truth; the verdict is decoration. The labels deliberately don't
-  say "matches" or "doesn't match" because the heuristic isn't
-  defended statistically.
+- **Strong verdict labels.** The verdict fits the log-log slope β of
+  `C` vs `param` over the trimmed tail (leading 20% of ratios
+  dropped by default). `|β| ≤ 0.15` → "consistent with declared
+  complexity", otherwise "inconclusive". β's sign is reported
+  alongside the verdict so callers can see direction, but the verdict
+  itself stays binary: the raw `ratios` array is the source of truth
+  and the verdict is decoration. The labels deliberately don't say
+  "matches" or "doesn't match" because the heuristic isn't defended
+  statistically.
 
 - **Statistical machinery.** No outlier rejection, confidence
   intervals, repeated outer trials. v0.1 trusts that

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -46,7 +46,7 @@ def main (args : List String) : IO UInt32 :=
 $ lake build bench
 $ lake exe bench list
 registered benchmarks:
-  «myFib»  →  complexity = «myFib._leanBench_complexity»
+  myFib    expected complexity: n + 1
 $ lake exe bench run myFib
 ... result table ...
 $ lake exe bench compare myFib someOtherFib
@@ -74,9 +74,11 @@ against `log2 0 = 0` producing a zero denominator in the ratio.
 
 Per-data-point ratio `C = perCallNanos / complexity(param)`. If your
 declared complexity matches the implementation, `C` is approximately
-constant and the verdict is `consistentWithDeclaredComplexity`.
-Otherwise the verdict is `inconclusive` and the raw ratios tell you
-which way `C` is drifting.
+constant. The verdict fits the log-log slope β of `C` vs `param` over
+the trimmed tail: "consistent with declared complexity" when
+`|β| ≤ 0.15`, otherwise "inconclusive". β is printed on the verdict
+line; its sign tells you the direction of any mismatch (positive →
+actually slower than declared, negative → actually faster).
 
 The harness prints its own per-spawn floor as part of the report. Any
 data point with `total_nanos` smaller than ~10× the spawn floor is
@@ -90,8 +92,8 @@ measurement.
   `brew install coreutils`, WSL works, native Windows doesn't. A
   pure-Lean cross-platform replacement is on the v0.2 list (PLAN.md F0).
 - The verdict is heuristic; the raw `ratios` array is the source of
-  truth. See [PLAN.md](../PLAN.md) for v0.2 plans (auto-fit, log-log
-  slope, baseline-diff, …).
+  truth. See [PLAN.md](../PLAN.md) for v0.2 plans (auto-fit,
+  baseline-diff, …).
 - Lean's `Nat` is arbitrary-precision. If your function returns big
   integers, the actual complexity includes the cost of arithmetic on
   results — likely worse than the "obvious" textbook complexity.

--- a/examples/Fib/LeanBenchExampleFib.lean
+++ b/examples/Fib/LeanBenchExampleFib.lean
@@ -8,9 +8,10 @@ Two implementations of Fibonacci, both benchmarked.
 - `goodFib` — linear bottom-up over `UInt64` (constant per-step).
    Declared complexity `n`.
 - `badFib`  — naive doubly-recursive over `Nat`. Declared complexity
-   `2 ^ n`. The verdict is `inconclusive` — the actual cost is
-   `Θ(φ ^ n)` (golden ratio), and `2 ^ n` overestimates by a
-   sub-exponential factor. The raw ratios show the gap.
+   `144 ^ n / 89 ^ n`: the actual cost is `Θ(φ ^ n)` (golden ratio),
+   and `144 / 89 ≈ 1.61798` is within ~3×10⁻⁵ of `φ ≈ 1.61803`, so
+   `(144/89)^n` tracks `φ^n` to well under a percent across the test
+   range — close enough that the verdict should be conclusive.
 
 Run them with `lake exe fib_benchmark_example list` /
 `run NAME` / `compare A B`.
@@ -39,6 +40,6 @@ def badFib : Nat → Nat
   | n + 2 => badFib n + badFib (n + 1)
 
 setup_benchmark goodFib n => n
-setup_benchmark badFib  n => 2 ^ n
+setup_benchmark badFib  n => 144 ^ n / 89 ^ n
 
 end LeanBench.Examples.Fib


### PR DESCRIPTION
## Summary

- Replaces the v0.1 `cMax/cMin ≤ 4` ratio verdict with an OLS log-log slope β over the trimmed tail (default warmup-fraction 0.2, slope tolerance 0.15). Verdict line surfaces β and a "looks slower/faster than declared by ~n^β" hint when |β| is both outside tolerance and ≥ 0.05.
- Report formatting: column-aligned decimal points via a new `fmtFloat3` + `alignDecimals` pair; `×2^k` for power-of-two repeats; units split from the numeric so columns stay aligned.
- Autotuner becomes probe-then-jump: probe doubles `count` from 1 until one batch crosses a tiny signal floor (~1ms), then jumps to a power-of-two count near `halfTarget`. Final count is always a power of two.
- `complexityFormula` field on `BenchmarkSpec` / `BenchmarkResult`, captured via `complexityTerm.raw.reprint`. The `list` output now shows the user-written formula instead of an internal helper name.
- CLI parses benchmark names via `String.toName` so namespaced identifiers like `LeanBench.Examples.Fib.goodFib` actually look up.
- `badFib` declares `144 ^ n / 89 ^ n` (rational approximation of φ^n, error ~3e-5) so its verdict is conclusive on the new slope-based rule.
- Doc updates in README, `doc/advanced.md`, `doc/design.md`, `doc/quickstart.md` for the new verdict semantics.

## Test plan

- [x] `lake build` succeeds (49 targets).
- [x] `lake exe roundtrip_benchmark_test` passes.
- [x] `lake exe fib_benchmark_example run LeanBench.Examples.Fib.goodFib` reports consistent (β ≈ 0).
- [x] `lake exe binary_search_benchmark_example run …runLinear` reports consistent (β ≈ 0).
- [x] `lake exe binary_search_benchmark_example run …runBinary` reports inconclusive with β ≈ +0.9 — this is the prep-clause bug fixed in the follow-up PR.

🤖 Prepared with Claude Code