### PR TITLE
feat: setup_benchmark gains optional `with prep := …` clause

### DIFF
--- a/LeanBench/Child.lean
+++ b/LeanBench/Child.lean
@@ -54,20 +54,17 @@ the parent's 1 s `maxSecondsPerCall` cap for the default 500 ms
 target.
 
 Returns `(innerRepeats, totalNanos, lastResultHash)`. The hash is
-whatever the runner reports — present iff the function's return type
-has a `Hashable` instance. -/
+whatever the loop reports — present iff the function's return type
+has a `Hashable` instance. The loop closure does its own timing
+internally; per-param prep ran in the caller (via the runtime
+entry's `runner`), once per spawn, before this autotune even starts. -/
 partial def autoTune
-    (runner : Nat → Nat → IO (Option UInt64))
-    (param : Nat)
+    (loop : Nat → IO (Nat × Option UInt64))
     (targetNanos : Nat) :
     IO (Nat × Nat × Option UInt64) := do
   let halfTarget := targetNanos / 2
   let probeFloor := max 1 (halfTarget / 256)
-  let rec runN (n : Nat) : IO (Nat × Option UInt64) := do
-    let t₀ ← IO.monoNanosNow
-    let hash ← runner n param
-    let t₁ ← IO.monoNanosNow
-    return (t₁ - t₀, hash)
+  let runN (n : Nat) : IO (Nat × Option UInt64) := loop n
   let mut count := 1
   let (t₀, h₀) ← runN count
   let mut t := t₀
@@ -79,9 +76,6 @@ partial def autoTune
     h := h'
   if halfTarget ≤ t then
     return (count, t, h)
-  -- Scale factor is `⌈halfTarget × 1.1 / t⌉`, rounded up to the next
-  -- power of two (so `count * scale` stays a power of two), and ≥ 2
-  -- so we never re-run the same size twice.
   let scaleRaw : Nat := (halfTarget * 11 + 10 * t - 1) / (10 * t)
   let scale    : Nat := max 2 (nextPowerOfTwo scaleRaw)
   let targetCount := count * scale
@@ -143,7 +137,8 @@ def runChildMode (benchName : Lean.Name) (param targetNanos : Nat) : IO UInt32 :
       (some s!"unregistered benchmark: {benchName}")
     return 1
   | some entry =>
-    let (count, total, hash) ← autoTune entry.runner param targetNanos
+    let loop ← entry.runner param
+    let (count, total, hash) ← autoTune loop targetNanos
     emitRow benchName param count total hash .ok
     return 0
 

--- a/LeanBench/Env.lean
+++ b/LeanBench/Env.lean
@@ -73,12 +73,24 @@ def allSpecs (env : Environment) : Array BenchmarkSpec :=
     function and its complexity model. -/
 structure RuntimeEntry where
   spec       : BenchmarkSpec
-  /-- Runs the function under test `count` times at parameter `param`,
-      then returns the hash of the last result (when the return type
-      has `Hashable`) or `none`. The whole loop happens *inside* this
-      single call so the compiler can inline the function-under-test
-      into the loop body — no per-iteration closure indirection. -/
-  runner     : (count : Nat) → (param : Nat) → IO (Option UInt64)
+  /-- Two-stage runner:
+
+      1. Apply to `param`: this runs any per-param setup (the `prep`
+         function from `setup_benchmark … with prep := …`, when
+         present) and returns a closure that holds the prepared state.
+      2. Apply that closure to `count`: this runs the function under
+         test `count` times, hashing each result, and returns
+         `(loopNanos, lastHash)` where `loopNanos` is the wall time
+         spent *only* inside the inner loop.
+
+      Per-param setup therefore runs once per child-process spawn —
+      not once per autotuner probe — and the inner loop's IO closure
+      captures the prepared value, so the function-under-test can be
+      inlined into the loop body with no per-iteration indirection.
+      The `lastHash` is `some _` iff the function's return type has
+      `Hashable`; the runner forces the prep result before the timer
+      starts so prep cost does not leak into the reported nanos. -/
+  runner     : (param : Nat) → IO (Nat → IO (Nat × Option UInt64))
   complexity : Nat → Nat
   deriving Inhabited
 
@@ -108,7 +120,7 @@ not call the two halves directly.
 -/
 def register
     (spec : BenchmarkSpec)
-    (runner : (count : Nat) → (param : Nat) → IO (Option UInt64))
+    (runner : (param : Nat) → IO (Nat → IO (Nat × Option UInt64)))
     (complexity : Nat → Nat) :
     IO Unit :=
   runtimeRegistry.modify (·.insert spec.name { spec, runner, complexity })

--- a/LeanBench/Setup.lean
+++ b/LeanBench/Setup.lean
@@ -49,21 +49,36 @@ If `α` has a `Hashable` instance, the auto-generated `runChecked`
 emits a `UInt64` hash of the result. Otherwise it returns `none`
 after forcing the result; conformance hashing is unavailable for
 this benchmark.
+
+An optional `with prep := <ident>` clause hoists per-param setup work
+out of the inner timing loop. With `with prep := mkInput`, the
+benchmarked function must have type `σ → α` where `σ` is the return
+type of `mkInput : Nat → σ`. The macro generates a runner that calls
+`mkInput param` once per batch and feeds the result into every inner
+iteration, so only the work inside the benchmarked function gets
+timed. Use this when the input the function operates on is expensive
+to build (an array, a tree, a hashmap), but cheap to reuse.
 -/
 syntax (name := setupBenchmark) "setup_benchmark "
-  ident ident " => " term : command
+  ident ident " => " term (" with " &"prep" " := " ident)? : command
 
-/-- Look up the type of a constant; assert it is `Nat → α` and return `α`. -/
-def expectNatToAlpha (env : Environment) (declName : Name) :
-    CommandElabM Expr := do
+/-- Look up the type of a constant; return `(argTy, resTy)`. -/
+def expectFunction (env : Environment) (declName : Name) :
+    CommandElabM (Expr × Expr) := do
   let some ci := env.find? declName
     | throwError "setup_benchmark: function `{declName}` is not defined"
   let .forallE _ argTy resTy _ := ci.type
     | throwError "setup_benchmark: function `{declName}` is not a function (type: {ci.type})"
-  unless argTy.isConstOf ``Nat do
-    throwError "setup_benchmark: function `{declName}` must take a single `Nat` argument; got `{argTy}`"
   if resTy.hasLooseBVars then
     throwError "setup_benchmark: function `{declName}`'s return type depends on its argument; only non-dependent functions are supported"
+  return (argTy, resTy)
+
+/-- Look up the type of a constant; assert it is `Nat → α` and return `α`. -/
+def expectNatToAlpha (env : Environment) (declName : Name) :
+    CommandElabM Expr := do
+  let (argTy, resTy) ← expectFunction env declName
+  unless argTy.isConstOf ``Nat do
+    throwError "setup_benchmark: function `{declName}` must take a single `Nat` argument; got `{argTy}`"
   return resTy
 
 /-- True iff `Hashable α` synthesizes. -/
@@ -74,24 +89,48 @@ def hasHashable (alphaExpr : Expr) : CommandElabM Bool := do
     | some _ => return true
     | none => return false
 
+/-- Resolve a `setup_benchmark` argument identifier against the current
+namespace, falling back to the bare name. Returns the candidate even
+on failure so the eventual error message names the user-visible
+qualified form rather than the bare identifier. -/
+def resolveDecl (env : Environment) (ns : Name) (id : Ident) : Name :=
+  let bare := id.getId
+  let candidate := ns ++ bare
+  if env.contains candidate then candidate
+  else if env.contains bare then bare
+  else candidate
+
 @[command_elab setupBenchmark]
 def elabSetupBenchmark : CommandElab := fun stx => do
   match stx with
-  | `(command| setup_benchmark $fnId:ident $argId:ident => $complexityTerm) => do
+  | `(command| setup_benchmark $fnId:ident $argId:ident => $complexityTerm) =>
+    elabCore fnId argId complexityTerm none
+  | `(command| setup_benchmark $fnId:ident $argId:ident => $complexityTerm
+        with prep := $prepId:ident) =>
+    elabCore fnId argId complexityTerm (some prepId)
+  | _ => throwUnsupportedSyntax
+where
+  elabCore (fnId argId : Ident) (complexityTerm : Term)
+      (prepId? : Option Ident) : CommandElabM Unit := do
     let env ← getEnv
-    -- Resolve the identifier relative to the current namespace, so
-    -- `setup_benchmark goodFib …` finds `LeanBench.Examples.Fib.goodFib`
-    -- when the call lives inside that namespace. We try the
-    -- current-namespace-prefixed name first, then fall back to the
-    -- bare identifier.
-    let bare := fnId.getId
     let ns ← getCurrNamespace
-    let candidate := ns ++ bare
-    let fnName :=
-      if env.contains candidate then candidate
-      else if env.contains bare then bare
-      else candidate  -- let `expectNatToAlpha` produce the helpful error
-    let resTy ← expectNatToAlpha env fnName
+    let fnName := resolveDecl env ns fnId
+    -- Validate types, branching on whether a prep clause was given.
+    -- `resTy` is the function's return type α (used for Hashable lookup).
+    let resTy ← match prepId? with
+      | none =>
+        -- No prep: fn must be `Nat → α`.
+        expectNatToAlpha env fnName
+      | some prepStx =>
+        -- With prep: `prep : Nat → σ` and `fn : σ → α`. Check the
+        -- types line up.
+        let prepName := resolveDecl env ns prepStx
+        let σ ← expectNatToAlpha env prepName
+        let (fnArgTy, fnResTy) ← expectFunction env fnName
+        let typesMatch ← liftTermElabM <| Meta.isDefEq fnArgTy σ
+        unless typesMatch do
+          throwError "setup_benchmark: function `{fnName}` takes argument of type `{fnArgTy}`, but prep `{prepName}` returns `{σ}`"
+        pure fnResTy
     let isHashable ← hasHashable resTy
     -- Names of the auto-generated helpers.
     let cName := fnName.str "_leanBench_complexity"
@@ -105,24 +144,76 @@ def elabSetupBenchmark : CommandElab := fun stx => do
     -- in this generated def so the Lean compiler can inline the
     -- function under test directly into it (no closure indirection,
     -- no per-iteration Hashable / Option wrap on the hot path).
-    if isHashable then
-      elabCommand <| ← `(command|
-        @[inline] def $rIdent (count param : Nat) : IO (Option UInt64) := do
-          if count = 0 then return none
-          let mut last : UInt64 := 0
-          for _ in [0:count] do
-            let r := $fnId param
-            last := Hashable.hash r
-            LeanBench.blackBox last
-          return some last)
-    else
-      elabCommand <| ← `(command|
-        @[inline] def $rIdent (count param : Nat) : IO (Option UInt64) := do
-          if count = 0 then return none
-          for _ in [0:count] do
-            let r := $fnId param
-            LeanBench.blackBox (Hashable.hash (sizeOf r))
-          return none)
+    --
+    -- The runner is two-stage: it takes `param`, runs prep (if any),
+    -- forces the prep value via `blackBox (Hashable.hash s)` so its
+    -- cost stays out of the timed loop, and returns a closure
+    -- `count → IO (loopNanos × hash)`. `IO.monoNanosNow` brackets
+    -- only the inner `for` loop. The closure captures the prep
+    -- result, so prep runs once per child-process spawn, not once
+    -- per autotuner probe.
+    --
+    -- For the no-prep path, the input (`param : Nat`) is already
+    -- strict and there is nothing to force; the runner is just
+    -- `pure (fun count => …)`.
+    let mkRunner : CommandElabM (TSyntax `command) := match prepId? with
+      | none =>
+        if isHashable then
+          `(command|
+            @[inline] def $rIdent (param : Nat) :
+                IO (Nat → IO (Nat × Option UInt64)) := pure fun count => do
+              if count = 0 then return (0, none)
+              let mut last : UInt64 := 0
+              let t₀ ← IO.monoNanosNow
+              for _ in [0:count] do
+                let r := $fnId param
+                last := Hashable.hash r
+                LeanBench.blackBox last
+              let t₁ ← IO.monoNanosNow
+              return (t₁ - t₀, some last))
+        else
+          `(command|
+            @[inline] def $rIdent (param : Nat) :
+                IO (Nat → IO (Nat × Option UInt64)) := pure fun count => do
+              if count = 0 then return (0, none)
+              let t₀ ← IO.monoNanosNow
+              for _ in [0:count] do
+                let r := $fnId param
+                LeanBench.blackBox (Hashable.hash (sizeOf r))
+              let t₁ ← IO.monoNanosNow
+              return (t₁ - t₀, none))
+      | some prepId =>
+        if isHashable then
+          `(command|
+            @[inline] def $rIdent (param : Nat) :
+                IO (Nat → IO (Nat × Option UInt64)) := do
+              let s := $prepId param
+              LeanBench.blackBox (Hashable.hash s)
+              return fun count => do
+                if count = 0 then return (0, none)
+                let mut last : UInt64 := 0
+                let t₀ ← IO.monoNanosNow
+                for _ in [0:count] do
+                  let r := $fnId s
+                  last := Hashable.hash r
+                  LeanBench.blackBox last
+                let t₁ ← IO.monoNanosNow
+                return (t₁ - t₀, some last))
+        else
+          `(command|
+            @[inline] def $rIdent (param : Nat) :
+                IO (Nat → IO (Nat × Option UInt64)) := do
+              let s := $prepId param
+              LeanBench.blackBox (Hashable.hash s)
+              return fun count => do
+                if count = 0 then return (0, none)
+                let t₀ ← IO.monoNanosNow
+                for _ in [0:count] do
+                  let r := $fnId s
+                  LeanBench.blackBox (Hashable.hash (sizeOf r))
+                let t₁ ← IO.monoNanosNow
+                return (t₁ - t₀, none))
+    elabCommand (← mkRunner)
     -- (3) emit an `initialize` block that puts the runtime closure
     --     into the IO.Ref registry. We `quote` the `Name`s so the
     --     runtime registry key is a properly hierarchical `Name` —
