### PR TITLE
feat: --param-schedule CLI flag, CLI parser tests, doc cleanup (closes #28)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,30 @@ jobs:
           ./.lake/build/bin/fib_benchmark_example list
           ./.lake/build/bin/fib_benchmark_example verify
 
+      # Live CLI override smoke test: `run` with declaration-time
+      # override flags must execute, honour the passed
+      # --param-ceiling, and exit cleanly. This is a real
+      # cross-platform check that the override-flag pipeline works
+      # end-to-end after a compile (the lean-side test exercises the
+      # parser; this one exercises the spawned binary). The second
+      # invocation pins `--param-schedule doubling` so the new flag
+      # is exercised end-to-end on every CI run, not just the
+      # parser-level test.
+      - name: fib example run with CLI overrides
+        shell: bash
+        run: |
+          ./.lake/build/bin/fib_benchmark_example run \
+            LeanBench.Examples.Fib.goodFib \
+            --max-seconds-per-call 0.5 \
+            --param-ceiling 1024 \
+            --slope-tolerance 0.5
+          ./.lake/build/bin/fib_benchmark_example run \
+            LeanBench.Examples.Fib.goodFib \
+            --max-seconds-per-call 0.5 \
+            --param-ceiling 256 \
+            --param-schedule doubling \
+            --slope-tolerance 0.5
+
       - name: sort example list & verify
         shell: bash
         run: |

--- a/LeanBench/Cli.lean
+++ b/LeanBench/Cli.lean
@@ -27,9 +27,9 @@ runner). Subcommand layout:
 `run` and `compare` accept run-time `BenchmarkConfig` overrides via
 flags (`--max-seconds-per-call`, `--target-inner-nanos`,
 `--param-floor`, `--param-ceiling`, `--warmup-fraction`,
-`--slope-tolerance`). Each flag corresponds 1:1 with a
-`ConfigOverride` field; missing flags leave the declared config
-untouched.
+`--slope-tolerance`, `--param-schedule`). Each flag corresponds 1:1
+with a `ConfigOverride` field; missing flags leave the declared
+config untouched.
 
 CLI parsing uses `Cli` (mhuisi/lean4-cli).
 -/
@@ -53,6 +53,22 @@ instance : Cli.ParseableType Float where
       | Except.ok (Lean.Json.num n) => some n.toFloat
       | _ => none
 
+/-- A `ParamSchedule` `ParseableType` for `Cli`. Recognises the three
+ladder shapes by name: `auto` (default — auto-pick from declared
+complexity), `doubling`, and `linear`. The CLI form intentionally
+doesn't expose the `linear samples` count; pin a different sample
+count at declaration time via `where { paramSchedule := .linear 32 }`.
+String comparison is case-insensitive so `--param-schedule LINEAR`
+works too. -/
+instance : Cli.ParseableType LeanBench.ParamSchedule where
+  name := "ParamSchedule"
+  parse? s :=
+    match s.toLower with
+    | "auto"     => some .auto
+    | "doubling" => some .doubling
+    | "linear"   => some .linear
+    | _          => none
+
 namespace Cli
 
 /-- Read a flag's typed value from a `Cli.Parsed` if it was passed.
@@ -73,7 +89,8 @@ def configOverrideFromParsed (p : Cli.Parsed) : ConfigOverride :=
     paramCeiling?          := parsedFlag? p "param-ceiling" Nat
     paramFloor?            := parsedFlag? p "param-floor" Nat
     verdictWarmupFraction? := parsedFlag? p "warmup-fraction" Float
-    slopeTolerance?        := parsedFlag? p "slope-tolerance" Float }
+    slopeTolerance?        := parsedFlag? p "slope-tolerance" Float
+    paramSchedule?         := parsedFlag? p "param-schedule" LeanBench.ParamSchedule }
 
 /-- Build a `FixedConfigOverride` from override flags. Only fields
 that share a flag namespace with parametric (`max-seconds-per-call`)
