### PR TITLE
feat: adaptive param ladders (doubling/linear) auto-picked from declared complexity

### DIFF
--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -40,6 +40,12 @@ structure DataPoint where
   /-- Present iff the function's return type has a `Hashable` instance. -/
   resultHash   : Option UInt64
   status       : Status
+  /-- False for doubling-probe rows in `.linear` mode: they exist to
+      bracket the productive band but must not enter the verdict (else
+      cold-regime rows corrupt `cMin/cMax`/slope). True for everything
+      else, including all rows in `.doubling` mode. Parent-side only —
+      not serialized in the child JSONL. -/
+  partOfVerdict : Bool := true
   deriving Repr, Inhabited
 
 /-- Heuristic verdict — see SPEC v0.1: weak labels by design. Decided
@@ -55,6 +61,29 @@ inductive Verdict
 def Verdict.describe : Verdict → String
   | .consistentWithDeclaredComplexity => "consistent with declared complexity"
   | .inconclusive => "inconclusive"
+
+/-- Shape of the parameter ladder.
+
+    `.doubling` is the right schedule for polynomial complexity: it
+    spreads samples evenly in log-space so the verdict's log-log slope
+    fit is well-conditioned.
+
+    `.linear` is the right schedule for exponential complexity: a
+    doubling probe brackets the productive band (between the last
+    `ok` rung and the first capped rung), then `samples` rungs are
+    run inside that bracket so the high-`n` regime where the model
+    dominates overhead is well-sampled.
+
+    `.auto` is the default — at runtime it inspects the declared
+    complexity and resolves to one of the above. The heuristic
+    compares `complexity(2n)/complexity(n)` at two scales: for any
+    `n^k` it is constant (→ doubling); for any `b^n` it grows
+    geometrically (→ linear). -/
+inductive ParamSchedule
+  | doubling
+  | linear (samples : Nat := 16)
+  | auto
+  deriving Inhabited, Repr
 
 /-- Per-benchmark configuration. Defaults are the v0.1 contract. -/
 structure BenchmarkConfig where
@@ -83,6 +112,22 @@ structure BenchmarkConfig where
       like `n log n` vs declared `n`. Widen on chronically noisy
       hardware; tighten only if you trust the measurements. -/
   slopeTolerance : Float := 0.15
+  /-- Noise tolerance on the multiplicative `cMax / cMin` range used
+      as a fallback verdict on narrow ladders (where the slope fit is
+      ill-conditioned). The actual bound combines this floor with the
+      scale-adjusted slope tolerance:
+      `cMax / cMin ≤ max(narrowRangeNoiseFloor, exp(slopeTolerance · xRange))`.
+      Default 1.50 admits the 15–25% spread observed at near-cap
+      `×2^0` rungs of an exponential-complexity linear ladder (where
+      single-shot timing variance is the dominant noise source) with
+      enough headroom for noisy hardware. Tighten if you want to
+      discriminate finer model differences and accept a higher
+      false-negative rate; widen further on chronically noisy hosts. -/
+  narrowRangeNoiseFloor : Float := 1.50
+  /-- Ladder shape — see `ParamSchedule`. `.auto` (default) inspects
+      the declared complexity at runtime and picks `.doubling` for
+      polynomial growth, `.linear` for exponential. -/
+  paramSchedule : ParamSchedule := .auto
   deriving Inhabited, Repr
 
 /-- One entry in the benchmark registry. Stored as `Name`s plus a

--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -120,12 +120,19 @@ private def rawRow (cMaybe : Option Float) (dp : DataPoint) : Row :=
   let cStr := match cMaybe with
     | some c => fmtFloat3 c
     | none   => "—"
+  let baseStatus := statusSuffix dp.status
+  -- Doubling probe rows in `.linear` mode are demoted from the
+  -- verdict; mark them so a row with valid timing but `C=—` doesn't
+  -- look like a measurement failure.
+  let status :=
+    if dp.status == .ok && !dp.partOfVerdict then baseStatus ++ " [probe]"
+    else baseStatus
   { param       := fmtNatUnderscores dp.param
     perCallNum  := num
     perCallUnit := unit
     repeats     := fmtRepeats dp.innerRepeats
     cStr
-    status      := statusSuffix dp.status }
+    status }
 
 /-- Render one `BenchmarkResult` as a multi-line block with every
 numeric value bounded to 3 decimals and every column width derived

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -6,21 +6,33 @@ import LeanBench.Stats
 /-!
 # `LeanBench.Run` — parent-side orchestration
 