@@ -157,6 +248,5 @@ def elabSetupBenchmark : CommandElab := fun stx => do
         hashable := isHashable
         config := {} }
     modifyEnv (addSpec · spec)
-  | _ => throwUnsupportedSyntax
 
 end LeanBench

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -53,6 +53,38 @@ $ lake exe bench compare myFib someOtherFib
 ... comparison report ...
 ```
 
+## Optional: per-param setup with `with prep := …`
+
+If your benchmarked function operates on a structure that's expensive
+to build (a sorted array, a tree, a hashmap), declaring it as
+`Nat → α` will fold the build cost into every timed iteration and
+ruin the verdict — a `log n` search behind a `O(n)` setup looks
+linear in the report. Use the optional `with prep := <ident>` clause
+to hoist the setup out of the timing loop:
+
+```lean
+def mkArr (n : Nat) : Array Nat := (Array.range n).map (· * 7)
+
+def prepInput (n : Nat) : Array Nat × Nat :=
+  (mkArr n, (n.max 1 - 1) * 7 / 2)
+
+partial def bsearch (a : Array Nat) (target : Nat) : Option Nat := ...
+
+def runBinary (input : Array Nat × Nat) : Nat :=
+  (bsearch input.1 input.2).getD 0
+
+setup_benchmark runBinary n => Nat.log2 (n + 1)
+  with prep := prepInput
+```
+
+Type contract: `prep : Nat → σ` and the benchmarked function has type
+`σ → α`. The prep's return type `σ` must be `Hashable` (in the example
+above, `Array Nat × Nat` derives it automatically); the macro hashes
+the prep result before timing starts so its construction cost is
+fully paid up front. Prep then runs once per child-process spawn —
+not once per autotuner probe — and the inner loop calls the function
+with the prepared value.
+
 ## Complexity expressions
 
 The complexity expression on the right of `=>` has type `Nat → Nat`.

--- a/examples/BinarySearch/LeanBenchExampleBinarySearchMain.lean
+++ b/examples/BinarySearch/LeanBenchExampleBinarySearchMain.lean
@@ -7,6 +7,11 @@ Search for a target in a sorted array of length `n`. Both
 implementations get the same input shape; binary search is `log n`
 and linear scan is `n`. Compare them to see the harness's verdict
 catch the asymptotic difference.
+
+This example also demonstrates `with prep := …`. The array
+construction is `O(n)`, which would dominate any `O(log n)` search if
+it ran inside the timing loop. We register `prepInput` to build the
+`(array, target)` pair once per param, outside the inner loop.
 -/
 
 namespace LeanBench.Examples.BinarySearch
@@ -41,20 +46,23 @@ def linearScan (a : Array Nat) (target : Nat) : Option Nat := Id.run do
     if a[i]! ≤ target then result := some i
   return result
 
-def runBinary (n : Nat) : Nat :=
-  let a := mkArr n
-  let target := (n.max 1 - 1) * 7 / 2
-  (bsearch a target).getD 0
+/-- Per-param setup: build the sorted array and the search target. -/
+def prepInput (n : Nat) : Array Nat × Nat :=
+  (mkArr n, (n.max 1 - 1) * 7 / 2)
 
-def runLinear (n : Nat) : Nat :=
-  let a := mkArr n
-  let target := (n.max 1 - 1) * 7 / 2
-  (linearScan a target).getD 0
+def runBinary (input : Array Nat × Nat) : Nat :=
+  (bsearch input.1 input.2).getD 0
+
+def runLinear (input : Array Nat × Nat) : Nat :=
+  (linearScan input.1 input.2).getD 0
 
 setup_benchmark runBinary n => Nat.log2 (n + 1)
+  with prep := prepInput
 setup_benchmark runLinear n => n
+  with prep := prepInput
 
 end LeanBench.Examples.BinarySearch
 
 def main (args : List String) : IO UInt32 :=
   LeanBench.Cli.dispatch args
+

--- a/test/LeanBenchTestSetupErrors.lean
+++ b/test/LeanBenchTestSetupErrors.lean
@@ -4,9 +4,9 @@ import LeanBench
 # `setup_benchmark` static-error tests
 
 Each `#guard_msgs` block confirms the macro fails with a helpful named