@@ -207,6 +224,7 @@ Each missing flag leaves the declared value untouched."
     "param-ceiling" : Nat;           "Parametric only: highest param the doubling ladder reaches before stopping."
     "warmup-fraction" : Float;       "Parametric only: fraction of leading ratios to drop before computing the verdict (e.g. 0.2; JSON-style numbers)."
     "slope-tolerance" : Float;       "Parametric only: verdict is `consistent` iff |β| ≤ this, where β is the log-log slope of C vs param (JSON-style numbers)."
+    "param-schedule" : LeanBench.ParamSchedule;  "Parametric only: ladder shape (auto, doubling, or linear). Default auto picks doubling for polynomial growth, linear for exponential."
     "repeats" : Nat;                 "Fixed only: number of measured invocations after the warmup call (default 5)."
 
   ARGS:
@@ -240,6 +258,7 @@ to every benchmark in the comparison."
     "param-ceiling" : Nat;           "Parametric only: highest param the doubling ladder reaches before stopping."
     "warmup-fraction" : Float;       "Parametric only: fraction of leading ratios to drop before computing the verdict (e.g. 0.2; JSON-style numbers)."
     "slope-tolerance" : Float;       "Parametric only: verdict is `consistent` iff |β| ≤ this, where β is the log-log slope of C vs param (JSON-style numbers)."
+    "param-schedule" : LeanBench.ParamSchedule;  "Parametric only: ladder shape (auto, doubling, or linear). Default auto picks doubling for polynomial growth, linear for exponential."
     "repeats" : Nat;                 "Fixed only: number of measured invocations after the warmup call (default 5)."
 
   ARGS:

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -153,8 +153,10 @@ Built by the CLI from flags such as `--max-seconds-per-call 0.5
 --param-ceiling 1024 --warmup-fraction 0.3`. Kept as a separate type
 so the macro-time defaults stay independent of CLI plumbing and so
 adding a new override knob is a one-field change. The set of fields
-here is intentionally narrower than `BenchmarkConfig` — schedule and
-noise-floor knobs stay declaration-time-only via `where { ... }`. -/
+here is intentionally narrower than `BenchmarkConfig` — the
+noise-floor knob stays declaration-time-only via `where { ... }`
+because its sensible value depends on hardware specifics rather than
+per-run intent. -/
 structure ConfigOverride where
   targetInnerNanos?      : Option Nat   := none
   maxSecondsPerCall?     : Option Float := none
@@ -163,14 +165,40 @@ structure ConfigOverride where
   verdictWarmupFraction? : Option Float := none
   slopeTolerance?        : Option Float := none
   killGraceMs?           : Option Nat   := none
+  /-- Override the ladder shape. CLI exposes this as
+      `--param-schedule auto|doubling|linear`. The `.linear` form
+      has a `samples` count that the CLI cannot express, so
+      `ConfigOverride.apply` carries the declared sample count
+      forward when both the declared and CLI shapes are `.linear`
+      — pin a non-default count via
+      `where { paramSchedule := .linear 32 }` and the CLI flag
+      becomes a no-op (the shape is already linear). When the CLI
+      switches the shape (e.g. declared `.doubling`, CLI `.linear`),
+      the macro-default sample count is used. -/
+  paramSchedule?         : Option ParamSchedule := none
   deriving Inhabited, Repr
+
+/-- Merge a CLI `paramSchedule` override on top of a declared
+schedule. `--param-schedule linear` only carries the schedule kind
+(no CLI surface for the `samples` count); when the declared config
+is already `.linear n`, preserve `n` rather than clobbering it with
+the parser's macro-default 16. Switching shape (e.g. declared
+`.doubling`, CLI `.linear`) lands on the macro default since the
+declared config has no `samples` to carry. -/
+private def mergeParamSchedule
+    (cli : Option ParamSchedule) (declared : ParamSchedule) :
+    ParamSchedule :=
+  match cli, declared with
+  | none, _ => declared
+  | some (.linear _), .linear n => .linear n
+  | some s, _ => s
 
 /-- Apply overrides on top of a config. `none` keeps the config value. -/
 def ConfigOverride.apply (o : ConfigOverride) (c : BenchmarkConfig) :
     BenchmarkConfig :=
   -- `{ c with ... }` so fields not present in `ConfigOverride`