-For each param in the doubling ladder:
+For each param in the chosen ladder shape (`ParamSchedule`), spawn
+the same binary as a child:
 
-1. Spawn the same binary as a child (`_child --bench NAME --param N
-   --target-nanos T`) with a wallclock cap enforced via the POSIX
-   `timeout(1)` utility. We delegate the kill semantics to coreutils
-   on purpose — it's simpler and more reliable than rolling our own
-   SIGTERM/SIGKILL escalation in Lean. (Linux/macOS only; documented.)
+1. `timeout(1)` enforces the wallclock cap (Linux/macOS; we delegate
+   kill semantics to coreutils rather than rolling SIGTERM/SIGKILL
+   escalation in Lean).
 2. Read the child's stdout (one JSONL row).
-3. If the child exited 0 with a parseable row → use it.
-   If `timeout` returned 124 (graceful timeout) or 137 (SIGKILL after
-   `--kill-after`) → synthesize a `killedAtCap` row.
-   If the child died otherwise → synthesize an `error` row.
-4. Stop doubling once the param hits `paramCeiling` or any single
-   batch returns a non-`ok` status.
-5. Hand the points to `Stats.summarize` for ratio + verdict.
+3. Exit 0 + parseable row → use it; 124/137 → `killedAtCap`; other →
+   `error`.
+4. Doubling stops at `paramCeiling` or any non-`ok` status.
+
+Two ladder shapes:
+
+- **Doubling** (`.doubling`): walk `paramFloor, 1, 2, 4, …` up to
+  `paramCeiling`. Right for polynomial complexity.
+- **Linear** (`.linear samples`): doubling probe brackets the
+  productive band `(lastOk, firstFail)`, then `samples` rungs are
+  evenly spaced strictly inside that bracket. Probe rows get
+  `partOfVerdict := false` so they don't corrupt `cMin/cMax`/slope;
+  sweep rows get `partOfVerdict := true`. Right for exponential
+  complexity, where the cap kills doubling within 1–2 useful rungs.
+
+`.auto` (the default) inspects the declared complexity at runtime
+and resolves to one of the above by comparing `complexity(64) /
+complexity(32)` against `complexity(16) / complexity(8)`: for any
+`n^k` they're equal (→ doubling); for any `b^n` the former dominates
+(→ linear).
 -/
 
 open Lean
@@ -73,7 +85,7 @@ def parseChildRow (line : String) : Except String DataPoint := do
 /-- Synthesize a row when the child died before emitting. -/
 def synthRow (param : Nat) (status : Status) : DataPoint :=
   { param, innerRepeats := 0, totalNanos := 0, perCallNanos := 0.0
-  , resultHash := none, status }
+  , resultHash := none, status, partOfVerdict := true }
 
 /-- Spawn one child invocation and return the resulting DataPoint. -/
 def runOneBatch (spec : BenchmarkSpec) (param : Nat) : IO DataPoint := do
@@ -124,6 +136,97 @@ def paramLadder (cfg : BenchmarkConfig) : Array Nat := Id.run do
       acc := acc.push p
   return acc
 