-error. v0.1 covers the two errors the elaborator can raise without
-spawning a child process: function-not-defined, and function-arity-bad.
-The compiled-code sanity checks (does `f 0` finish?) live in the
+error. The elaborator's static checks (function-not-defined, bad
+argument type, prep / function type mismatch) live here. The
+compiled-code sanity checks (does `f 0` finish?) live in the
 `lean-bench verify` subcommand and are tested by running it, not here.
 -/
 
@@ -27,5 +27,35 @@ error: setup_benchmark: function `LeanBench.Test.SetupErrors.boolFn` must take a
 -/
 #guard_msgs in
 setup_benchmark boolFn n => n
+
+-- Test 3: `with prep := …` referencing an undefined prep.
+def takesNat (_ : Nat) : Nat := 0
+
+/--
+error: setup_benchmark: function `LeanBench.Test.SetupErrors.noSuchPrep` is not defined
+-/
+#guard_msgs in
+setup_benchmark takesNat n => n
+  with prep := noSuchPrep
+
+-- Test 4: prep doesn't take `Nat`.
+def badPrep (_ : Bool) : Nat := 0
+
+/--
+error: setup_benchmark: function `LeanBench.Test.SetupErrors.badPrep` must take a single `Nat` argument; got `Bool`
+-/
+#guard_msgs in
+setup_benchmark takesNat n => n
+  with prep := badPrep
+
+-- Test 5: function's argument type doesn't match prep's return type.
+def prepReturnsString (_ : Nat) : String := ""
+
+/--
+error: setup_benchmark: function `LeanBench.Test.SetupErrors.takesNat` takes argument of type `Nat`, but prep `LeanBench.Test.SetupErrors.prepReturnsString` returns `String`
+-/
+#guard_msgs in
+setup_benchmark takesNat n => n
+  with prep := prepReturnsString
 
 end LeanBench.Test.SetupErrors


