### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: leanprover/lean-action@v1
+        with:
+          # The default `lake build` covers the whole defaultTargets list:
+          # the LeanBench library, all three example libs+exes (Fib, Sort,
+          # BinarySearch), the LeanBenchTest library (whose `#guard_msgs`
+          # blocks in LeanBenchTestSetupErrors.lean are checked at build
+          # time), and the test exes (roundtrip_benchmark_test,
+          # verify_benchmark_test).
+          build-args: ""
+          test: false
+
+      # Test exes: each exits non-zero on failure.
+      - name: roundtrip test
+        run: ./.lake/build/bin/roundtrip_benchmark_test
+
+      - name: verify-command test
+        run: ./.lake/build/bin/verify_benchmark_test
+
+      # End-to-end smoke tests: `list` exercises the registry +
+      # `initialize` blocks; `verify` spawns each registered benchmark's
+      # child path against `f 0` / `f 1` and is bounded by the spec's
+      # maxSecondsPerCall, so it cannot hang CI.
+      - name: fib example list & verify
+        run: |
+          ./.lake/build/bin/fib_benchmark_example list
+          ./.lake/build/bin/fib_benchmark_example verify
+
+      - name: sort example list & verify
+        run: |
+          ./.lake/build/bin/sort_benchmark_example list
+          ./.lake/build/bin/sort_benchmark_example verify
+
+      - name: binary-search example list & verify
+        run: |
+          ./.lake/build/bin/binary_search_benchmark_example list
+          ./.lake/build/bin/binary_search_benchmark_example verify


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml`. Runs on push-to-master and on PRs.

Single Linux job using [`leanprover/lean-action@v1`](https://github.com/leanprover/lean-action), which picks up the toolchain from `lean-toolchain`. It does:

- **Build** — `lake build` covers everything in `defaultTargets`: the `LeanBench` library, all three example libs+exes (Fib, Sort, BinarySearch), the `LeanBenchTest` library (whose `#guard_msgs` static-error blocks in [test/LeanBenchTestSetupErrors.lean](test/LeanBenchTestSetupErrors.lean) are checked at build time, so build = test for the `setup_benchmark` macro errors), and the test exes (`roundtrip_benchmark_test`, `verify_benchmark_test`).
- **Run test exes** — `roundtrip_benchmark_test` and `verify_benchmark_test`. Each exits non-zero on failure.
- **Smoke-test each example** — `<example> list` (registry + `initialize` blocks fire) and `<example> verify` (spawns the child path against `f 0`/`f 1`, bounded by the spec's `maxSecondsPerCall` so it cannot hang).

`verify` (#18) is what makes this practical: it replaces the slow ladder run as the end-to-end smoke test.

## Not in scope

- macOS / Windows: README is explicit that v0.1 is Linux-only. Cross-platform CI is on the v0.2 list ([PLAN.md F0](PLAN.md)) once the `timeout(1)` shellout is replaced.
- Pinning the floating `Cli` dep ([lakefile.toml:13](lakefile.toml)) to a SHA. Worth doing for CI reproducibility, but a separate concern.

## Test plan

- [ ] CI run on this PR is green
- [ ] CI catches a deliberately broken `setup_benchmark` (e.g. mutate one of the `#guard_msgs` expected messages) — verifies the static-error suite is actually being exercised at build time

🤖 Prepared with Claude Code