+/-- Doubling-rate-of-doubling-rate test for "is this complexity
+    super-polynomial?" Compares `complexity(64)/complexity(32)`
+    against `complexity(16)/complexity(8)`: equal for any `n^k`,
+    grows geometrically for any `b^n` with `b > 1`. The threshold
+    of 4× catches even mild exponentials like `(1.1)^n` while
+    leaving high-degree polynomials and slow growers on doubling.
+
+    Denominators are clamped to `≥ 1` so that complexity functions
+    that bottom out at 0 don't divide by zero. -/
+private def autoPicksLinear (complexity : Nat → Nat) : Bool :=
+  let c8  := (max 1 (complexity 8)).toFloat
+  let c16 := (complexity 16).toFloat
+  let c32 := (max 1 (complexity 32)).toFloat
+  let c64 := (complexity 64).toFloat
+  let r8  := c16 / c8
+  let r32 := c64 / c32
+  r32 ≥ 4.0 * r8
+
+/-- Estimate the largest `n` past `lastOk` whose run cost should fit
+    within `capNanos`, extrapolating from `lastOk`'s observed per-call
+    cost via the declared complexity model:
+
+    ```
+    predicted(n) ≈ lastOkPerCallNanos × complexity(n) / complexity(lastOk)
+    ```
+
+    Returns the first `n ∈ (lastOk, probedFirstFail)` where
+    `predicted(n) > safety × capNanos`, or `probedFirstFail` if none.
+    The doubling probe's `firstFail` overshoots the real boundary by
+    up to a factor of two (cost doubles per `n` doubling for any
+    polynomial; far more for an exponential), so this refinement
+    matters: without it, an exponential benchmark wastes most of its
+    sweep budget on rungs guaranteed to hit the cap. -/
+private def estimateFirstFail (complexity : Nat → Nat)
+    (lastOk : Nat) (lastOkPerCallNanos : Float)
+    (capNanos : Float) (probedFirstFail : Nat) : Nat :=
+  let safety : Float := 0.7
+  let lastOkComp := (max 1 (complexity lastOk)).toFloat
+  let perUnit := lastOkPerCallNanos / lastOkComp
+  Id.run do
+    let mut n := lastOk + 1
+    while n < probedFirstFail do
+      if perUnit * (complexity n).toFloat > safety * capNanos then return n
+      n := n + 1
+    return probedFirstFail
+
+/-- Linear sweep rungs strictly inside `(lastOk, firstFail)`, stride 1,
+    capped at `samples` rungs from the bottom of the bracket.
+
+    With a complexity-tightened `firstFail` the bracket is narrow enough
+    that stride 1 gives the maximum useful samples without wasting runs
+    on rungs that would hit the cap. Returns `#[]` when the bracket is
+    empty. -/
+private def pickLinearRungs (lastOk firstFail samples : Nat) : Array Nat :=
+  if firstFail ≤ lastOk + 1 || samples = 0 then #[] else
+    let last := min (firstFail - 1) (lastOk + samples)
+    (Array.range (last - lastOk)).map (lastOk + 1 + ·)
+
+/-- Run the static doubling ladder. Returns `(points, lastOk?, firstFail?)`:
+
+- `lastOk?` is the largest param whose status was `.ok` (none if no row
+  was ok),
+- `firstFail?` is the first param after `lastOk` whose status was non-ok
+  (none if the ladder ran to ceiling without failing).
+
+Probe rows are returned with whatever `partOfVerdict` `runOneBatch`
+chose (defaults to true); the caller flips them as needed. -/
+private def runDoublingProbe (spec : BenchmarkSpec) :
+    IO (Array DataPoint × Option Nat × Option Nat) := do
+  let ladder := paramLadder spec.config
+  let mut points : Array DataPoint := #[]
+  let mut lastOk : Option Nat := none
+  let mut firstFail : Option Nat := none
+  for param in ladder do
+    if firstFail.isSome then break
+    let dp ← runOneBatch spec param
+    points := points.push dp
+    match dp.status with
+    | .ok => lastOk := some param
+    | _   => firstFail := some param
+  return (points, lastOk, firstFail)
+
+/-- Resolve `.auto` to either `.doubling` or a sensible `.linear`. -/
+private def resolveSchedule (cfg : BenchmarkConfig) (complexity : Nat → Nat) :
+    ParamSchedule :=
+  match cfg.paramSchedule with
+  | .doubling => .doubling
+  | .linear samples => .linear samples
+  | .auto =>
+    if autoPicksLinear complexity then .linear 16 else .doubling
+
 /-- Measure the per-spawn floor: spawn the child against the first
     available benchmark with a 1µs target. The result is dominated by
     spawn cost when the inner work is trivial. -/
@@ -136,20 +239,48 @@ def measureSpawnFloor : IO (Option Nat) := do
   let t₁ ← IO.monoNanosNow
   return some (t₁ - t₀)
 
-/-- Run one benchmark end-to-end. -/
+/-- Run one benchmark end-to-end: resolve the schedule, run the
+    doubling probe, optionally do a bracket-internal linear sweep,
+    then summarise. -/
 def runBenchmark (name : Lean.Name) : IO BenchmarkResult := do
   let some entry ← findRuntimeEntry name
     | throw (.userError s!"unregistered benchmark: {name}")