-  -- (`narrowRangeNoiseFloor`, `paramSchedule`) are preserved from the
-  -- declared config rather than reset to structure defaults.
+  -- (`narrowRangeNoiseFloor`) are preserved from the declared
+  -- config rather than reset to structure defaults.
   { c with
     targetInnerNanos      := o.targetInnerNanos?.getD      c.targetInnerNanos
     maxSecondsPerCall     := o.maxSecondsPerCall?.getD     c.maxSecondsPerCall
@@ -178,7 +206,8 @@ def ConfigOverride.apply (o : ConfigOverride) (c : BenchmarkConfig) :
     paramFloor            := o.paramFloor?.getD            c.paramFloor
     verdictWarmupFraction := o.verdictWarmupFraction?.getD c.verdictWarmupFraction
     slopeTolerance        := o.slopeTolerance?.getD        c.slopeTolerance
-    killGraceMs           := o.killGraceMs?.getD           c.killGraceMs }
+    killGraceMs           := o.killGraceMs?.getD           c.killGraceMs
+    paramSchedule         := mergeParamSchedule o.paramSchedule? c.paramSchedule }
 
 /-- Validate a `BenchmarkConfig`. The macro accepts arbitrary user
 expressions and the CLI accepts arbitrary JSON-style numbers, so

--- a/doc/design.md
+++ b/doc/design.md
@@ -144,9 +144,37 @@ branching leaking through the design.
   `targetInnerNanos := 500ms` × auto-tuned inner-repeats is enough
   signal-to-noise for the orders of magnitude we care about.
 
