### PR TITLE
docs+ci: finish the timeout(1) removal story (closes #27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
         shell: bash
         run: ./.lake/build/bin/config_benchmark_test
 
+      - name: fixed-benchmark test (kill path for setup_fixed_benchmark)
+        shell: bash
+        run: ./.lake/build/bin/fixed_benchmark_test
+
       # End-to-end smoke tests: `list` exercises the registry +
       # `initialize` blocks; `verify` spawns each registered benchmark's
       # child path against `f 0` / `f 1` and is bounded by the spec's

--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -102,20 +102,28 @@ times until the param grows past where startup dominates.
 
 ## CI integration
 
-A typical CI step runs the bench exe with low budget per call so the
-whole job stays bounded:
+A typical CI step runs the bench exe with a low per-call budget so
+each individual measurement is bounded:
 
 ```yaml
 - name: Benchmark sanity
+  timeout-minutes: 10
   run: |
     lake build bench
-    timeout 60 lake exe bench list                # always passes
-    timeout 120 lake exe bench run goodFib \
+    lake exe bench list
+    lake exe bench run goodFib \
       --max-seconds-per-call 0.5 --param-ceiling 1024
 ```
 
-The same flags work on `compare`, so you can pin a comparison run to
-a tight wallclock budget without recompiling. See
+`run`, `compare`, and `verify` enforce their own per-call wallclock
+cap via the in-Lean kill path, so they don't need an external
+`timeout(1)` wrapper — and the example above runs unchanged on
+Windows, which lacks GNU `timeout`. `list` and `lake build` aren't
+covered by the per-call cap (they don't run user code), so for an
+overall job-level bound use the CI system's own timeout (e.g.
+GitHub Actions' `timeout-minutes` shown above) rather than a shell
+wrapper. The same per-call flags work on `compare`, so you can pin a
+comparison run to a tight wallclock budget without recompiling. See
 [quickstart.md](quickstart.md#configuring-a-benchmark) for the full
 flag list and the matching declaration-time `where { … }` syntax.
 


### PR DESCRIPTION
Closes #27.

The code-level removal of GNU coreutils `timeout(1)` from the runner
landed in #20 (which closed #1). This PR finishes the migration story
by tying up the remaining doc + CI loose ends called out in #27's
acceptance criteria.

## Changes

**`doc/advanced.md`** — drop the `timeout 60 lake exe bench list` /
`timeout 120 lake exe bench run goodFib …` shell wrappers from the
CI integration example. They:
- Contradict the project's no-external-dependency stance.
- Don't work on Windows (GNU `timeout` isn't available).
- Are redundant with the harness's own in-Lean per-call cap for `run`
  / `compare` / `verify`.

The new wording is precise about which subcommands are covered by
the in-Lean cap and points at the CI system's own job-level timeout
(e.g. `timeout-minutes` for GitHub Actions) for bounding `list` /
`lake build`, which don't run user code.

**`.github/workflows/ci.yml`** — wire the existing
`fixed_benchmark_test` (added in #26) as a CI step on all three OSes.
That test exercises `runFixedOneBatch`'s kill-on-cap path, which
previously wasn't validated in CI even though the executable was
already in `defaultTargets`. With this, both the parametric and
fixed-benchmark kill paths now run on Linux / macOS / Windows.

## Acceptance criteria from #27

- [x] `LeanBench/Run.lean` no longer shells out to `timeout` — done
  in #20.
- [x] No user-facing docs claim `timeout(1)` is still required — the
  remaining shell-`timeout` examples in `doc/advanced.md` are gone
  with this PR.
- [x] Timeout / killed-at-cap behavior still works correctly — covered
  by `kill_path_benchmark_test` (parametric) and `fixed_benchmark_test`
  (fixed), both now running cross-platform.
- [x] CI covers at least one non-Linux platform — matrix already has
  `ubuntu-latest`, `macos-latest`, `windows-latest`; this PR extends
  the kill-path coverage on those platforms to the fixed-benchmark
  variant.

## Test plan

- [x] `lake build` clean
- [x] `kill_path_benchmark_test` passes locally
- [x] `fixed_benchmark_test` passes locally (exercises `killOnCap`
  case alongside the rest of the fixed suite)
- [ ] CI green on all three OSes

🤖 Prepared with Claude Code