-  let ladder := paramLadder entry.spec.config
-  let mut points : Array DataPoint := #[]
-  let mut continueLadder := true
-  for param in ladder do
-    if !continueLadder then break
-    let dp ← runOneBatch entry.spec param
-    points := points.push dp
-    match dp.status with
-    | .ok => pure ()
-    | _ => continueLadder := false
+  let schedule := resolveSchedule entry.spec.config entry.complexity
+  let (probePoints, lastOk?, firstFail?) ← runDoublingProbe entry.spec
+  let mut points := probePoints
+  match schedule with
+  | .doubling => pure ()
+  | .auto => pure ()  -- unreachable after resolveSchedule
+  | .linear samples =>
+    match lastOk?, firstFail? with
+    | some lastOk, some firstFail =>
+      -- Tighten the bracket using the complexity model + observed
+      -- cost at `lastOk`, so we don't burn the sweep budget on rungs
+      -- that are guaranteed to hit the cap.
+      let lastOkPerCall : Float :=
+        (probePoints.findSome? fun dp =>
+            if dp.param == lastOk && dp.status == .ok then
+              some dp.perCallNanos
+            else none).getD 0.0
+      let capNanos : Float :=
+        entry.spec.config.maxSecondsPerCall.toFloat * 1.0e9
+      let effFirstFail :=
+        estimateFirstFail entry.complexity lastOk lastOkPerCall
+          capNanos firstFail
+      let rungs := pickLinearRungs lastOk effFirstFail samples
+      if !rungs.isEmpty then
+        -- Probe rows are bracket-finding only; demote them so they
+        -- don't enter `cMin`/`cMax`/slope.
+        points := points.map ({ · with partOfVerdict := false })
+        for n in rungs do
+          let dp ← runOneBatch entry.spec n
+          points := points.push dp
+          if dp.status != .ok then break
+    | _, _ =>
+      -- No bracket (doubling ran clean to ceiling, or first rung failed).
+      -- Fall back to doubling-only — probe rows already have
+      -- `partOfVerdict := true`.
+      pure ()
   let spawnFloor ← measureSpawnFloor
   let summary := Stats.summarize entry.spec entry.complexity points
   return { summary with spawnFloorNanos? := spawnFloor }

--- a/LeanBench/Stats.lean
+++ b/LeanBench/Stats.lean
@@ -18,8 +18,9 @@ namespace LeanBench
 namespace Stats
 
 /-- Compute the per-point ratio C = perCallNanos / complexity(param).
-    Skips param=0 and param=1 (denominator may be 0 or 1, noisy)
-    and any non-`ok` data points. -/
+    Skips param=0 and param=1 (denominator may be 0 or 1, noisy),
+    any non-`ok` data points, and any rows flagged as not part of
+    the verdict (doubling-probe rows in `.linear` mode). -/
 def ratiosFromPoints
     (complexity : Nat → Nat)
     (points : Array DataPoint) :
@@ -28,22 +29,32 @@ def ratiosFromPoints
   for dp in points do
     if dp.param < 2 then continue
     if dp.status != .ok then continue
+    if !dp.partOfVerdict then continue
     let d := complexity dp.param
     if d == 0 then continue
     acc := acc.push (dp.param, dp.perCallNanos / d.toFloat)
   return acc
 
 /-- OLS slope of the points `(x, y)`. `none` if there are fewer than
-    two points, or if the `x` values are (essentially) all equal. -/
+    two points, the `x` values are (essentially) all equal, or the
+    `x` range is too narrow to make the slope estimate trustworthy
+    (a linear-ladder log-x span of `~0.65` is not enough to tell
+    `n^k` from `n^(k+0.1)` with realistic noise). The caller is
+    expected to fall back to a range check on `cMin`/`cMax`. -/
 private def fitSlope (pts : Array (Float × Float)) : Option Float :=
   if pts.size < 2 then none
   else Id.run do
     let n := pts.size.toFloat
     let mut sx : Float := 0.0
     let mut sy : Float := 0.0
+    let mut xMin : Float := pts[0]!.1
+    let mut xMax : Float := pts[0]!.1
     for (x, y) in pts do
       sx := sx + x
       sy := sy + y
+      if x < xMin then xMin := x
+      if x > xMax then xMax := x
+    if xMax - xMin < 1.0 then return none
     let xbar := sx / n
     let ybar := sy / n
     let mut num : Float := 0.0
@@ -64,11 +75,16 @@ private def fitSlope (pts : Array (Float × Float)) : Option Float :=
 
     The verdict is decided by the log-log slope β of `C` vs `param`
     over the trimmed tail: `|β| ≤ slopeTolerance` → consistent, else
