### PR TITLE
test: end-to-end + failure-mode coverage (issue #2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,22 @@ jobs:
         shell: bash
         run: ./.lake/build/bin/fixed_benchmark_test
 
+      - name: child-outcome classifier test (parent failure-mode units)
+        shell: bash
+        run: ./.lake/build/bin/child_outcome_benchmark_test
+
+      - name: format regression test (pinned report layout)
+        shell: bash
+        run: ./.lake/build/bin/format_benchmark_test
+
+      - name: cli-errors test (parser + dispatch error paths)
+        shell: bash
+        run: ./.lake/build/bin/cli_errors_benchmark_test
+
+      - name: end-to-end run/compare test
+        shell: bash
+        run: ./.lake/build/bin/e2e_benchmark_test
+
       # End-to-end smoke tests: `list` exercises the registry +
       # `initialize` blocks; `verify` spawns each registered benchmark's
       # child path against `f 0` / `f 1` and is bounded by the spec's

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -93,6 +93,33 @@ def synthRow (param : Nat) (status : Status) : DataPoint :=
   { param, innerRepeats := 0, totalNanos := 0, perCallNanos := 0.0
   , resultHash := none, status, partOfVerdict := true }
 
+/-- Pure classifier for the post-spawn outcome of a child run. Folds
+    `(exit, stdout, stderr, wasKilled)` into a `DataPoint` using exactly
+    the same rules `runOneBatch` applies inline. Extracted so the failure
+    branches (empty stdout, malformed JSONL, non-zero exit, killed-at-cap)
+    are unit-testable without spawning a real subprocess.
+
+    The `stderrText` argument is appended to synthesized error messages so
+    the user sees whatever the child wrote before dying. Pass `""` when
+    there's nothing to attach. -/
+def classifyChildOutcome
+    (param : Nat) (exit : UInt32) (stdout stderrText : String)
+    (wasKilled : Bool) : DataPoint :=
+  let withStderr (msg : String) : String :=
+    if stderrText.isEmpty then msg else s!"{msg}; stderr: {stderrText}"
+  if wasKilled then
+    synthRow param .killedAtCap
+  else match exit with
+    | 0 =>
+      let line := stdout.trimAscii.toString
+      if line.isEmpty then
+        synthRow param (.error (withStderr "child exited 0 but produced no output"))
+      else match parseChildRow line with
+        | .ok row => row
+        | .error e => synthRow param (.error (withStderr s!"parse: {e}"))
+    | other =>
+      synthRow param (.error (withStderr s!"child exited with code {other}"))
+
 /-- Spawn one child invocation and return the resulting DataPoint. -/
 def runOneBatch (spec : BenchmarkSpec) (param : Nat) : IO DataPoint := do
   let exe ← ownExe
@@ -166,24 +193,12 @@ def runOneBatch (spec : BenchmarkSpec) (param : Nat) : IO DataPoint := do
     match stderrTask.get with
     | .ok s => s.trimAscii.toString
     | .error _ => ""
-  let withStderr (msg : String) : String :=
-    if stderrText.isEmpty then msg else s!"{msg}; stderr: {stderrText}"
   -- The killer writes `killedRef := true` *before* it calls `Child.kill`,
   -- so by the time `child.wait` has returned (which can only happen
   -- after the kill takes effect, in the kill case) the flag is already
   -- committed. Hence we don't have to synchronize with the killer task.
   let wasKilled ← killedRef.get
-  if wasKilled then
-    return synthRow param .killedAtCap
-  match exit with
-  | 0 =>
-    let line := stdout.trimAscii.toString
-    if line.isEmpty then
-      return synthRow param (.error (withStderr "child exited 0 but produced no output"))
-    match parseChildRow line with
-    | .ok row => return row
-    | .error e => return synthRow param (.error (withStderr s!"parse: {e}"))
-  | other => return synthRow param (.error (withStderr s!"child exited with code {other}"))
+  return classifyChildOutcome param exit stdout stderrText wasKilled
 
 /-- Doubling ladder from floor through ceiling. -/
 def paramLadder (cfg : BenchmarkConfig) : Array Nat := Id.run do
@@ -384,6 +399,29 @@ def parseFixedChildRow (line : String) : Except String FixedDataPoint := do
 private def synthFixedRow (idx : Nat) (status : Status) : FixedDataPoint :=
   { repeatIndex := idx, totalNanos := 0, resultHash := none, status }
 
+/-- Pure classifier for the post-spawn outcome of a fixed-benchmark
+    child run. Mirrors `classifyChildOutcome` for the parametric path. -/
+def classifyFixedChildOutcome
+    (repeatIndex : Nat) (exit : UInt32) (stdout stderrText : String)
+    (wasKilled : Bool) : FixedDataPoint :=
+  let withStderr (msg : String) : String :=
+    if stderrText.isEmpty then msg else s!"{msg}; stderr: {stderrText}"
+  if wasKilled then
+    synthFixedRow repeatIndex .killedAtCap
+  else match exit with
+    | 0 =>
+      let line := stdout.trimAscii.toString
+      if line.isEmpty then
+        synthFixedRow repeatIndex
+          (.error (withStderr "child exited 0 but produced no output"))
+      else match parseFixedChildRow line with
+        | .ok row => row
+        | .error e =>
+          synthFixedRow repeatIndex (.error (withStderr s!"parse: {e}"))
+    | other =>
+      synthFixedRow repeatIndex
+        (.error (withStderr s!"child exited with code {other}"))
+
 /-- Spawn one fixed-benchmark child. `repeatIndex` is the 0-based
     index reported back in the JSONL row; `cfg` carries the kill
     cap. Same kill-on-cap machinery as `runOneBatch`. -/
@@ -436,24 +474,8 @@ def runFixedOneBatch (spec : FixedSpec) (cfg : FixedBenchmarkConfig)
     match stderrTask.get with
     | .ok s => s.trimAscii.toString
     | .error _ => ""
-  let withStderr (msg : String) : String :=
-    if stderrText.isEmpty then msg else s!"{msg}; stderr: {stderrText}"
   let wasKilled ← killedRef.get
-  if wasKilled then
-    return synthFixedRow repeatIndex .killedAtCap
-  match exit with
-  | 0 =>
-    let line := stdout.trimAscii.toString
-    if line.isEmpty then
-      return synthFixedRow repeatIndex
-        (.error (withStderr "child exited 0 but produced no output"))
-    match parseFixedChildRow line with
-    | .ok row => return row
-    | .error e =>
-      return synthFixedRow repeatIndex (.error (withStderr s!"parse: {e}"))
-  | other =>
-    return synthFixedRow repeatIndex
-      (.error (withStderr s!"child exited with code {other}"))
+  return classifyFixedChildOutcome repeatIndex exit stdout stderrText wasKilled
 
 /-- Numeric median of a sorted `Array Nat`. Returns the upper of the
     two middle elements for even sizes — i.e. the element at index

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -9,6 +9,8 @@ defaultTargets = [
   "LeanBenchTest", "roundtrip_benchmark_test", "verify_benchmark_test",
   "kill_path_benchmark_test", "config_benchmark_test",
   "fixed_benchmark_test",
+  "child_outcome_benchmark_test", "format_benchmark_test",
+  "e2e_benchmark_test", "cli_errors_benchmark_test",
 ]
 
 [[require]]
@@ -84,3 +86,23 @@ root = "LeanBenchTestConfig"
 name = "fixed_benchmark_test"
 srcDir = "test"
 root = "LeanBenchTestFixed"
+
+[[lean_exe]]
+name = "child_outcome_benchmark_test"
+srcDir = "test"
+root = "LeanBenchTestChildOutcome"
+
+[[lean_exe]]
+name = "format_benchmark_test"
+srcDir = "test"
+root = "LeanBenchTestFormat"
+
+[[lean_exe]]
+name = "e2e_benchmark_test"
+srcDir = "test"
+root = "LeanBenchTestE2E"
+
+[[lean_exe]]
+name = "cli_errors_benchmark_test"
+srcDir = "test"
+root = "LeanBenchTestCliErrors"

--- a/test/LeanBenchTestChildOutcome.lean
+++ b/test/LeanBenchTestChildOutcome.lean
@@ -1,0 +1,250 @@
+import LeanBench
+
+/-!
+# Parent-side child-outcome classification (issue #2)
+
+`runOneBatch` and `runFixedOneBatch` both fold the post-spawn quartet
+`(exit, stdout, stderr, wasKilled)` into a `DataPoint` /
+`FixedDataPoint` via the pure `classifyChildOutcome` /
+`classifyFixedChildOutcome` helpers. This test pins the failure-mode
+contract directly against those classifiers, so the failure branches
+are covered without paying the wallclock cost of spawning hundreds of
+real subprocesses.
+
+Failure modes pinned here (parametric and fixed):
+
+- exit 0 with empty stdout
+- exit 0 with malformed (non-JSON) stdout
+- exit 0 with JSON missing required fields
+- exit 0 with valid JSONL → row passes through unchanged
+- non-zero exit with no stderr
+- non-zero exit with stderr (stderr is appended to the error message)
+- killed-at-cap (overrides exit code)
+
+The `parseChildRow` parser is also exercised directly on the same
+malformed inputs, so a regression in either layer surfaces here.
+-/
+
+open LeanBench
+
+/-- Substring containment helper. `String.contains` is `Char`-only. -/
+private def containsSub (haystack needle : String) : Bool :=
+  ((haystack.splitOn needle).length) > 1
+
+/-- A canonical `ok` JSONL row exactly like `Child.emitRow` produces. -/
+private def okJsonlRow : String :=
+  "{\"schema_version\":1,\"function\":\"foo.bar\",\"param\":42," ++
+  "\"inner_repeats\":1024,\"total_nanos\":3000000," ++
+  "\"per_call_nanos\":2929.6875,\"result_hash\":\"0xdeadbeef\"," ++
+  "\"status\":\"ok\",\"error\":null}"
+
+/-- A canonical fixed `ok` JSONL row. -/
+private def okFixedJsonlRow : String :=
+  "{\"schema_version\":1,\"kind\":\"fixed\",\"function\":\"foo.bar\"," ++
+  "\"repeat_index\":2,\"total_nanos\":1234567,\"result_hash\":\"0xcafebabe\"," ++
+  "\"status\":\"ok\",\"error\":null}"
+
+private def expect (label : String) (cond : Bool) : IO UInt32 := do
+  if cond then return 0
+  else
+    IO.eprintln s!"FAIL: {label}"
+    return 1
+
+/-! ## `parseChildRow` direct unit coverage -/
+
+def testParseRejectsEmpty : IO UInt32 := do
+  match parseChildRow "" with
+  | .ok dp =>
+    IO.eprintln s!"expected empty input to fail to parse, got {repr dp}"
+    return 1
+  | .error _ => return 0
+
+def testParseRejectsMalformedJson : IO UInt32 := do
+  match parseChildRow "{not json" with
+  | .ok dp =>
+    IO.eprintln s!"expected non-JSON to fail to parse, got {repr dp}"
+    return 1
+  | .error _ => return 0
+
+def testParseRejectsMissingRequiredField : IO UInt32 := do
+  -- Drop `"param"` from the canonical row; everything else is
+  -- well-formed JSON.
+  let row :=
+    "{\"schema_version\":1,\"function\":\"foo.bar\"," ++
+    "\"inner_repeats\":1024,\"total_nanos\":3000000," ++
+    "\"per_call_nanos\":2929.6875,\"status\":\"ok\",\"error\":null}"
+  match parseChildRow row with
+  | .ok dp =>
+    IO.eprintln s!"expected missing-`param` to fail to parse, got {repr dp}"
+    return 1
+  | .error _ => return 0
+
+def testParseUnknownStatusBecomesError : IO UInt32 := do
+  -- Unknown status string must round-trip into `.error`, not silently
+  -- coerce to `.ok` (which would mark a broken child as healthy).
+  let row :=
+    "{\"schema_version\":1,\"function\":\"foo.bar\",\"param\":42," ++
+    "\"inner_repeats\":1024,\"total_nanos\":3000000," ++
+    "\"per_call_nanos\":2929.6875,\"result_hash\":null," ++
+    "\"status\":\"weirdo\",\"error\":null}"
+  match parseChildRow row with
+  | .error e =>
+    IO.eprintln s!"expected unknown-status to parse with `.error` payload, got parse failure: {e}"
+    return 1
+  | .ok dp =>
+    match dp.status with
+    | .error msg =>
+      if containsSub msg "weirdo" then return 0
+      else
+        IO.eprintln s!"expected error msg to mention `weirdo`, got: {msg}"
+        return 1
+    | s =>
+      IO.eprintln s!"expected `.error _`, got {repr s}"
+      return 1
+
+/-! ## `classifyChildOutcome` (parametric) -/
+
+def testClassifyKilledAtCap : IO UInt32 := do
+  -- `wasKilled = true` overrides everything else. Even if the child
+  -- somehow emitted a parseable row before being signalled, we report
+  -- killedAtCap (the timing is unsound).
+  let dp := classifyChildOutcome (param := 7) (exit := 0)
+              (stdout := okJsonlRow) (stderrText := "") (wasKilled := true)
+  expect s!"killedAtCap (got {repr dp.status})" (dp.status == .killedAtCap)
+
+def testClassifyKilledIgnoresExit : IO UInt32 := do
+  -- A non-zero exit code AND a wasKilled flag → still killedAtCap; we
+  -- don't want to confuse the user with both signals at once.
+  let dp := classifyChildOutcome 0 137 "" "" true
+  expect s!"killedAtCap on (exit=137, wasKilled=true), got {repr dp.status}"
+    (dp.status == .killedAtCap)
+
+def testClassifyOkRoundtrip : IO UInt32 := do
+  let dp := classifyChildOutcome 42 0 okJsonlRow "" false
+  expect s!"ok roundtrip: status={repr dp.status} param={dp.param} repeats={dp.innerRepeats}"
+    (dp.status == .ok ∧ dp.param == 42 ∧ dp.innerRepeats == 1024
+      ∧ dp.totalNanos == 3000000 ∧ dp.resultHash == some 0xdeadbeef)
+
+def testClassifyEmptyStdoutSynthesizesError : IO UInt32 := do
+  let dp := classifyChildOutcome 11 0 "" "" false
+  match dp.status with
+  | .error msg =>
+    expect s!"empty-stdout error mentions 'no output': {msg}"
+      (containsSub msg "no output" ∧ dp.param == 11 ∧ dp.innerRepeats == 0)
+  | s =>
+    IO.eprintln s!"expected `.error _`, got {repr s}"
+    return 1
+
+def testClassifyMalformedStdoutSynthesizesError : IO UInt32 := do
+  let dp := classifyChildOutcome 12 0 "{not json" "" false
+  match dp.status with
+  | .error msg =>
+    expect s!"parse-error message mentions 'parse:': {msg}"
+      (containsSub msg "parse:")
+  | s =>
+    IO.eprintln s!"expected `.error _`, got {repr s}"
+    return 1
+
+def testClassifyNonZeroExit : IO UInt32 := do
+  let dp := classifyChildOutcome 13 1 "" "" false
+  match dp.status with
+  | .error msg =>
+    expect s!"exit-1 message mentions code: {msg}" (containsSub msg "code 1")
+  | s =>
+    IO.eprintln s!"expected `.error _`, got {repr s}"
+    return 1
+
+def testClassifyNonZeroExitAppendsStderr : IO UInt32 := do
+  -- Non-zero exit with stderr → stderr is appended to the synthesized
+  -- error message so the user has a hope of debugging.
+  let dp := classifyChildOutcome 14 2 "" "boom: cannot allocate" false
+  match dp.status with
+  | .error msg =>
+    expect s!"stderr appended to error: {msg}"
+      (containsSub msg "code 2" ∧ containsSub msg "boom: cannot allocate"
+        ∧ containsSub msg "stderr:")
+  | s =>
+    IO.eprintln s!"expected `.error _`, got {repr s}"
+    return 1
+
+def testClassifyEmptyStderrNotAppended : IO UInt32 := do
+  -- Empty stderr must NOT produce a trailing "; stderr: " noise tag.
+  let dp := classifyChildOutcome 15 99 "" "" false
+  match dp.status with
+  | .error msg =>
+    expect s!"no stderr suffix when stderr is empty: {msg}"
+      (! containsSub msg "stderr:")
+  | s =>
+    IO.eprintln s!"expected `.error _`, got {repr s}"
+    return 1
+
+/-! ## `classifyFixedChildOutcome` (fixed) -/
+
+def testFixedClassifyKilledAtCap : IO UInt32 := do
+  let dp := classifyFixedChildOutcome 0 0 okFixedJsonlRow "" true
+  expect s!"fixed killedAtCap: {repr dp.status}" (dp.status == .killedAtCap)
+
+def testFixedClassifyOkRoundtrip : IO UInt32 := do
+  let dp := classifyFixedChildOutcome 2 0 okFixedJsonlRow "" false
+  expect s!"fixed ok roundtrip: status={repr dp.status} idx={dp.repeatIndex} nanos={dp.totalNanos} hash={dp.resultHash}"
+    (dp.status == .ok ∧ dp.repeatIndex == 2 ∧ dp.totalNanos == 1234567
+      ∧ dp.resultHash == some 0xcafebabe)
+
+def testFixedClassifyEmptyStdoutSynthesizesError : IO UInt32 := do
+  let dp := classifyFixedChildOutcome 3 0 "" "" false
+  match dp.status with
+  | .error msg =>
+    expect s!"fixed empty-stdout error: {msg}"
+      (containsSub msg "no output" ∧ dp.repeatIndex == 3)
+  | s =>
+    IO.eprintln s!"expected `.error _`, got {repr s}"
+    return 1
+
+def testFixedClassifyMalformedStdoutSynthesizesError : IO UInt32 := do
+  let dp := classifyFixedChildOutcome 4 0 "garbage" "" false
+  match dp.status with
+  | .error msg =>
+    expect s!"fixed parse-error message: {msg}" (containsSub msg "parse:")
+  | s =>
+    IO.eprintln s!"expected `.error _`, got {repr s}"
+    return 1
+
+def testFixedClassifyNonZeroExitAppendsStderr : IO UInt32 := do
+  let dp := classifyFixedChildOutcome 5 1 "" "kapow" false
+  match dp.status with
+  | .error msg =>
+    expect s!"fixed stderr appended: {msg}"
+      (containsSub msg "code 1" ∧ containsSub msg "kapow")
+  | s =>
+    IO.eprintln s!"expected `.error _`, got {repr s}"
+    return 1
+
+/-! ## Driver -/
+
+def main : IO UInt32 := do
+  for (label, t) in
+    [ ("parse.empty", testParseRejectsEmpty),
+      ("parse.malformedJson", testParseRejectsMalformedJson),
+      ("parse.missingField", testParseRejectsMissingRequiredField),
+      ("parse.unknownStatus", testParseUnknownStatusBecomesError),
+      ("classify.killedAtCap", testClassifyKilledAtCap),
+      ("classify.killedIgnoresExit", testClassifyKilledIgnoresExit),
+      ("classify.okRoundtrip", testClassifyOkRoundtrip),
+      ("classify.emptyStdout", testClassifyEmptyStdoutSynthesizesError),
+      ("classify.malformedStdout", testClassifyMalformedStdoutSynthesizesError),
+      ("classify.nonZeroExit", testClassifyNonZeroExit),
+      ("classify.nonZeroExitWithStderr", testClassifyNonZeroExitAppendsStderr),
+      ("classify.emptyStderrNoSuffix", testClassifyEmptyStderrNotAppended),
+      ("fixed.killedAtCap", testFixedClassifyKilledAtCap),
+      ("fixed.okRoundtrip", testFixedClassifyOkRoundtrip),
+      ("fixed.emptyStdout", testFixedClassifyEmptyStdoutSynthesizesError),
+      ("fixed.malformedStdout", testFixedClassifyMalformedStdoutSynthesizesError),
+      ("fixed.nonZeroExitWithStderr", testFixedClassifyNonZeroExitAppendsStderr) ]
+  do
+    let code ← t
+    if code != 0 then
+      IO.eprintln s!"FAIL: {label}"
+      return code
+    IO.println s!"  ok  {label}"
+  IO.println "child-outcome tests passed"
+  return 0

--- a/test/LeanBenchTestCliErrors.lean
+++ b/test/LeanBenchTestCliErrors.lean
@@ -1,0 +1,142 @@
+import LeanBench
+
+/-!
+# CLI argument-validation tests (issue #2)
+
+`LeanBenchTestConfig` covers the override-flag pipeline and pins typo
+rejection for one bad spelling. This file goes wider on the parser-
+and dispatch-level error paths so a regression in CLI ergonomics
+(missing positionals, unknown subcommands, default-subcommand
+dispatch, handler errors on unregistered names) breaks the build.
+
+What's pinned:
+
+- Unknown subcommand → parser rejects.
+- Missing required positional `name` on `run` → parser rejects.
+- `--param-floor` rejects negative input (`Nat` parser).
+- `--param-ceiling` rejects non-numeric input.
+- `--max-seconds-per-call` rejects non-numeric input.
+- `dispatch []` defaults to `list` and exits 0.
+- `compare` with zero names → handler exits non-zero with the
+  documented error message.
+- `run NAME` with an unregistered `NAME` → handler exits non-zero.
+
+Handler-level tests drive `Cli.dispatch` (which calls
+`topCmd.validate`); the test process inherits the eprintln that the
+handler writes, but we only assert on the exit code so the noise
+doesn't make the test brittle.
+-/
+
+open LeanBench
+
+private def containsSub (haystack needle : String) : Bool :=
+  ((haystack.splitOn needle).length) > 1
+
+/-! ## Parser-level rejection -/
+
+/-- Drive `topCmd.process` and assert it errors. The matched message
+    is checked against `expectedSub` so we don't depend on the exact
+    wording of an internal Cli error template. -/
+private def expectParserError (label : String) (argv : List String)
+    (expectedSub : String) : IO UInt32 := do
+  match LeanBench.Cli.topCmd.process argv with
+  | .ok _ =>
+    IO.eprintln s!"FAIL: {label}: expected parser to reject {argv}"
+    return 1
+  | .error (_, msg) =>
+    if containsSub msg expectedSub then
+      IO.println s!"  ok  {label}"
+      return 0
+    IO.eprintln s!"FAIL: {label}: expected msg to mention {expectedSub.quote}, got: {msg}"
+    return 1
+
+def testUnknownSubcommand : IO UInt32 :=
+  expectParserError "parser.unknownSubcommand" ["totally-not-a-command"] "totally-not-a-command"
+
+def testRunMissingName : IO UInt32 :=
+  -- `run` requires a positional `name`; with none the parser must err.
+  expectParserError "parser.runMissingName" ["run"] "name"
+
+def testNegativeNatRejected : IO UInt32 :=
+  -- `--param-floor` is typed `Nat`; the parser must reject negatives,
+  -- not silently coerce to 0 or wrap to a giant unsigned value.
+  expectParserError "parser.negativeNatRejected"
+    ["run", "anything", "--param-floor", "-5"]
+    "param-floor"
+
+def testNonNumericNatRejected : IO UInt32 :=
+  expectParserError "parser.nonNumericNatRejected"
+    ["run", "anything", "--param-ceiling", "huge"]
+    "param-ceiling"
+
+def testNonNumericFloatRejected : IO UInt32 :=
+  expectParserError "parser.nonNumericFloatRejected"
+    ["run", "anything", "--max-seconds-per-call", "soonish"]
+    "max-seconds-per-call"
+
+/-! ## Dispatch-level behaviour -/
+
+/-- `dispatch []` must not crash and must dispatch as `list`. We can't
+    capture stdout cleanly here, but the exit code distinguishes
+    "happy path" from "argument validation error". -/
+def testDispatchEmptyDefaultsToList : IO UInt32 := do
+  let code ← LeanBench.Cli.dispatch []
+  if code == 0 then
+    IO.println "  ok  dispatch.emptyDefaultsToList"
+    return 0
+  IO.eprintln s!"FAIL: dispatch.emptyDefaultsToList: expected 0, got {code}"
+  return 1
+
+/-- `compare` with zero benchmark names: the handler eprints the
+    documented message and returns 1. -/
+def testCompareNoNames : IO UInt32 := do
+  -- The handler writes "compare: need at least two benchmark names"
+  -- to stderr and returns 1. We don't capture stderr; just assert
+  -- the exit code so the test is robust to wording tweaks.
+  let code ← LeanBench.Cli.dispatch ["compare"]
+  if code == 1 then
+    IO.println "  ok  dispatch.compareNoNames"
+    return 0
+  IO.eprintln s!"FAIL: dispatch.compareNoNames: expected exit 1, got {code}"
+  return 1
+
+/-- `run` against an unregistered name: handler returns 1. -/
+def testRunUnregistered : IO UInt32 := do
+  let code ← LeanBench.Cli.dispatch ["run", "definitelyNotRegisteredXYZ"]
+  if code == 1 then
+    IO.println "  ok  dispatch.runUnregistered"
+    return 0
+  IO.eprintln s!"FAIL: dispatch.runUnregistered: expected exit 1, got {code}"
+  return 1
+
+/-- `verify` with an unregistered name: handler returns 1. The
+    underlying `verify` call throws a userError on unknown names; the
+    CLI catches it, prints, and returns 1. -/
+def testVerifyUnregistered : IO UInt32 := do
+  let code ← LeanBench.Cli.dispatch ["verify", "definitelyNotRegisteredXYZ"]
+  if code == 1 then
+    IO.println "  ok  dispatch.verifyUnregistered"
+    return 0
+  IO.eprintln s!"FAIL: dispatch.verifyUnregistered: expected exit 1, got {code}"
+  return 1
+
+/-! ## Driver -/
+
+def main : IO UInt32 := do
+  let mut anyFail : UInt32 := 0
+  for t in
+    [ testUnknownSubcommand,
+      testRunMissingName,
+      testNegativeNatRejected,
+      testNonNumericNatRejected,
+      testNonNumericFloatRejected,
+      testDispatchEmptyDefaultsToList,
+      testCompareNoNames,
+      testRunUnregistered,
+      testVerifyUnregistered ]
+  do
+    let code ← t
+    if code != 0 then anyFail := 1
+  if anyFail == 0 then
+    IO.println "cli-errors tests passed"
+  return anyFail

--- a/test/LeanBenchTestE2E.lean
+++ b/test/LeanBenchTestE2E.lean
@@ -1,0 +1,244 @@
+import LeanBench
+
+/-!
+# End-to-end run/compare test (issue #2)
+
+Drives `runBenchmark` and `compare` against a tiny registered
+benchmark, then asserts on the result structure. Each measurement
+spawns the same compiled binary as a child (`_child` first arg
+distinguishes child mode), so this also exercises the full spawn /
+read / parse / synthesize pipeline against a real subprocess.
+
+The benchmark function is deliberately tiny (a single `XOR` per
+iteration) and the config caps `paramCeiling := 8` and
+`maxSecondsPerCall := 0.25`, so the whole test runs in well under a
+second on any reasonable host.
+
+What's pinned:
+
+- `runBenchmark`: every `ok` point has a non-zero hash, the verdict
+  resolves (not stuck), and the ratios array is non-empty.
+- `compare` (parametric, two functions): both per-function results
+  are present, `commonParams` is the intersection of their measured
+  params, and `agreeOnCommon` reports `divergedAt` when the two
+  benchmarks return distinguishable hashes.
+- `compare` (parametric, two identical functions): `agreeOnCommon`
+  reports `allAgreed`.
+- Unregistered name → `runBenchmark` throws a `userError` mentioning
+  the name (so the CLI can print it cleanly).
+-/
+
+open LeanBench
+
+namespace LeanBench.Test.E2E
+
+/-- A trivially-fast `Nat → UInt64`. Each call does `n` cheap XORs. -/
+def littleFn (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 1
+  for _ in [0:n] do
+    x := x ^^^ n.toUInt64
+  return x
+
+/-- Same shape, different output: `+ 1` so the hash differs from
+    `littleFn` and the comparison divergence is observable. -/
+def littleFn' (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 1
+  for _ in [0:n] do
+    x := x ^^^ n.toUInt64
+  return x + 1
+
+/-- Same body as `littleFn` so the comparison reports `allAgreed`. -/
+def littleFnTwin (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 1
+  for _ in [0:n] do
+    x := x ^^^ n.toUInt64
+  return x
+
+/-! Each benchmark uses a tight cap and a small inner-tune target.
+With the default `targetInnerNanos := 500_000_000`, autoTune wants
+~250ms of inner work per batch — that overshoots a 0.25s cap once the
+final doubling step lands past the half-target. Lower the inner
+target so even slow CI hosts converge before the kill timer fires. -/
+setup_benchmark littleFn n => n where {
+  maxSecondsPerCall := 0.5, paramCeiling := 8, targetInnerNanos := 50_000_000
+}
+setup_benchmark littleFn' n => n where {
+  maxSecondsPerCall := 0.5, paramCeiling := 8, targetInnerNanos := 50_000_000
+}
+setup_benchmark littleFnTwin n => n where {
+  maxSecondsPerCall := 0.5, paramCeiling := 8, targetInnerNanos := 50_000_000
+}
+
+end LeanBench.Test.E2E
+
+private def littleName     : Lean.Name := `LeanBench.Test.E2E.littleFn
+private def littlePrimeName : Lean.Name := `LeanBench.Test.E2E.littleFn'
+private def littleTwinName : Lean.Name := `LeanBench.Test.E2E.littleFnTwin
+
+/-- `String.contains` is `Char`-only; this is a substring check. -/
+private def containsSub (haystack needle : String) : Bool :=
+  ((haystack.splitOn needle).length) > 1
+
+/-! ## End-to-end `runBenchmark` -/
+
+def testRunBenchmarkHappyPath : IO UInt32 := do
+  let result ← runBenchmark littleName
+  -- The benchmark is registered; we should see at least one row.
+  if result.points.isEmpty then
+    IO.eprintln "expected at least one measured point"
+    return 1
+  -- Most rows should succeed. A solitary killed-at-cap on the largest
+  -- param is tolerable on a slow host; an all-killed ladder means the
+  -- subprocess pipeline isn't returning real measurements.
+  let okCount := result.points.filter (·.status == .ok) |>.size
+  if okCount == 0 then
+    IO.eprintln s!"expected at least one ok point; all status: {repr (result.points.map (·.status))}"
+    return 1
+  -- Every `ok` row must have a hash (the function returns `UInt64`,
+  -- which is `Hashable`; hash = none would be a regression in the
+  -- `setup_benchmark` Hashable detection).
+  for dp in result.points do
+    if dp.status == .ok && dp.resultHash.isNone then
+      IO.eprintln s!"ok row missing hash: {repr dp}"
+      return 1
+  -- `ratios` must be populated by `Stats.summarize`. An empty array
+  -- here means either no `ok` points landed in the verdict band or
+  -- the ratio computation skipped them all — both are regressions
+  -- that block the verdict pipeline.
+  if result.ratios.isEmpty then
+    IO.eprintln s!"expected non-empty ratios; got points: {repr result.points}"
+    return 1
+  -- The verdict must resolve. Any `Verdict` constructor is fine; the
+  -- regression we care about is the harness silently producing an
+  -- `Inhabited` default before reaching this line.
+  match result.verdict with
+  | .consistentWithDeclaredComplexity => pure ()
+  | .inconclusive                     => pure ()
+  -- The complexity formula must round-trip from setup_benchmark's
+  -- captured-source path, not show as `<unknown>` or empty.
+  if result.complexityFormula.isEmpty then
+    IO.eprintln s!"expected non-empty complexity formula, got '{result.complexityFormula}'"
+    return 1
+  return 0
+
+def testRunBenchmarkUnregistered : IO UInt32 := do
+  let result ← (runBenchmark `definitelyNotRegistered).toBaseIO
+  match result with
+  | .ok _ =>
+    IO.eprintln "expected runBenchmark on unregistered name to throw"
+    return 1
+  | .error e =>
+    let msg := e.toString
+    if containsSub msg "unregistered" ∧ containsSub msg "definitelyNotRegistered" then
+      return 0
+    IO.eprintln s!"expected error to mention 'unregistered' and the name, got: {msg}"
+    return 1
+
+/-! ## End-to-end `compare` -/
+
+def testCompareDiverges : IO UInt32 := do
+  -- littleFn vs littleFn' return different hashes, so the
+  -- comparison must report divergence.
+  let report ← compare [littleName, littlePrimeName]
+  if report.results.size != 2 then
+    IO.eprintln s!"expected 2 results, got {report.results.size}"
+    return 1
+  -- `commonParams` is the intersection of every function's measured
+  -- params. Both benchmarks share the same ladder shape and ceiling,
+  -- so the intersection is exactly the union of params each side
+  -- actually completed — and at minimum the small end (1, 2) survives
+  -- on every host that doesn't kill the very first batch.
+  let p0 := report.results[0]!.points.map (·.param) |>.toList.toArray
+  let p1 := report.results[1]!.points.map (·.param) |>.toList.toArray
+  let expectedCommon := p0.filter (p1.contains ·)
+  unless report.commonParams == expectedCommon do
+    IO.eprintln s!"commonParams != intersection: got {report.commonParams}, expected {expectedCommon}"
+    return 1
+  if report.commonParams.isEmpty then
+    IO.eprintln "expected non-empty common params"
+    return 1
+  match report.agreeOnCommon with
+  | .divergedAt entries =>
+    if entries.isEmpty then
+      IO.eprintln "expected at least one divergence entry"
+      return 1
+    return 0
+  | s =>
+    IO.eprintln s!"expected divergence, got {repr s}"
+    return 1
+
+def testCompareAgrees : IO UInt32 := do
+  -- littleFn and littleFnTwin are byte-identical, so the comparison
+  -- must report agreement.
+  let report ← compare [littleName, littleTwinName]
+  if report.results.size != 2 then
+    IO.eprintln s!"expected 2 results, got {report.results.size}"
+    return 1
+  match report.agreeOnCommon with
+  | .allAgreed => return 0
+  | s =>
+    IO.eprintln s!"expected allAgreed, got {repr s}"
+    return 1
+
+/-! ## End-to-end `list` (via the CLI dispatch entry point) -/
+
+def testListIncludesRegistered : IO UInt32 := do
+  -- `runListCmd` walks `allRuntimeEntries`; assert our three
+  -- registrations are present so a regression in the registry
+  -- (e.g. the macro forgetting to emit `initialize`) shows up here.
+  let entries ← allRuntimeEntries
+  let names := entries.map (·.spec.name)
+  for n in [littleName, littlePrimeName, littleTwinName] do
+    unless names.contains n do
+      IO.eprintln s!"registered benchmark missing from runtime registry: {n}"
+      return 1
+  return 0
+
+/-- Drive the `list` subcommand through the actual CLI dispatch
+    pipeline against this binary's populated registry. Catches
+    regressions in `runListCmd` (the formatter, the registry walk,
+    the exit code) that the registry-only check above misses.
+
+    We redirect stdout to /dev/null on POSIX or NUL on Windows so the
+    test output stays clean — we only need the exit code to confirm
+    `list` ran the populated path without crashing. -/
+def testListCliDispatch : IO UInt32 := do
+  -- Suppress stdout so the formatted listing doesn't pollute the
+  -- test log. The exit code is what we're asserting on.
+  let nullDev := if System.Platform.isWindows then "NUL" else "/dev/null"
+  let h ← IO.FS.Handle.mk nullDev .write
+  let code ← IO.withStdout (.ofHandle h) do
+    LeanBench.Cli.dispatch ["list"]
+  if code == 0 then return 0
+  IO.eprintln s!"FAIL: list dispatch returned {code}"
+  return 1
+
+/-! ## Driver -/
+
+def runTests : IO UInt32 := do
+  let mut anyFail : UInt32 := 0
+  for (label, t) in
+    [ ("listIncludesRegistered", testListIncludesRegistered),
+      ("listCliDispatch", testListCliDispatch),
+      ("runBenchmark.happy", testRunBenchmarkHappyPath),
+      ("runBenchmark.unregistered", testRunBenchmarkUnregistered),
+      ("compare.agrees", testCompareAgrees),
+      ("compare.diverges", testCompareDiverges) ]
+  do
+    let code ← t
+    if code != 0 then
+      IO.eprintln s!"FAIL: {label}"
+      anyFail := 1
+    else
+      IO.println s!"  ok  {label}"
+  if anyFail == 0 then
+    IO.println "e2e tests passed"
+  return anyFail
+
+/-- The same compiled binary acts as parent (test driver) and child
+    (single-batch runner spawned by `runOneBatch`). The `_child`
+    first arg distinguishes them. -/
+def main (args : List String) : IO UInt32 :=
+  match args with
+  | "_child" :: _ => LeanBench.Cli.dispatch args
+  | _ => runTests

--- a/test/LeanBenchTestE2E.lean
+++ b/test/LeanBenchTestE2E.lean
@@ -11,19 +11,23 @@ read / parse / synthesize pipeline against a real subprocess.
 
 The benchmark function is deliberately tiny (a single `XOR` per
 iteration) and the config caps `paramCeiling := 8` and
-`maxSecondsPerCall := 0.25`, so the whole test runs in well under a
-second on any reasonable host.
+`maxSecondsPerCall := 0.5` with a `targetInnerNanos := 50_000_000`
+inner-tune budget, so the whole test runs in ~1.3s on a Linux host.
 
 What's pinned:
 
-- `runBenchmark`: every `ok` point has a non-zero hash, the verdict
-  resolves (not stuck), and the ratios array is non-empty.
-- `compare` (parametric, two functions): both per-function results
-  are present, `commonParams` is the intersection of their measured
-  params, and `agreeOnCommon` reports `divergedAt` when the two
-  benchmarks return distinguishable hashes.
-- `compare` (parametric, two identical functions): `agreeOnCommon`
-  reports `allAgreed`.
+- `list`: every registered benchmark appears in the runtime registry
+  AND `Cli.dispatch ["list"]` exits 0 against a populated registry.
+- `runBenchmark`: at least one `ok` point lands in the ladder, every
+  `ok` row has a `Hashable`-derived hash, `ratios` is non-empty,
+  the verdict resolves (not stuck on `Inhabited`), and the
+  complexity formula round-trips from `setup_benchmark`.
+- `compare` (two distinguishable functions): both per-function
+  results are present, `commonParams` equals the actual intersection
+  of measured params (computed independently in the test), and
+  `agreeOnCommon` reports `divergedAt`.
+- `compare` (two identical functions): `agreeOnCommon` reports
+  `allAgreed`.
 - Unregistered name → `runBenchmark` throws a `userError` mentioning
   the name (so the CLI can print it cleanly).
 -/

--- a/test/LeanBenchTestFormat.lean
+++ b/test/LeanBenchTestFormat.lean
@@ -1,0 +1,313 @@
+import LeanBench
+
+/-!
+# Formatting regression test (issue #2)
+
+Pin the human-readable output of `Format.*` against fixed inputs so
+report layout changes are intentional. The `BenchmarkResult` /
+`ComparisonReport` literals constructed below are entirely pure (no
+subprocesses), so the test is fast and deterministic across hosts.
+
+When a layout change is intentional, run this test, copy the printed
+"actual" block over the "expected" string in the test, commit, and
+mention the format change in the PR description.
+
+Coverage:
+
+- `fmtNanos`               (5 magnitude tiers)
+- `fmtNanosStr`            (combined number+unit)
+- `fmtSpec`                (registered parametric benchmark)
+- `fmtFixedSpec`           (registered fixed benchmark)
+- `fmtResult`              (multi-row parametric table, with verdict)
+- `fmtComparison`          (multi-result parametric report)
+- `fmtFixedResult`         (multi-row fixed table)
+- `fmtFixedComparison`     (multi-result fixed report)
+- `fmtVerifyReport`        (passing AND failing)
+- `fmtVerify`              (multi-report summary)
+- `fmtCombinedVerify`      (parametric + fixed)
+-/
+
+open LeanBench
+
+/-- Snapshot equality. On failure prints both expected and actual
+    side-by-side so the diff is visible in CI logs. -/
+private def snapshot (label expected actual : String) : IO UInt32 := do
+  if actual == expected then
+    IO.println s!"  ok  {label}"
+    return 0
+  IO.eprintln s!"FAIL: {label}"
+  IO.eprintln "----- expected -----"
+  IO.eprintln expected
+  IO.eprintln "----- actual   -----"
+  IO.eprintln actual
+  IO.eprintln "--------------------"
+  return 1
+
+/-! ## Fixed inputs -/
+
+private def sampleSpec : BenchmarkSpec :=
+  { name := `Sample.linearFn
+  , complexityName := `Sample.linearFn._leanBench_complexity
+  , complexityFormula := "n"
+  , runCheckedName := `Sample.linearFn._leanBench_runChecked
+  , hashable := true
+  , config := {} }
+
+private def sampleNoHashSpec : BenchmarkSpec :=
+  { sampleSpec with name := `Sample.noHashFn, hashable := false }
+
+private def sampleFixedSpec : FixedSpec :=
+  { name := `Sample.cheap
+  , runnerName := `Sample.cheap._leanBench_runner
+  , hashable := true
+  , config := { repeats := 3 } }
+
+/-- Three perfectly-linear points so the verdict is unambiguous. -/
+private def linearPoints : Array DataPoint := #[
+  { param := 2, innerRepeats := 4, totalNanos := 100
+  , perCallNanos := 25.0, resultHash := some 0xabc
+  , status := .ok, partOfVerdict := true },
+  { param := 4, innerRepeats := 4, totalNanos := 200
+  , perCallNanos := 50.0, resultHash := some 0xabc
+  , status := .ok, partOfVerdict := true },
+  { param := 8, innerRepeats := 4, totalNanos := 400
+  , perCallNanos := 100.0, resultHash := some 0xabc
+  , status := .ok, partOfVerdict := true } ]
+
+private def sampleResult : BenchmarkResult :=
+  { function := sampleSpec.name
+  , complexityFormula := sampleSpec.complexityFormula
+  , config := sampleSpec.config
+  , points := linearPoints
+  , ratios := #[(2, 12.5), (4, 12.5), (8, 12.5)]
+  , verdict := .consistentWithDeclaredComplexity
+  , cMin? := some 12.5
+  , cMax? := some 12.5
+  , verdictDroppedLeading := 0
+  , slope? := some 0.0
+  , spawnFloorNanos? := none }
+
+/-- A second result for the comparison snapshot. Hand-tuned so the
+    table is not identical to `sampleResult`. -/
+private def sampleResult2 : BenchmarkResult :=
+  { function := `Sample.otherFn
+  , complexityFormula := "n"
+  , config := {}
+  , points := #[
+      { param := 2, innerRepeats := 4, totalNanos := 200
+      , perCallNanos := 50.0, resultHash := some 0xdef
+      , status := .ok, partOfVerdict := true },
+      { param := 4, innerRepeats := 4, totalNanos := 400
+      , perCallNanos := 100.0, resultHash := some 0xdef
+      , status := .ok, partOfVerdict := true },
+      { param := 8, innerRepeats := 4, totalNanos := 800
+      , perCallNanos := 200.0, resultHash := some 0xdef
+      , status := .ok, partOfVerdict := true } ]
+  , ratios := #[(2, 25.0), (4, 25.0), (8, 25.0)]
+  , verdict := .consistentWithDeclaredComplexity
+  , cMin? := some 25.0
+  , cMax? := some 25.0
+  , verdictDroppedLeading := 0
+  , slope? := some 0.0
+  , spawnFloorNanos? := none }
+
+private def sampleComparison : ComparisonReport :=
+  { results := #[sampleResult, sampleResult2]
+  , commonParams := #[2, 4, 8]
+  , agreeOnCommon := .divergedAt #[(`Sample.linearFn, `Sample.otherFn, 2)] }
+
+private def fixedPoints : Array FixedDataPoint := #[
+  { repeatIndex := 0, totalNanos := 1_000_000
+  , resultHash := some 0xfeed, status := .ok },
+  { repeatIndex := 1, totalNanos := 1_100_000
+  , resultHash := some 0xfeed, status := .ok },
+  { repeatIndex := 2, totalNanos := 1_050_000
+  , resultHash := some 0xfeed, status := .ok } ]
+
+private def sampleFixedResult : FixedResult :=
+  { function := sampleFixedSpec.name
+  , config := sampleFixedSpec.config
+  , points := fixedPoints
+  , medianNanos? := some 1_050_000
+  , minNanos? := some 1_000_000
+  , maxNanos? := some 1_100_000
+  , hashesAgree := true }
+
+private def sampleFixedComparison : FixedComparisonReport :=
+  { results := #[sampleFixedResult]
+  , agreeOnHash := .allAgreed }
+
+/-! ## Snapshots
+
+Each test calls `snapshot label expected actual`. To accept a
+deliberate format change, replace the `expected` string with what
+the test prints under "actual ----" and commit. -/
+
+def testFmtNanos : IO UInt32 := do
+  -- Each tier of the magnitude switch.
+  let cases : List (Nat × String × String) :=
+    [(123, "123.000", "ns"),
+     (1_500, "1.500", "µs"),
+     (2_500_000, "2.500", "ms"),
+     (3_000_000_000, "3.000", "s"),
+     (0, "0.000", "ns")]
+  for (n, num, unit) in cases do
+    let (gotNum, gotUnit) := Format.fmtNanos n
+    if gotNum != num || gotUnit != unit then
+      IO.eprintln s!"fmtNanos {n}: expected ({num}, {unit}), got ({gotNum}, {gotUnit})"
+      return 1
+  return 0
+
+def testFmtNanosStr : IO UInt32 := do
+  if Format.fmtNanosStr 1_500 != "1.500 µs" then
+    IO.eprintln s!"fmtNanosStr 1500: expected '1.500 µs', got '{Format.fmtNanosStr 1500}'"
+    return 1
+  return 0
+
+def testFmtSpec : IO UInt32 := do
+  let expected := "  Sample.linearFn    expected complexity: n"
+  snapshot "fmtSpec.hashable" expected (Format.fmtSpec sampleSpec)
+
+def testFmtSpecNoHash : IO UInt32 := do
+  let expected := "  Sample.noHashFn    expected complexity: n  (no Hashable)"
+  snapshot "fmtSpec.noHashable" expected (Format.fmtSpec sampleNoHashSpec)
+
+def testFmtFixedSpec : IO UInt32 := do
+  let expected := "  Sample.cheap    [fixed] repeats=3"
+  snapshot "fmtFixedSpec" expected (Format.fmtFixedSpec sampleFixedSpec)
+
+def testFmtResult : IO UInt32 := do
+  let expected :=
+    "Sample.linearFn    expected complexity: n\n" ++
+    "  param  per-call    repeats  C\n" ++
+    "      2   25.000 ns  ×2^2     C=12.500\n" ++
+    "      4   50.000 ns  ×2^2     C=12.500\n" ++
+    "      8  100.000 ns  ×2^2     C=12.500\n" ++
+    "  verdict: consistent with declared complexity (cMin=12.500, cMax=12.500, β=+0.000)"
+  snapshot "fmtResult" expected (Format.fmtResult sampleResult)
+
+def testFmtComparison : IO UInt32 := do
+  let expected :=
+    "Sample.linearFn    expected complexity: n\n" ++
+    "  param  per-call    repeats  C\n" ++
+    "      2   25.000 ns  ×2^2     C=12.500\n" ++
+    "      4   50.000 ns  ×2^2     C=12.500\n" ++
+    "      8  100.000 ns  ×2^2     C=12.500\n" ++
+    "  verdict: consistent with declared complexity (cMin=12.500, cMax=12.500, β=+0.000)\n" ++
+    "\n" ++
+    "Sample.otherFn    expected complexity: n\n" ++
+    "  param  per-call    repeats  C\n" ++
+    "      2   50.000 ns  ×2^2     C=25.000\n" ++
+    "      4  100.000 ns  ×2^2     C=25.000\n" ++
+    "      8  200.000 ns  ×2^2     C=25.000\n" ++
+    "  verdict: consistent with declared complexity (cMin=25.000, cMax=25.000, β=+0.000)\n" ++
+    "\n" ++
+    "common params (apples-to-apples): 2, 4, 8\n" ++
+    "agreement: DIVERGED on 1 (function, function, param) triples"
+  snapshot "fmtComparison" expected (Format.fmtComparison sampleComparison)
+
+def testFmtFixedResult : IO UInt32 := do
+  let expected :=
+    "Sample.cheap    [fixed] repeats=3\n" ++
+    "  repeat 0  1.000 ms\n" ++
+    "  repeat 1  1.100 ms\n" ++
+    "  repeat 2  1.050 ms\n" ++
+    "  median: 1.050 ms    min: 1.000 ms    max: 1.100 ms\n" ++
+    "  hash: all repeats agree"
+  snapshot "fmtFixedResult" expected (Format.fmtFixedResult sampleFixedResult)
+
+def testFmtFixedComparison : IO UInt32 := do
+  let expected :=
+    "Sample.cheap    [fixed] repeats=3\n" ++
+    "  repeat 0  1.000 ms\n" ++
+    "  repeat 1  1.100 ms\n" ++
+    "  repeat 2  1.050 ms\n" ++
+    "  median: 1.050 ms    min: 1.000 ms    max: 1.100 ms\n" ++
+    "  hash: all repeats agree\n" ++
+    "\n" ++
+    "relative median (baseline = Sample.cheap, the first CLI argument):\n" ++
+    "  Sample.cheap: 1.000× (1.050 ms)\n" ++
+    "agreement: all functions agree on output"
+  snapshot "fmtFixedComparison" expected
+    (Format.fmtFixedComparison sampleFixedComparison)
+
+def testFmtVerifyPass : IO UInt32 := do
+  let r : VerifyReport :=
+    { spec := sampleSpec, checks := #[] }
+  snapshot "fmtVerifyReport.pass"
+    "  [ok ] Sample.linearFn"
+    (Format.fmtVerifyReport r)
+
+def testFmtVerifyFail : IO UInt32 := do
+  let failingCheck : VerifyCheck :=
+    { param := 0
+    , point :=
+        { param := 0, innerRepeats := 0, totalNanos := 0
+        , perCallNanos := 0.0, resultHash := none
+        , status := .error "boom" }
+    , failure := some "child error at param=0: boom" }
+  let r : VerifyReport :=
+    { spec := sampleSpec, checks := #[failingCheck] }
+  let expected :=
+    "  [FAIL] Sample.linearFn\n" ++
+    "         —  child error at param=0: boom"
+  snapshot "fmtVerifyReport.fail" expected (Format.fmtVerifyReport r)
+
+def testFmtVerifyMulti : IO UInt32 := do
+  let pass : VerifyReport :=
+    { spec := sampleSpec, checks := #[] }
+  let fail : VerifyReport :=
+    { spec := { sampleSpec with name := `Sample.brokenFn }
+    , checks := #[
+        { param := 1, point :=
+            { param := 1, innerRepeats := 0, totalNanos := 0
+            , perCallNanos := 0.0, resultHash := none
+            , status := .error "kapow" }
+        , failure := some "child error at param=1: kapow" } ] }
+  let expected :=
+    "verifying 2 benchmark(s)...\n" ++
+    "  [ok ] Sample.linearFn\n" ++
+    "  [FAIL] Sample.brokenFn\n" ++
+    "         —  child error at param=1: kapow\n" ++
+    "1 of 2 benchmark(s) failed verification"
+  snapshot "fmtVerify.multi" expected (Format.fmtVerify #[pass, fail])
+
+def testFmtCombinedVerify : IO UInt32 := do
+  let pParam : VerifyReport := { spec := sampleSpec, checks := #[] }
+  let fFixed : FixedVerifyReport :=
+    { spec := sampleFixedSpec, checks := #[] }
+  let combined : CombinedVerifyReports :=
+    { parametric := #[pParam], fixed := #[fFixed] }
+  let expected :=
+    "verifying 2 benchmark(s)...\n" ++
+    "  [ok ] Sample.linearFn\n" ++
+    "  [ok ] Sample.cheap  [fixed]\n" ++
+    "all 2 benchmark(s) passed"
+  snapshot "fmtCombinedVerify" expected (Format.fmtCombinedVerify combined)
+
+/-! ## Driver -/
+
+def main : IO UInt32 := do
+  let mut anyFail : UInt32 := 0
+  for (label, t) in
+    [ ("fmtNanos", testFmtNanos),
+      ("fmtNanosStr", testFmtNanosStr),
+      ("fmtSpec.hashable", testFmtSpec),
+      ("fmtSpec.noHash", testFmtSpecNoHash),
+      ("fmtFixedSpec", testFmtFixedSpec),
+      ("fmtResult", testFmtResult),
+      ("fmtComparison", testFmtComparison),
+      ("fmtFixedResult", testFmtFixedResult),
+      ("fmtFixedComparison", testFmtFixedComparison),
+      ("fmtVerifyReport.pass", testFmtVerifyPass),
+      ("fmtVerifyReport.fail", testFmtVerifyFail),
+      ("fmtVerify.multi", testFmtVerifyMulti),
+      ("fmtCombinedVerify", testFmtCombinedVerify) ]
+  do
+    let code ← t
+    if code != 0 then
+      IO.eprintln s!"FAIL: {label}"
+      anyFail := 1
+  if anyFail == 0 then
+    IO.println "format regression tests passed"
+  return anyFail


### PR DESCRIPTION
Closes #2.

## Summary

The visible test surface only covered setup-time errors and one JSONL
roundtrip. For a harness that orchestrates subprocesses and interprets
their results, that left every parent/child failure path, the live
\`run\`/\`compare\` pipelines, the CLI argument parser, and the
human-readable formatter untested. This PR fills those gaps.

## What's new

**Refactor** (\`LeanBench/Run.lean\`): extracted two pure helpers,
\`classifyChildOutcome\` and \`classifyFixedChildOutcome\`, that fold
\`(exit, stdout, stderr, wasKilled)\` into a \`DataPoint\` /
\`FixedDataPoint\`. \`runOneBatch\` and \`runFixedOneBatch\` now delegate
to them so the failure-mode branches are unit-testable without
spawning a subprocess. Behaviour is unchanged.

**Four new test executables**:

| Test                               | What it pins                                                                |
| ---                                | ---                                                                         |
| \`child_outcome_benchmark_test\`     | 17 unit tests of \`parseChildRow\` + the two classifiers (parametric & fixed) covering empty/malformed/missing-field stdout, unknown-status round-trip, killed-overrides-exit, exit-0 with empty/malformed output, non-zero exit with and without stderr, no-stderr-no-suffix |
| \`format_benchmark_test\`            | 13 snapshot tests pinning \`fmtNanos\`, \`fmtSpec\` (hashable + non-hashable), \`fmtFixedSpec\`, \`fmtResult\`, \`fmtComparison\`, \`fmtFixedResult\`, \`fmtFixedComparison\`, \`fmtVerifyReport\` (pass + fail), \`fmtVerify\`, \`fmtCombinedVerify\` |
| \`e2e_benchmark_test\`               | End-to-end \`runBenchmark\` + \`compare\` against three trivially-fast registered benchmarks (~1.3s total). Asserts ratios populated, ok rows have hashes, complexity formula round-trips, \`commonParams\` equals the actual intersection, divergence and agreement reported correctly. Also drives \`Cli.dispatch [\"list\"]\` against the populated registry. |
| \`cli_errors_benchmark_test\`        | Parser-level rejection (unknown subcommand, missing positional, negative \`Nat\`, non-numeric \`Nat\`/\`Float\`) and dispatch-level error paths (empty argv defaults to \`list\`, \`compare\` with no names, \`run\`/\`verify\` against unregistered names) |

Each new exe runs as its own CI step on Linux, macOS, and Windows.

## Codex pre-review

Ran \`/second-opinion\` before opening: confirmed the \`Run.lean\`
refactor preserves branch order and behaviour. Two coverage nits
addressed in the same branch:

- \`testRunBenchmarkHappyPath\` now asserts \`result.ratios\` is non-empty.
- \`testCompareDiverges\` now asserts \`commonParams\` equals the actual
  per-function intersection, not just \"non-empty\".
- New \`testListCliDispatch\` drives \`Cli.dispatch [\"list\"]\` against
  this binary's populated registry, instead of just inspecting
  \`allRuntimeEntries\`.

🤖 Prepared with Claude Code