-- **Where-clause overrides on `setup_benchmark`.** v0.1 uses default
-  `BenchmarkConfig` for every benchmark. `where { maxSecondsPerCall
-  := 10 }` etc. is on the v0.2 list.
+## Per-benchmark configuration: `where { ... }` and CLI overrides
+
+A `BenchmarkConfig` can be tightened in two layered places:
+
+- Declaration time, via the `where { ... }` clause on
+  `setup_benchmark`. The macro elaborates the term against
+  `BenchmarkConfig` and emits an auto-generated `_leanBench_config`
+  def whose contents the runtime registry caches alongside the
+  benchmark's runner.
+- Run time, via `--max-seconds-per-call`, `--target-inner-nanos`,
+  `--param-floor`, `--param-ceiling`, `--warmup-fraction`,
+  `--slope-tolerance`, and `--param-schedule` on `run` / `compare`.
+  The CLI builds a `ConfigOverride` (each field optional) and
+  `ConfigOverride.apply` merges it on top of the declared config:
+  `none` keeps the declared value, `some` replaces it.
+
+The split is deliberate. Declaration-time defaults express what is
+true forever about a benchmark (`runInsertion` is O(n²); cap at half
+a second so the ladder doesn't pin the CPU). CLI flags express what
+is true for one run (CI tightens `--max-seconds-per-call 0.25`;
+local debugging widens `--param-ceiling`). Both feed the same
+`BenchmarkConfig`, validated by `BenchmarkConfig.validate` before
+the first child spawns.
+
+The `ConfigOverride` field set is intentionally narrower than
+`BenchmarkConfig`. `narrowRangeNoiseFloor` stays declaration-time
+only because its sensible value depends on hardware specifics, not
+per-run intent; `killGraceMs` is a SIGTERM-vs-SIGKILL implementation
+detail rather than a benchmark-shape knob. Adding a new override is a
+one-field change in `ConfigOverride` plus one `parsedFlag?` line in
+`LeanBench.Cli`.
 
 ## Failure modes and synthesized rows
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -147,14 +147,27 @@ $ lake exe bench compare goodFib badFib --warmup-fraction 0.3 --slope-tolerance 
 
 Available flags:
 
-| Flag                     | Type   | `BenchmarkConfig` field   |
-|--------------------------|--------|---------------------------|
-| `--max-seconds-per-call` | Float  | `maxSecondsPerCall`       |
-| `--target-inner-nanos`   | Nat    | `targetInnerNanos`        |
-| `--param-floor`          | Nat    | `paramFloor`              |
-| `--param-ceiling`        | Nat    | `paramCeiling`            |
-| `--warmup-fraction`      | Float  | `verdictWarmupFraction`   |
-| `--slope-tolerance`      | Float  | `slopeTolerance`          |
+| Flag                     | Type           | `BenchmarkConfig` field   |
+|--------------------------|----------------|---------------------------|
+| `--max-seconds-per-call` | Float          | `maxSecondsPerCall`       |
+| `--target-inner-nanos`   | Nat            | `targetInnerNanos`        |
+| `--param-floor`          | Nat            | `paramFloor`              |
+| `--param-ceiling`        | Nat            | `paramCeiling`            |
+| `--warmup-fraction`      | Float          | `verdictWarmupFraction`   |
+| `--slope-tolerance`      | Float          | `slopeTolerance`          |
+| `--param-schedule`       | ParamSchedule  | `paramSchedule`           |
+
+`--param-schedule` accepts `auto` (default — pick from declared
+complexity), `doubling`, or `linear`. Use `--param-schedule linear`
+to force the linear ladder on a benchmark whose declared model
+fooled the auto-detect heuristic, or `--param-schedule doubling` to
+force a wider log-x sweep. Pin a non-default sample count for
+`linear` at declaration time via
+`where { paramSchedule := .linear 32 }`. There is no CLI flag for
+the sample count: `--param-schedule linear` on a benchmark already
+declared with `.linear 32` keeps the declared `32`, since the flag
+only carries the schedule kind. Switching from `.auto` / `.doubling`
+to `.linear` via the CLI uses the macro-default 16 samples.
 
 `--warmup-fraction F` drops the leading `F` × ratios.size data points
 from the verdict reduction (the cold regime where per-call overhead

--- a/test/LeanBenchTestConfig.lean
+++ b/test/LeanBenchTestConfig.lean
@@ -1,9 +1,9 @@
 import LeanBench
 
 /-!
-# Tests for issue #5 — config ergonomics
+# Tests for issue #5 / #28 — config ergonomics
 
-Two layers of config plumbing live in this PR:
+Three layers of config plumbing are exercised here:
 
 1. `setup_benchmark … where { … }` — declaration-time overrides on
    `BenchmarkConfig`. Verified by registering benchmarks with various
@@ -12,8 +12,14 @@ Two layers of config plumbing live in this PR:
    `--max-seconds-per-call` etc., applied on top of the declared config.
    Verified by elaboration-time `example` blocks (so failures stop the
    build).
+3. CLI argv parsing — drive the `run` subcommand's parser with a
+   handcrafted argv list and verify `configOverrideFromParsed`
+   recovers each override flag with the right type. This is the
+   "tests cover CLI behavior" leg of the issue #28 acceptance
+   criteria; the previous test suite only covered parsing-free
+   `ConfigOverride.apply` semantics.
 
-Both are unit-testable without spawning a subprocess.
+Everything is unit-testable without spawning a subprocess.
 -/
 
 open LeanBench
@@ -106,6 +112,228 @@ private def expectEq {α} [BEq α] [Repr α] (label : String) (got want : α) :
     throw <| .userError
       s!"{label}: expected {repr want}, got {repr got}"
 
+/-! ## End-to-end CLI argv parsing — drive the actual `Cli` command tree.
+
+`Cli.Cmd.process` returns `(matched-Cmd × Parsed)` without dispatching
+the runner, so we can hand it a `run NAME --flag value …` argv,
+extract the `Parsed`, and assert `configOverrideFromParsed` recovers
+each field with the right type. This is a real test of the
+parser-to-`ConfigOverride` pipeline rather than a hand-built
+`ConfigOverride` literal. -/
+
+/-- Drive `topCmd.process` with a concrete argv list and either
+return the `Parsed` from the matched subcommand or fail the test
+with a descriptive error. -/
+private def parseRunArgs (argv : List String) : IO Cli.Parsed := do
+  match LeanBench.Cli.topCmd.process argv with
+  | .ok (_, parsed) => return parsed
+  | .error (_, msg) =>
+    throw <| .userError s!"unexpected parse failure for argv {argv}: {msg}"
+
+/-- Every parametric override flag round-trips through the CLI parser
+into `ConfigOverride` with the right type. The `repeats` flag is
+fixed-only and ignored on the parametric side; we still assert that
+mixing parametric and fixed flags doesn't fail the parser, since
+`run` accepts both. -/
+def testCliParsesAllOverrides : IO UInt32 := do
+  let argv := [
+    "run", "trivialDefault",
+    "--max-seconds-per-call", "0.5",
+    "--target-inner-nanos", "250000000",
+    "--param-floor", "8",
+    "--param-ceiling", "1024",
+    "--warmup-fraction", "0.3",
+    "--slope-tolerance", "0.05",
+    "--param-schedule", "linear" ]
+  let parsed ← parseRunArgs argv
+  let ovr := LeanBench.Cli.configOverrideFromParsed parsed
+  expectEq "cli.maxSecondsPerCall"     ovr.maxSecondsPerCall?     (some 0.5)
+  expectEq "cli.targetInnerNanos"      ovr.targetInnerNanos?      (some 250_000_000)
+  expectEq "cli.paramFloor"            ovr.paramFloor?            (some 8)
+  expectEq "cli.paramCeiling"          ovr.paramCeiling?          (some 1024)
+  expectEq "cli.verdictWarmupFraction" ovr.verdictWarmupFraction? (some 0.3)
+  expectEq "cli.slopeTolerance"        ovr.slopeTolerance?        (some 0.05)
+  expectEq "cli.paramSchedule"         ovr.paramSchedule?         (some .linear)
+  return 0
+
+/-- Missing flags leave the corresponding `ConfigOverride` fields
+`none`, so the declared config bubbles through `apply`. -/
+def testCliMissingFlagsAreNone : IO UInt32 := do
+  let parsed ← parseRunArgs ["run", "trivialDefault"]
+  let ovr := LeanBench.Cli.configOverrideFromParsed parsed
+  -- Every override field must default to `none` when no flag was passed.
+  expectEq "missing.maxSecondsPerCall"     ovr.maxSecondsPerCall?     (none : Option Float)
+  expectEq "missing.targetInnerNanos"      ovr.targetInnerNanos?      (none : Option Nat)
+  expectEq "missing.paramCeiling"          ovr.paramCeiling?          (none : Option Nat)
+  expectEq "missing.paramFloor"            ovr.paramFloor?            (none : Option Nat)
+  expectEq "missing.verdictWarmupFraction" ovr.verdictWarmupFraction? (none : Option Float)
+  expectEq "missing.slopeTolerance"        ovr.slopeTolerance?        (none : Option Float)
+  expectEq "missing.paramSchedule"         ovr.paramSchedule?         (none : Option ParamSchedule)
+  -- And the resulting config equals the declared config exactly.
+  let declared : BenchmarkConfig :=
+    { maxSecondsPerCall := 0.25, paramCeiling := 256
+      verdictWarmupFraction := 0.4, slopeTolerance := 0.3 }
+  expectEq "applied config equals declared on empty CLI"
+    (ovr.apply declared) declared
+  return 0
+
+/-- The fixed-only `--repeats` flag is recognised on `run` and feeds
+`fixedConfigOverrideFromParsed`. The parametric override builder
+ignores it, the fixed one picks it up — both assertions matter. -/
+def testCliRepeatsIsFixedOnly : IO UInt32 := do
+  let parsed ← parseRunArgs
+    ["run", "trivialDefault", "--repeats", "7", "--max-seconds-per-call", "1.5"]
+  let pOvr := LeanBench.Cli.configOverrideFromParsed parsed
+  let fOvr := LeanBench.Cli.fixedConfigOverrideFromParsed parsed
+  expectEq "fixed.repeats"           fOvr.repeats?           (some 7)
+  expectEq "fixed.maxSecondsPerCall" fOvr.maxSecondsPerCall? (some 1.5)
+  -- The shared flag also lands on the parametric override.
+  expectEq "shared.maxSecondsPerCall" pOvr.maxSecondsPerCall? (some 1.5)
+  return 0
+
+/-- `--param-schedule auto|doubling|linear` parses every documented
+spelling. Case-insensitivity is part of the contract; the matching
+`Cli.ParseableType` instance lowercases before comparing. -/
+def testCliParamScheduleSpellings : IO UInt32 := do
+  let cases : List (String × ParamSchedule) :=
+    [("auto", .auto), ("doubling", .doubling), ("linear", .linear),
+     ("AUTO", .auto), ("Linear", .linear)]
+  for (s, expected) in cases do
+    let parsed ← parseRunArgs ["run", "trivialDefault", "--param-schedule", s]
+    let ovr := LeanBench.Cli.configOverrideFromParsed parsed
+    unless ovr.paramSchedule? == some expected do
+      throw <| .userError
+        s!"--param-schedule {s}: expected {repr (some expected)}, got {repr ovr.paramSchedule?}"
+  -- An unknown spelling must be rejected by the parser, not silently
+  -- dropped to `none` (which would make typos look like "use the
+  -- declared default"). A failure here means the `parse?` instance
+  -- accepted garbage.
+  match LeanBench.Cli.topCmd.process
+      ["run", "trivialDefault", "--param-schedule", "bogus"] with
+  | .ok _ =>
+    throw <| .userError "expected --param-schedule bogus to be rejected"
+  | .error _ => return 0
+
+/-- The full pipeline: a parsed CLI override layered on top of a
+declared `where { … }` config produces the expected merged config.
+Pins that `paramSchedule` propagates from CLI as well as from the
+declared `where` clause, and that an unrecognised long flag is
+rejected by the parser (no silent typo fallthrough). -/
+def testCliLayersOnDeclaredConfig : IO UInt32 := do
+  -- Typo rejection: an unknown long flag must fail parsing rather
+  -- than be silently dropped, otherwise `--paramceiling 512` would
+  -- look like "use the declared default" and confuse the user.
+  match LeanBench.Cli.topCmd.process
+      ["run", "trivialDefault", "--paramceiling-not-real", "512"] with
+  | .ok _ =>
+    throw <| .userError "expected unknown flag to be rejected by parser"
+  | .error _ => pure ()
+  -- Real merge: CLI override layers on top of the declared
+  -- `where { ... }` config. Untouched declared fields survive.
+  let parsed ← parseRunArgs
+    ["run", "trivialOverridden",
+     "--param-ceiling", "32",
+     "--param-schedule", "doubling"]
+  let ovr := LeanBench.Cli.configOverrideFromParsed parsed
+  let declared ← fetchConfig "trivialOverridden"
+  let merged := ovr.apply declared
+  -- CLI overrides win where they were passed.
+  expectEq "merged.paramCeiling" merged.paramCeiling 32
+  expectEq "merged.paramSchedule" merged.paramSchedule .doubling
+  -- Untouched declared fields survive.
+  expectEq "merged.maxSecondsPerCall" merged.maxSecondsPerCall 0.25
+  expectEq "merged.verdictWarmupFraction" merged.verdictWarmupFraction 0.4
+  expectEq "merged.slopeTolerance" merged.slopeTolerance 0.3
+  return 0
+
+/-- The `compare` subcommand carries its own flag table — adding
+`--param-schedule` to `run` only is a footgun, so this test
+parses the same argv against `compare` and expects an identical
+override. A regression here would be a copy-paste miss between the
+two `[Cli|]` blocks in `LeanBench.Cli`. -/
+def testCliCompareAcceptsAllOverrides : IO UInt32 := do
+  -- Pass two benchmark names so `compare` accepts the variadic
+  -- positional args; the override flag set must round-trip the same
+  -- way as `run`.
+  let argv := [
+    "compare", "trivialDefault", "trivialOverridden",
+    "--max-seconds-per-call", "0.5",
+    "--target-inner-nanos", "250000000",
+    "--param-floor", "8",
+    "--param-ceiling", "1024",
+    "--warmup-fraction", "0.3",
+    "--slope-tolerance", "0.05",
+    "--param-schedule", "doubling" ]
+  let parsed ← parseRunArgs argv
+  let ovr := LeanBench.Cli.configOverrideFromParsed parsed
+  expectEq "compare.maxSecondsPerCall"     ovr.maxSecondsPerCall?     (some 0.5)
+  expectEq "compare.targetInnerNanos"      ovr.targetInnerNanos?      (some 250_000_000)
+  expectEq "compare.paramFloor"            ovr.paramFloor?            (some 8)
+  expectEq "compare.paramCeiling"          ovr.paramCeiling?          (some 1024)
+  expectEq "compare.verdictWarmupFraction" ovr.verdictWarmupFraction? (some 0.3)
+  expectEq "compare.slopeTolerance"        ovr.slopeTolerance?        (some 0.05)
+  expectEq "compare.paramSchedule"         ovr.paramSchedule?         (some .doubling)
+  -- And bogus values get rejected on `compare` too.
+  match LeanBench.Cli.topCmd.process
+      ["compare", "trivialDefault", "trivialOverridden",
+       "--param-schedule", "bogus"] with
+  | .ok _ =>
+    throw <| .userError "expected `compare --param-schedule bogus` to be rejected"
+  | .error _ => return 0
+
+/-- `mergeParamSchedule` semantics:
+    - CLI `.linear _` on a declared `.linear n` carries `n` forward
+      (the CLI flag has no surface for the sample count, so it
+      acts as a no-op when the shape is already linear).
+    - CLI shape switch (e.g. declared `.doubling`, CLI `.linear`)
+      lands on the macro-default sample count (16).
+    - CLI `.doubling` / `.auto` overwrites declared as expected.
+    - No CLI override (`none`) preserves declared exactly. -/
+def testParamScheduleMerge : IO UInt32 := do
+  let baseLinear32 : BenchmarkConfig := { paramSchedule := .linear 32 }
+  let baseDoubling : BenchmarkConfig := { paramSchedule := .doubling }
+  let cliLinear : ConfigOverride := { paramSchedule? := some .linear }
+  let cliDoubling : ConfigOverride := { paramSchedule? := some .doubling }
+  let cliAuto : ConfigOverride := { paramSchedule? := some .auto }
+  let empty : ConfigOverride := {}
+  -- `--param-schedule linear` on declared `.linear 32` keeps `32`.
+  expectEq "merge.linearOnLinear32"
+    (cliLinear.apply baseLinear32).paramSchedule (.linear 32)
+  -- `--param-schedule linear` on declared `.doubling` lands on default samples.
+  expectEq "merge.linearOnDoubling"
+    (cliLinear.apply baseDoubling).paramSchedule (.linear)
+  -- `--param-schedule doubling` overwrites declared `.linear 32`.
+  expectEq "merge.doublingOnLinear32"
+    (cliDoubling.apply baseLinear32).paramSchedule .doubling
+  -- `--param-schedule auto` overwrites declared.
+  expectEq "merge.autoOnLinear32"
+    (cliAuto.apply baseLinear32).paramSchedule .auto
+  -- Empty CLI override preserves declared exactly.
+  expectEq "merge.emptyKeepsLinear32"
+    (empty.apply baseLinear32).paramSchedule (.linear 32)
+  expectEq "merge.emptyKeepsDoubling"
+    (empty.apply baseDoubling).paramSchedule .doubling
+  return 0
+
+/-- Drive every CLI test fail-fast. Returns the first non-zero exit
+code; on success, a single confirmation line. -/
+private def runCliTests : IO UInt32 := do
+  for (label, t) in
+    [("cli.parsesAllOverrides", testCliParsesAllOverrides),
+     ("cli.compareAcceptsAllOverrides", testCliCompareAcceptsAllOverrides),
+     ("cli.missingFlagsAreNone", testCliMissingFlagsAreNone),
+     ("cli.repeatsIsFixedOnly", testCliRepeatsIsFixedOnly),
+     ("cli.paramScheduleSpellings", testCliParamScheduleSpellings),
+     ("cli.layersOnDeclaredConfig", testCliLayersOnDeclaredConfig),
+     ("cli.paramScheduleMerge", testParamScheduleMerge)]
+  do
+    let code ← t
+    if code != 0 then
+      IO.eprintln s!"FAIL: {label}"
+      return code
+    IO.println s!"  ok  {label}"
+  return 0
+
 def main : IO UInt32 := do
   -- `trivialOverridden` carries every override we set.
   let c ← fetchConfig "trivialOverridden"
@@ -140,5 +368,8 @@ def main : IO UInt32 := do
     let msg := e.toString
     unless msg.endsWith "paramFloor must be ≤ paramCeiling; got 100 > 10" do
       throw <| .userError s!"unexpected error message: {msg}"
+  -- CLI argv parsing tests.
+  let cliCode ← runCliTests
+  if cliCode != 0 then return cliCode
   IO.println "config tests OK"
   return 0


### PR DESCRIPTION
## Summary

- Add `--param-schedule auto|doubling|linear` flag to `run` / `compare` (the only un-shipped item from the issue's *Initial override targets* list). The flag carries the schedule kind only; `ConfigOverride.apply` preserves a declared `.linear n` sample count when the CLI passes `linear`, since the flag has no surface for that count. Switching shape (e.g. `.doubling` → `.linear` from CLI) lands on the macro-default 16 samples.
- Add end-to-end CLI parser tests that drive `LeanBench.Cli.topCmd.process` with handcrafted argv lists and assert each override flag round-trips into a `ConfigOverride` with the right type. Covers `run` and `compare`, missing-flags default to `none`, `--repeats` parametric/fixed split, case-insensitive `--param-schedule` spellings, unknown-flag rejection, and the new `mergeParamSchedule` carry-over rule.
- Replace the stale "where-clause overrides intentionally NOT in v0.1" bullet in `doc/design.md` with a "Per-benchmark configuration: `where { ... }` and CLI overrides" section that documents the shipped two-layer pipeline. Update the quickstart flag table with `--param-schedule` and the carry-over semantics.
- Add a CI smoke step that runs the example binary with override flags including `--param-schedule doubling`, so the override-flag pipeline is exercised cross-platform on every CI run alongside the parser-level tests.

The `where { ... }` syntax and the rest of the CLI flags themselves were already shipped via #19; this PR only finishes the ergonomic coverage that issue #28 explicitly called out as missing (param-schedule flag, doc cleanup, CLI behavior tests).

## Test plan

- [x] `lake build` is green
- [x] `config_benchmark_test` passes (now includes 7 CLI tests)
- [x] All other existing test exes pass (`roundtrip`, `verify`, `kill_path`, `fixed`)
- [x] `fib_benchmark_example list / verify / run --param-schedule doubling` succeed
- [ ] CI matrix (Linux / macOS / Windows) goes green on the new smoke step

🤖 Prepared with Claude Code