-    inconclusive. `cMin`/`cMax` are still reported as diagnostic
-    context, but no longer drive the verdict. Returns
+    inconclusive. On narrow log-x ranges (where the slope fit is
+    ill-conditioned and rejected by `fitSlope`), falls back to a
+    multiplicative range check: `cMax / cMin ≤ max(noiseFloor,
+    exp(slopeTolerance · xRange))`. The `noiseFloor` admits the
+    realistic spread of single-shot near-cap measurements (15-20%)
+    that exponential-complexity benchmarks unavoidably hit. `cMin`/
+    `cMax` are still reported as diagnostic context. Returns
     `(verdict, cMin?, cMax?, slope?, droppedLeading)`. -/
 def deriveVerdict (ratios : Array Ratio)
-    (warmupFraction : Float) (slopeTolerance : Float) :
+    (warmupFraction slopeTolerance noiseFloor : Float) :
     Verdict × Option Float × Option Float × Option Float × Nat :=
   if ratios.size < 3 then
     (.inconclusive, none, none, none, 0)
@@ -87,10 +103,28 @@ def deriveVerdict (ratios : Array Ratio)
         none
     let slope? := fitSlope pts
     let v : Verdict := match slope? with
-      | some β => if β.abs ≤ slopeTolerance then
-                    .consistentWithDeclaredComplexity
-                  else .inconclusive
-      | none   => .inconclusive
+      | some β =>
+        if β.abs ≤ slopeTolerance then .consistentWithDeclaredComplexity
+        else .inconclusive
+      | none =>
+        -- Slope was rejected (narrow log-x range or degenerate).
+        -- Fall back to a multiplicative range check matching the
+        -- slope semantics: log(cMax/cMin) ≤ slopeTolerance · xRange.
+        -- Equivalent to `cMax/cMin ≤ exp(slopeTolerance · xRange)`.
+        -- Naive `cMax/cMin ≤ 1 + slopeTolerance` is unsound — it
+        -- admits e.g. an actual `n² log n` declared as `n²` because
+        -- `log` varies slowly over any narrow `n` interval.
+        if pts.size < 2 || cMin ≤ 0.0 then .inconclusive
+        else
+          let xs := pts.map (·.1)
+          let xMin := xs.foldl min xs[0]!
+          let xMax := xs.foldl max xs[0]!
+          let xRange := xMax - xMin
+          let scaled := Float.exp (slopeTolerance * xRange)
+          let bound := if scaled > noiseFloor then scaled else noiseFloor
+          if cMax / cMin ≤ bound then
+            .consistentWithDeclaredComplexity
+          else .inconclusive
     (v, some cMin, some cMax, slope?, dropCount)
 
 /-- Build a `BenchmarkResult` from spec + complexity closure + collected points. -/
@@ -102,7 +136,7 @@ def summarize
   let ratios := ratiosFromPoints complexity points
   let (verdict, cMin?, cMax?, slope?, dropped) :=
     deriveVerdict ratios spec.config.verdictWarmupFraction