### PR DESCRIPTION
## Summary

- Extends `setup_benchmark` with an optional `with prep := <ident>` clause that hoists per-param setup out of the inner timing loop.
- Reshapes the runtime entry's runner into a two-stage `Nat → IO (Nat → IO (Nat × Option UInt64))`: first stage runs prep and returns a closure capturing the prep result; second stage runs `count` iterations and reports loop nanos. Prep runs once per child-process spawn, never per autotuner probe.
- The runner forces the prep result via `blackBox (Hashable.hash s)` before the timer starts, so building (e.g.) a 4M-element array doesn't leak into the reported per-call nanos.
- Refactors `runBinary` / `runLinear` in the BinarySearch example to take `Array Nat × Nat` and registers them via `with prep := prepInput`. Without the clause, `runBinary` reports inconclusive with β ≈ +0.9 (the `O(n)` `mkArr` setup dominates the `O(log n)` search inside the timer); with it, β ≈ -0.02 and the verdict is consistent.
- Three new `#guard_msgs` tests for the new error paths: prep not defined, prep doesn't take `Nat`, `fn` argument type doesn't match `prep` return type.
- `doc/quickstart.md` gains an "Optional: per-param setup" section showing the syntax and the type contract.

## Type contract

```lean
setup_benchmark fnName n => complexity_expr
  with prep := prepName
```

- `prep : Nat → σ`
- `fn  : σ → α`
- `σ` must derive `Hashable` (for the timer-start force; tuples and arrays of `Nat` derive it automatically)

## Test plan

- [x] `lake build` succeeds (49 targets).
- [x] `lake exe roundtrip_benchmark_test` passes.
- [x] `lake exe binary_search_benchmark_example run LeanBench.Examples.BinarySearch.runBinary` reports **consistent** with β ≈ -0.02 (was inconclusive with β ≈ +0.9 on master).
- [x] All other example benchmark verdicts unchanged (goodFib / runLinear / runInsertion / runMergeSort all consistent; `badFib` inconclusive as documented).
- [x] All five `#guard_msgs` tests in `LeanBenchTestSetupErrors.lean` pass.

Builds on top of #21.

🤖 Prepared with Claude Code