-      spec.config.slopeTolerance
+      spec.config.slopeTolerance spec.config.narrowRangeNoiseFloor
   { function := spec.name
   , complexityFormula := spec.complexityFormula
   , config := spec.config

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 Microbenchmark library for Lean 4. Declare a benchmark and the
 complexity model you expect; run it; the harness reports per-call
-times across a doubling parameter ladder and the ratio
+times across an adaptive parameter ladder and the ratio
 `C = perCallNanos / complexity(n)`. If your model fits, `C` is
 roughly constant.
+
+The ladder shape is auto-picked from the declared complexity:
+doubling for polynomial growth, linear-inside-the-cap-bracket for
+exponential.
 
 ## Try it
 

--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -6,7 +6,7 @@ v0.1; v0.2+ items live in [PLAN.md](../PLAN.md).
 ## Comparing implementations
 
 `lake exe bench compare A B C [...]` runs each named benchmark
-through its own doubling ladder, then prints:
+through its own (auto-picked) ladder, then prints:
 
 - the full per-function table (one block per benchmark)
 - the `commonParams` intersection (the params at which every
@@ -59,6 +59,16 @@ claim. Things that produce an inconclusive verdict:
 - arbitrary-precision arithmetic on growing results (Lean's `Nat`
   is bignum; if `f n` returns a number with k bits, every operation
   on it costs O(k))
+
+For exponential complexity, the verdict's β line shows `—` because
+the slope fit is rejected for narrow log-x ranges (the fit would be
+ill-conditioned). The `cMin/cMax` range check takes over: the
+verdict is consistent iff `cMax/cMin ≤ max(narrowRangeNoiseFloor,
+exp(slopeTolerance · xRange))`. Default `narrowRangeNoiseFloor = 1.50`
+admits the 15-25% spread that single-shot near-cap measurements show
+on noisy hardware. Tighten if you want to discriminate finer model
+differences and accept the false-negative rate; widen further on
+chronically noisier hardware.
 
 β tells you the direction; the raw ratios tell you the magnitude.
 Together they're enough to tell "off by a polynomial factor" from

--- a/doc/design.md
+++ b/doc/design.md
@@ -122,9 +122,67 @@ get a synthesized `error` row. Both paths are explicitly tested in
 
 ## Ladder semantics
 
-Each benchmark gets its own doubling ladder
-`[paramFloor, 1, 2, 4, …, paramCeiling]`. Stops at the first
-non-`ok` rung (kill, timeout, error). Two functions in the same
-`compare` may stop at very different params; the report preserves
-both ladders fully and computes `agreeOnCommon` only over the
-intersection.
+The ladder shape is per-benchmark and chosen via `BenchmarkConfig.paramSchedule`:
+
+- `.doubling` — `[paramFloor, 1, 2, 4, …, paramCeiling]`. Stops at
+  the first non-`ok` rung. Right for polynomial complexity: it
+  spreads samples evenly in log-space, which is what the verdict's
+  log-log slope fit needs.
+- `.linear samples` — runs the doubling ladder as a *probe* (rows
+  marked `partOfVerdict := false`), records the bracket
+  `(lastOk, firstFail)`, then refines `firstFail` against the
+  declared complexity model and the wallclock cap (so we don't
+  burn the sweep budget on rungs guaranteed to time out), then
+  walks `samples` consecutive rungs from `lastOk + 1` upward inside
+  the refined bracket. Right for exponential complexity, where the
+  cap kills doubling within 1–2 useful samples.
+- `.auto` (default) — at runtime, evaluates the declared complexity
+  at probe points 8/16/32/64 and resolves to one of the above. The
+  test compares `complexity(64)/complexity(32)` against
+  `complexity(16)/complexity(8)`: equal for any `n^k` (→ doubling),
+  super-linearly larger for any `b^n` (→ linear, threshold 4×).
+
+Probe rows in `.linear` mode are kept in the report (so the user
+sees the cold-regime context that determined the bracket) but
+filtered out of `cMin/cMax`/slope by `Stats.ratiosFromPoints`.
+
+Two functions in the same `compare` may stop at very different
+params; the report preserves both ladders fully and computes
+`agreeOnCommon` only over the intersection.
+
+### Verdict on narrow ladders
+
+The slope-based verdict (`|β| ≤ slopeTolerance`) only works when the
+log-x range is wide enough to make OLS well-conditioned. Linear
+ladders span a narrow log-x range (e.g. `n ∈ 33..40` is `log
+40/33 ≈ 0.19`), so `Stats.fitSlope` returns `none` for spans below
+`1.0` and `deriveVerdict` falls back to a multiplicative range
+check:
+
+```
+cMax / cMin  ≤  max(narrowRangeNoiseFloor, exp(slopeTolerance × xRange))
+```
+
+Two ingredients:
+
+- The scale-adjusted slope bound `exp(slopeTolerance × xRange)`
+  matches the slope semantics: it converges to `1 + slopeTolerance ·
+  xRange` for small spans and admits exactly the constant-`C` data
+  the slope check would. Naive `cMax/cMin ≤ 1 + slopeTolerance` is
+  unsound (admits e.g. `n² log n` declared as `n²` because `log`
+  varies slowly over any narrow interval).
+- The `narrowRangeNoiseFloor` (default 1.50) admits the realistic
+  15–25% spread of single-shot near-cap measurements. At the upper
+  rungs of an exponential-complexity ladder the autotuner runs 1–4
+  inner repeats per spawn (because each batch is already at the
+  cap), so per-call timings are unsmoothed. Without a noise floor
+  the bound `exp(slopeTolerance · xRange) ≈ 1.03` over `xRange ≈
+  0.2` would reject the actual data run after run; `1.50` lets a
+  flat-with-noise C pass with comfortable margin on noisy hardware
+  while still flagging gross deviations.
+
+The tradeoff: with a 1.50 noise floor on a narrow ladder, an actual
+`n^(2.1)` declared as `n^2` over `n ∈ 33..40` would pass (cMax/cMin
+≈ 1.20). On wider ladders that benchmark would use doubling and the
+slope check would catch it. The noise floor only relaxes the
+narrow-range path.

--- a/examples/Fib/LeanBenchExampleFib.lean
+++ b/examples/Fib/LeanBenchExampleFib.lean
@@ -10,8 +10,10 @@ Two implementations of Fibonacci, both benchmarked.
 - `badFib`  — naive doubly-recursive over `Nat`. Declared complexity
    `144 ^ n / 89 ^ n`: the actual cost is `Θ(φ ^ n)` (golden ratio),
    and `144 / 89 ≈ 1.61798` is within ~3×10⁻⁵ of `φ ≈ 1.61803`, so
-   `(144/89)^n` tracks `φ^n` to well under a percent across the test
-   range — close enough that the verdict should be conclusive.
+   `(144/89)^n` tracks `φ^n` to well under a percent. The harness
+   auto-detects this is exponential and runs a linear ladder over
+   `(lastOk, firstFail)` instead of doubling, which would only get
+   1–2 useful samples before hitting the cap.
 
 Run them with `lake exe fib_benchmark_example list` /
 `run NAME` / `compare A B`.


### PR DESCRIPTION
## Summary

Hardcoded doubling ladder is right for polynomial complexity but gets only 1-2 useful samples for exponential complexity before the wallclock cap kicks in. `badFib` with declared `144^n/89^n` (a φⁿ approximation) used to get inconclusive verdicts because the productive band sits *between* the last ok doubling rung and the first capped one — and doubling never samples there.

This adds:

- `ParamSchedule` (`.doubling | .linear samples | .auto`) on `BenchmarkConfig`, default `.auto`. Auto-detect compares `complexity(64)/complexity(32)` against `complexity(16)/complexity(8)`: equal for any `n^k` (→ doubling); super-linear for any `b^n` (→ linear, threshold 4×). Robust against high-degree polynomials and mild exponentials like `(1.1)^n`.
- Linear sweep runs *inside* the `(lastOk, firstFail)` bracket found by the doubling probe, with `firstFail` further tightened against the complexity model + cap so we don't burn the sweep budget on rungs guaranteed to time out. Stride 1 from `lastOk + 1`.
- `partOfVerdict : Bool` on `DataPoint` so probe rows don't corrupt `cMin`/`cMax`/slope.
- Slope fit rejects narrow log-x ranges (`xMax - xMin < 1.0`); falls back to a multiplicative range check `cMax/cMin ≤ max(narrowRangeNoiseFloor, exp(slopeTolerance · xRange))`. The `exp(·)` form matches slope semantics; the noise floor (1.50) admits the 15-25% spread observed at near-cap `×2^0` rungs of exponential ladders.
- Format prints a `[probe]` marker on demoted-but-ok rows so they're distinguishable from killed-at-cap rows.

`badFib` now produces ~9 ok rungs at n=33..41 and a green verdict across 5/5 runs. `goodFib` still uses doubling (auto detects the linear complexity), unchanged. Polynomial benchmarks (sort, binary search) likewise unchanged.

The `setup_benchmark … where { … }` clause for explicit per-benchmark override stays on the v0.2 roadmap.

## Test plan

- [x] `lake build` clean
- [x] `lake exe fib_benchmark_example run LeanBench.Examples.Fib.badFib` — auto-detects exponential, runs linear sweep n=33..41, verdict consistent (5/5 runs)
- [x] `lake exe fib_benchmark_example run LeanBench.Examples.Fib.goodFib` — auto-detects polynomial, runs doubling, unchanged
- [x] `lake exe fib_benchmark_example compare …` — works across mixed schedules
- [x] `lake exe binary_search_benchmark_example run LeanBench.Examples.BinarySearch.runBinary` — `Nat.log2 (n+1)`, doubling, consistent
- [x] `lake exe sort_benchmark_example run LeanBench.Examples.Sort.runInsertion` — `n*n`, doubling, consistent
- [x] `lake exe roundtrip_benchmark_test` — JSONL roundtrip passes (new `partOfVerdict` field is parent-side only)

🤖 Prepared with Claude Code