### PR TITLE
feat: versioned JSONL result schema (issue #14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
         shell: bash
         run: ./.lake/build/bin/cli_errors_benchmark_test
 
+      - name: schema-stability test (issue #14: required keys + version policy)
+        shell: bash
+        run: ./.lake/build/bin/schema_benchmark_test
+
       - name: end-to-end run/compare test
         shell: bash
         run: ./.lake/build/bin/e2e_benchmark_test

--- a/LeanBench.lean
+++ b/LeanBench.lean
@@ -1,4 +1,5 @@
 import LeanBench.Core
+import LeanBench.Schema
 import LeanBench.Env
 import LeanBench.Setup
 import LeanBench.Child

--- a/LeanBench/Child.lean
+++ b/LeanBench/Child.lean
@@ -1,6 +1,7 @@
 import Lean
 import LeanBench.Core
 import LeanBench.Env
+import LeanBench.Schema
 
 /-!
 # `LeanBench.Child` — child-mode runner
@@ -116,7 +117,8 @@ def emitRow
   let perCall : Float := totalNanos.toFloat / innerRepeats.toFloat
   let row :=
     "{" ++ String.intercalate "," [
-      "\"schema_version\":1",
+      s!"\"schema_version\":{Schema.schemaVersion}",
+      s!"\"kind\":{jsonStr Schema.kindParametric}",
       s!"\"function\":{jsonStr function.toString}",
       s!"\"param\":{param}",
       s!"\"inner_repeats\":{innerRepeats}",
@@ -171,8 +173,8 @@ def emitFixedRow
     IO Unit := do
   let row :=
     "{" ++ String.intercalate "," [
-      "\"schema_version\":1",
-      "\"kind\":\"fixed\"",
+      s!"\"schema_version\":{Schema.schemaVersion}",
+      s!"\"kind\":{jsonStr Schema.kindFixed}",
       s!"\"function\":{jsonStr function.toString}",
       s!"\"repeat_index\":{repeatIndex}",
       s!"\"total_nanos\":{totalNanos}",

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -2,6 +2,7 @@ import Lean
 import Std.Sync.Mutex
 import LeanBench.Core
 import LeanBench.Env
+import LeanBench.Schema
 import LeanBench.Stats
 
 /-!
@@ -62,9 +63,29 @@ private def parseHexU64 (s : String) : Option UInt64 := do
     acc * 16 + d
   return n.toUInt64
 
-/-- Parse the child's JSONL row into a `DataPoint`. -/
+/-- Parse the child's JSONL row into a `DataPoint`.
+
+Schema-compatibility contract (see [`doc/schema.md`](../../doc/schema.md)):
+
+- `schema_version > Schema.schemaVersion` is rejected with an
+  explicit error. A missing `schema_version` is tolerated for
+  back-compat and treated as v1.
+- Required fields (`param`, `inner_repeats`, `total_nanos`, `status`)
+  are still required; absence is a parse error.
+- Optional fields (`per_call_nanos`, `result_hash`, `error`) are
+  tolerated when missing or `null`.
+- Unknown extra keys are ignored — that's the forward-compat lever
+  that lets future PRs add fields (memory metrics, env metadata,
+  budget tags, …) without rewriting every reader. -/
 def parseChildRow (line : String) : Except String DataPoint := do
   let json ← Json.parse line
+  Schema.checkVersion json
+  Schema.checkKind Schema.kindParametric json
+  -- `function` is required by the schema. The parent already knows
+  -- what it dispatched, but external tooling reading raw JSONL needs
+  -- this as a sanity check, so the parser still requires its
+  -- presence.
+  let _ ← json.getObjValAs? String "function"
   let param ← json.getObjValAs? Nat "param"
   let innerRepeats ← json.getObjValAs? Nat "inner_repeats"
   let totalNanos ← json.getObjValAs? Nat "total_nanos"
@@ -377,9 +398,13 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
 
 /-! ## Fixed-benchmark orchestration -/
 
-/-- Parse one fixed-benchmark JSONL row into a `FixedDataPoint`. -/
+/-- Parse one fixed-benchmark JSONL row into a `FixedDataPoint`.
+    Same schema-compatibility contract as `parseChildRow`. -/
 def parseFixedChildRow (line : String) : Except String FixedDataPoint := do
   let json ← Json.parse line
+  Schema.checkVersion json
+  Schema.checkKind Schema.kindFixed json
+  let _ ← json.getObjValAs? String "function"
   let repeatIndex ← json.getObjValAs? Nat "repeat_index"
   let totalNanos ← json.getObjValAs? Nat "total_nanos"
   let resultHash : Option UInt64 :=

--- a/LeanBench/Schema.lean
+++ b/LeanBench/Schema.lean
@@ -1,0 +1,143 @@
+import Lean.Data.Json
+import LeanBench.Core
+
+/-!
+# `LeanBench.Schema` — versioned result schema
+
+Single source of truth for the JSONL row format produced by the child
+process and consumed by the parent. Pins the version constant, the
+canonical required-key sets, and the tolerance rules described in
+[`doc/schema.md`](../doc/schema.md).
+
+The split from `LeanBench.Core` is deliberate: `Core` defines the
+in-memory data shapes (`DataPoint`, `FixedDataPoint`, …) that are
+internal to the harness, while `Schema` owns the wire format that
+external tooling (baseline diffs, exporters, dashboards) reads. The
+two move on different cadences: in-memory shapes can be refactored
+freely; the wire format only changes under the rules in `schema.md`.
+-/
+
+open Lean (Json)
+
+namespace LeanBench
+namespace Schema
+
+/-- Current schema version. Bump only on breaking changes — see
+[`doc/schema.md#versioning`](../doc/schema.md#versioning). -/
+def schemaVersion : Nat := 1
+
+/-! ## Row-kind discriminator
+
+Older parametric rows omit `kind` entirely. Readers treat a missing
+`kind` as `"parametric"`; writers emit it explicitly going forward. -/
+
+def kindParametric : String := "parametric"
+def kindFixed      : String := "fixed"
+
+/-! ## Canonical key sets
+
+These are the keys readers and writers commit to. They drive the
+schema-stability test in `test/LeanBenchTestSchema.lean`: a missing
+key here vs. there means the diff caught a wire-format change that
+needs human review. -/
+
+/-- Required keys on every row, regardless of kind. -/
+def requiredCommonKeys : Array String :=
+  #["schema_version", "function", "status", "total_nanos"]
+
+/-- Required keys on a parametric row, in addition to
+    `requiredCommonKeys`. -/
+def requiredParametricKeys : Array String :=
+  #["param", "inner_repeats"]
+
+/-- Required keys on a fixed row, in addition to
+    `requiredCommonKeys`. -/
+def requiredFixedKeys : Array String :=
+  #["repeat_index"]
+
+/-- Optional keys emitted on every row today. Absence is equivalent
+    to `null`. -/
+def optionalCommonKeys : Array String :=
+  #["kind", "result_hash", "error"]
+
+/-- Optional keys emitted only on parametric rows today. -/
+def optionalParametricKeys : Array String :=
+  #["per_call_nanos"]
+
+/-! ## Version handling
+
+Reader contract: accept exactly the versions we know how to read.
+There are no historical versions yet, so the admitted set is
+`{schemaVersion}` plus a back-compat carve-out for missing
+`schema_version`. -/
+
+/-- Pull `schema_version` off a row. Missing → `none` (callers
+    decide whether to default to `1` or fail). -/
+def getVersion? (json : Json) : Option Nat :=
+  match json.getObjValAs? Nat "schema_version" with
+  | .ok n => some n
+  | .error _ => none
+
+/-- The set of `schema_version` values this reader can interpret.
+    Currently a singleton; future readers add older versions here as
+    they implement migrations. -/
+def supportedVersions : Array Nat := #[schemaVersion]
+
+/-- Validate that a row's `schema_version` is one we can read.
+
+Rules:
+
+- Missing `schema_version` is tolerated and treated as v1. This is
+  the back-compat carve-out for hand-rolled fixtures and for any
+  pre-versioning row that might still be in the wild.
+- An explicit `schema_version` outside `supportedVersions` is
+  rejected with an explicit error that names the version. We MUST
+  NOT silently best-effort-read a future version (a renamed field
+  would silently parse as `null`) or an older one we don't yet
+  know how to migrate. -/
+def checkVersion (json : Json) : Except String Unit := do
+  match getVersion? json with
+  | none => .ok ()
+  | some v =>
+    if supportedVersions.contains v then .ok ()
+    else if v > schemaVersion then
+      .error s!"schema_version {v} is newer than this reader (max {schemaVersion}); upgrade lean-bench to read it"
+    else
+      .error s!"schema_version {v} is older than this reader supports (supported: {supportedVersions}); migration not implemented"
+
+/-- Read the `kind` discriminator. Default `"parametric"` when the
+    field is missing — see the back-compat carve-out in
+    [`doc/schema.md#compatibility`](../doc/schema.md#compatibility). -/
+def getKind (json : Json) : String :=
+  match json.getObjValAs? String "kind" with
+  | .ok s => s
+  | .error _ => kindParametric
+
+/-- Validate that a row's `kind` matches `expected` (or is absent —
+    treated as `"parametric"` per the back-compat rule). Used by both
+    parsers to refuse rows that were emitted from the wrong path
+    (e.g. a fixed row mis-routed into `parseChildRow`). -/
+def checkKind (expected : String) (json : Json) : Except String Unit := do
+  let actual := getKind json
+  if actual == expected then .ok ()
+  else .error s!"kind mismatch: expected {expected}, got {actual}"
+
+/-! ## Status string contract
+
+Mirrors `Status.toJsonString`. Pinning the canonical strings here
+means the schema-stability test can assert the round-trip without
+depending on `Status.toJsonString`'s implementation. -/
+
+def statusOk          : String := "ok"
+def statusTimedOut    : String := "timed_out"
+def statusKilledAtCap : String := "killed_at_cap"
+def statusError       : String := "error"
+
+/-- Every documented status string. Readers MUST accept any of these
+    as `Status` values; producers MUST emit one of these on every
+    row. -/
+def statusStrings : Array String :=
+  #[statusOk, statusTimedOut, statusKilledAtCap, statusError]
+
+end Schema
+end LeanBench

--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ for the full guide.
 
 v0.1. Cross-platform: works on every platform Lean's process API
 supports (Linux, macOS, Windows). See [PLAN.md](PLAN.md) for the
-v0.2+ roadmap and [doc/quickstart.md](doc/quickstart.md) for the
-user guide.
+v0.2+ roadmap, [doc/quickstart.md](doc/quickstart.md) for the
+user guide, and [doc/schema.md](doc/schema.md) for the JSONL
+result-row schema and its evolution rules.
 
 ## Design
 

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -1,0 +1,199 @@
+# Result schema
+
+`lean-bench` emits machine-readable results as JSONL — one JSON object
+per line — written to the child process's stdout and consumed by the
+parent. Downstream tooling (baseline diffs, CI dashboards, exporters)
+also reads these rows. This document pins the schema and spells out
+the evolution rules so producers and consumers can rely on it.
+
+The single source of truth in the code is
+[`LeanBench/Schema.lean`](../LeanBench/Schema.lean): the
+`schemaVersion` constant, the canonical key sets, and the parser
+shared by `Run.parseChildRow` and `Run.parseFixedChildRow`.
+
+## Row kinds
+
+Two row kinds exist. They share most fields and the same
+`schema_version` namespace.
+
+- `parametric` — emitted by the parametric path (`setup_benchmark`).
+  Carries one `(param, inner_repeats, total_nanos)` triple per child
+  invocation.
+- `fixed` — emitted by the fixed path (`setup_fixed_benchmark`).
+  Carries one `(repeat_index, total_nanos)` triple per child
+  invocation; no inner-repeat loop, no parameter.
+
+Rows are tagged with `"kind":"parametric"` or `"kind":"fixed"`. Older
+parametric rows produced before this field existed omit `kind`
+entirely; readers MUST treat a missing `kind` as `"parametric"` to
+preserve backwards compatibility (see [Compatibility](#compatibility)).
+
+## Versioning
+
+Every row carries a top-level integer `schema_version`. The current
+version is **1**.
+
+The version increments on any **breaking** change. Breaking changes
+are:
+
+- Removing a required field.
+- Renaming a required field.
+- Changing the type of a required field.
+- Changing the meaning of an existing field (e.g. flipping units).
+- **Adding a required field** (older writers won't emit it, so older
+  data fails the new reader).
+- **Promoting an existing optional field to required** (same reason).
+- Tightening the value domain of a field in a way that rejects
+  previously-valid data (e.g. making `result_hash` mandatory when it
+  was optional).
+
+The following changes are **non-breaking** (additive) and do NOT
+bump the version:
+
+- Adding a new **optional** field. Older readers ignore it; older
+  writers still produce valid v1 rows.
+- Documenting a previously-tolerated behaviour (e.g. accepting a
+  shorter `result_hash`).
+- Widening the value domain of an existing field (e.g. accepting more
+  `status` strings).
+- Making a previously-required field optional, provided readers continue
+  to handle the field's absence as if the prior emit-side default
+  were present.
+
+Bumps are integer (`1 → 2 → 3`). There is no semver minor; consumers
+key on the integer only.
+
+## Required vs optional fields
+
+### Required for both kinds
+
+| key              | type    | meaning |
+|------------------|---------|---------|
+| `schema_version` | integer | Always `1` for v1 rows. |
+| `kind`           | string  | `"parametric"` or `"fixed"`. Always emitted by current writers. Readers MUST reject a row whose `kind` mismatches the expected kind for the parser; a missing `kind` is tolerated only as `"parametric"` (the back-compat carve-out for parametric rows produced before this field was added). |
+| `function`       | string  | Fully-qualified Lean name of the registered benchmark. |
+| `total_nanos`    | integer | Wall time in nanoseconds for the measured work. |
+| `status`         | string  | One of `"ok"`, `"timed_out"`, `"killed_at_cap"`, `"error"`. |
+
+### Required for `parametric` only
+
+| key              | type    | meaning |
+|------------------|---------|---------|
+| `param`          | integer | Ladder parameter the function was invoked with. |
+| `inner_repeats`  | integer | Auto-tuned inner repeat count. `0` on synthesized error rows. |
+
+### Required for `fixed` only
+
+| key              | type    | meaning |
+|------------------|---------|---------|
+| `repeat_index`   | integer | 0-based index across the configured `repeats`. |
+
+### Optional fields (both kinds)
+
+These are emitted today. Readers MUST treat absence as if the field
+were `null`.
+
+| key                | type             | meaning |
+|--------------------|------------------|---------|
+| `result_hash`      | string \| null   | Hex-prefixed `0xDEADBEEF` literal (case-insensitive). `null` when the function's return type lacks `Hashable`. |
+| `error`            | string \| null   | Free-form message for `status == "error"`. `null` otherwise. |
+
+`kind` is also classified as optional from the reader's standpoint
+(absence defaults to `"parametric"`), but every current writer emits
+it explicitly; producing a row without `kind` is a writer bug.
+
+### Optional fields (parametric only)
+
+| key                | type             | meaning |
+|--------------------|------------------|---------|
+| `per_call_nanos`   | number           | `total_nanos / inner_repeats` precomputed. Derived; readers MAY recompute it from `total_nanos` and `inner_repeats` when absent. |
+
+### Reserved-for-future-use fields
+
+The following keys are reserved by the issues that prompted this
+schema and will land as additive (non-breaking) fields. They are
+listed here so concurrent feature work claims a stable name from
+the start:
+
+- `alloc_bytes`, `peak_rss_kb` — memory metrics ([#6]).
+- `env` — an object carrying reproducibility metadata: Lean version,
+  toolchain, platform, hostname, … ([#11]).
+- `budget_status` — additional status discriminator for budgeted-run
+  rows that were skipped or partially completed ([#9]).
+
+Producers MUST NOT emit any of these keys with semantics other than
+the ones described in their landing PRs.
+
+[#6]:  https://github.com/kim-em/lean-bench/issues/6
+[#9]:  https://github.com/kim-em/lean-bench/issues/9
+[#11]: https://github.com/kim-em/lean-bench/issues/11
+
+## Compatibility
+
+The contract for every reader and writer:
+
+**Readers MUST:**
+
+- Accept rows whose `schema_version` is in their `supportedVersions`
+  set (currently the singleton `{1}`).
+- Reject rows whose `schema_version` is outside that set with an
+  explicit error that names the unsupported version. Silent
+  best-effort reads of unknown versions risk producing wrong
+  results.
+- Tolerate a missing `schema_version` field by treating it as v1.
+  This is the back-compat carve-out for hand-rolled fixtures and
+  any pre-versioning row in the wild.
+- Tolerate unknown extra keys: ignore them rather than failing.
+- Tolerate missing optional keys (treating them as `null` / absent /
+  the documented default).
+- Treat a missing `kind` field as `"parametric"`. This is the one
+  back-compat hatch for rows produced before `kind` was tagged on
+  the parametric side. A present-but-mismatched `kind` (e.g. a
+  fixed-shaped row arriving at the parametric parser) MUST be
+  rejected.
+
+**Readers MAY:**
+
+- Decline to interpret rows whose required fields are missing or
+  malformed — those are emitter bugs and surfacing them as a parse
+  error is the right behaviour.
+
+**Writers MUST:**
+
+- Emit `schema_version` exactly once per row.
+- Emit every required field for the row's kind.
+- Use the documented status strings exactly. Unknown status strings
+  are reserved for future use.
+
+**Writers MAY:**
+
+- Add new optional fields without bumping `schema_version`, provided
+  every existing reader's "ignore unknown" rule keeps the output
+  valid.
+- Order the keys however they like. Consumers MUST NOT depend on key
+  order.
+
+## Migration
+
+There are no historical schema versions yet — `schema_version == 1`
+is the first formal cut. When the version bumps, this document will
+gain a per-version section describing the migration. Readers
+implementing migration should be permissive on input ("read what you
+get") and strict on output ("emit the current version").
+
+## Test enforcement
+
+[`test/LeanBenchTestSchema.lean`](../test/LeanBenchTestSchema.lean)
+pins:
+
+- The exact `schema_version` constant.
+- The canonical required-key sets for both row kinds.
+- The parser's tolerance of unknown extra keys.
+- The parser's tolerance of missing optional keys.
+- The parser's rejection of missing required keys and unsupported
+  schema versions.
+
+Adding a new field is a one-line edit there. Removing a required
+field requires a `schema_version` bump and a corresponding edit
+to this document and the test fixtures, so the change shows up in
+review.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -11,6 +11,7 @@ defaultTargets = [
   "fixed_benchmark_test",
   "child_outcome_benchmark_test", "format_benchmark_test",
   "e2e_benchmark_test", "cli_errors_benchmark_test",
+  "schema_benchmark_test",
 ]
 
 [[require]]
@@ -106,3 +107,8 @@ root = "LeanBenchTestE2E"
 name = "cli_errors_benchmark_test"
 srcDir = "test"
 root = "LeanBenchTestCliErrors"
+
+[[lean_exe]]
+name = "schema_benchmark_test"
+srcDir = "test"
+root = "LeanBenchTestSchema"

--- a/test/LeanBenchTestSchema.lean
+++ b/test/LeanBenchTestSchema.lean
@@ -1,0 +1,483 @@
+import LeanBench
+
+/-!
+# Schema-stability tests (issue #14)
+
+Pin the wire format documented in `doc/schema.md` so accidental
+changes to required keys, the version constant, or compatibility
+expectations break this test.
+
+Two perspectives:
+
+- **Producer.** A child process for a parametric and a fixed
+  benchmark must emit a JSONL row that contains the canonical
+  required keys plus today's optional keys, with `schema_version`
+  matching `Schema.schemaVersion`.
+- **Consumer.** `parseChildRow` and `parseFixedChildRow` must accept
+  rows with unknown extra fields, accept rows with missing
+  optional fields, reject rows with missing required fields, and
+  reject rows whose `schema_version` is newer than the reader.
+-/
+
+open LeanBench
+
+namespace LeanBench.Test.Schema
+
+/-- A trivial parametric benchmark. The body just returns `n`; we're
+    pinning the schema, not the workload. -/
+def schemaProbe (n : Nat) : UInt64 := n.toUInt64
+
+setup_benchmark schemaProbe n => n + 1 where {
+  paramCeiling := 4
+  paramFloor := 0
+  maxSecondsPerCall := 1.0
+}
+
+/-- A fixed-benchmark counterpart so the fixed-emit path is exercised
+    by `verify`. -/
+def schemaFixedProbe : UInt64 := 7
+
+setup_fixed_benchmark schemaFixedProbe where { repeats := 1, warmup := false }
+
+end LeanBench.Test.Schema
+
+private def schemaProbeName : Lean.Name := `LeanBench.Test.Schema.schemaProbe
+private def schemaFixedProbeName : Lean.Name := `LeanBench.Test.Schema.schemaFixedProbe
+
+/-- Substring containment helper. -/
+private def containsSub (haystack needle : String) : Bool :=
+  ((haystack.splitOn needle).length) > 1
+
+/-- Spawn the running binary in `_child` mode and return its stdout. -/
+private def spawnChild (args : List String) : IO (UInt32 × String) := do
+  let exe := (← IO.appPath).toString
+  let child ← IO.Process.spawn {
+    cmd := exe
+    args := args.toArray
+    stdout := .piped
+    stderr := .piped
+    stdin := .null
+  }
+  let stdout ← child.stdout.readToEnd
+  let exit ← child.wait
+  return (exit, stdout.trimAscii.toString)
+
+/-- Look up a JSON object's key set, sorted ascending so the
+    fixture-comparison order is deterministic. -/
+private def objKeys (j : Lean.Json) : Array String :=
+  match j with
+  | .obj kvs =>
+    let xs : Array String := kvs.toArray.map Prod.fst
+    xs.qsort (· < ·)
+  | _ => #[]
+
+/-- Assert that every key in `required` is present in `actual`.
+    Returns the missing key names, if any. -/
+private def missingKeys (actual : Array String) (required : Array String) :
+    Array String :=
+  required.filter (fun k => !actual.contains k)
+
+private def expect (label : String) (cond : Bool) : IO UInt32 := do
+  if cond then return 0
+  IO.eprintln s!"FAIL: {label}"
+  return 1
+
+/-! ## Producer-side: an emitted row carries the documented keys -/
+
+/-- Sort an array of strings ascending. Local helper so the
+    expected-key fixtures below stay readable. -/
+private def sortKeys (xs : Array String) : Array String := xs.qsort (· < ·)
+
+/-- The exact set of keys today's parametric writer emits. Any
+    additional optional field landing in #6/#9/#11 must update both
+    this fixture and `Schema.optionalParametricKeys`/
+    `optionalCommonKeys`, and the producer test below catches
+    missing edits. -/
+private def expectedParametricKeys : Array String := sortKeys (
+  Schema.requiredCommonKeys ++ Schema.requiredParametricKeys ++
+  Schema.optionalCommonKeys ++ Schema.optionalParametricKeys)
+
+/-- The exact set of keys today's fixed writer emits. -/
+private def expectedFixedKeys : Array String := sortKeys (
+  Schema.requiredCommonKeys ++ Schema.requiredFixedKeys ++
+  Schema.optionalCommonKeys)
+
+/-- Spawn the child for a parametric run and check the resulting
+    JSONL row's keys against the canonical fixture. -/
+def testParametricEmitKeys : IO UInt32 := do
+  let (exit, line) ← spawnChild
+    ["_child", "--bench", schemaProbeName.toString (escape := false),
+     "--param", "1", "--target-nanos", "1000000"]
+  if exit != 0 then
+    IO.eprintln s!"parametric child exited {exit}; stdout: {line}"
+    return 1
+  match Lean.Json.parse line with
+  | .error e =>
+    IO.eprintln s!"parametric row failed to parse: {e}\nrow: {line}"
+    return 1
+  | .ok j =>
+    let actual := objKeys j
+    -- Pin the exact emitted-key set so silently dropping or adding
+    -- a field shows up in the diff.
+    unless actual == expectedParametricKeys do
+      IO.eprintln s!"parametric row keys mismatch:\n  got      {actual}\n  expected {expectedParametricKeys}"
+      return 1
+    -- `schema_version` must equal the constant.
+    match j.getObjValAs? Nat "schema_version" with
+    | .ok v =>
+      unless v == Schema.schemaVersion do
+        IO.eprintln s!"emitted schema_version={v}, expected {Schema.schemaVersion}"
+        return 1
+    | .error _ =>
+      IO.eprintln "parametric row missing schema_version"
+      return 1
+    -- `kind` must be `"parametric"` (the v1 contract).
+    match j.getObjValAs? String "kind" with
+    | .ok k =>
+      unless k == Schema.kindParametric do
+        IO.eprintln s!"emitted kind={k}, expected {Schema.kindParametric}"
+        return 1
+    | .error _ =>
+      IO.eprintln "parametric row missing kind discriminator"
+      return 1
+    -- `status` must be one of the documented status strings.
+    match j.getObjValAs? String "status" with
+    | .ok s =>
+      unless Schema.statusStrings.contains s do
+        IO.eprintln s!"emitted status={s}, not in documented set {Schema.statusStrings}"
+        return 1
+    | .error _ =>
+      IO.eprintln "parametric row missing status"
+      return 1
+    return 0
+
+def testFixedEmitKeys : IO UInt32 := do
+  let (exit, line) ← spawnChild
+    ["_child", "--bench", schemaFixedProbeName.toString (escape := false),
+     "--fixed", "--repeat-index", "0"]
+  if exit != 0 then
+    IO.eprintln s!"fixed child exited {exit}; stdout: {line}"
+    return 1
+  match Lean.Json.parse line with
+  | .error e =>
+    IO.eprintln s!"fixed row failed to parse: {e}\nrow: {line}"
+    return 1
+  | .ok j =>
+    let actual := objKeys j
+    unless actual == expectedFixedKeys do
+      IO.eprintln s!"fixed row keys mismatch:\n  got      {actual}\n  expected {expectedFixedKeys}"
+      return 1
+    -- `kind == "fixed"` is mandatory on the fixed side.
+    match j.getObjValAs? String "kind" with
+    | .ok k =>
+      unless k == Schema.kindFixed do
+        IO.eprintln s!"emitted kind={k}, expected {Schema.kindFixed}"
+        return 1
+    | .error _ =>
+      IO.eprintln "fixed row missing kind discriminator"
+      return 1
+    return 0
+
+/-! ## Producer-side: pin the canonical key sets
+
+If `Schema.requiredCommonKeys` etc. change, this test catches it
+before any external tool that depends on the wire format does.
+Adding a new key here is a one-line edit; removing a required key
+needs a `schema_version` bump. -/
+
+def testCanonicalKeyConstants : IO UInt32 := do
+  let okCommon :=
+    Schema.requiredCommonKeys ==
+      #["schema_version", "function", "status", "total_nanos"]
+  let okParametric :=
+    Schema.requiredParametricKeys == #["param", "inner_repeats"]
+  let okFixed :=
+    Schema.requiredFixedKeys == #["repeat_index"]
+  let okOptCommon :=
+    Schema.optionalCommonKeys == #["kind", "result_hash", "error"]
+  let okOptParametric :=
+    Schema.optionalParametricKeys == #["per_call_nanos"]
+  let okStatus :=
+    Schema.statusStrings ==
+      #["ok", "timed_out", "killed_at_cap", "error"]
+  let okVersion := Schema.schemaVersion == 1
+  let okKindStrings :=
+    Schema.kindParametric == "parametric" ∧ Schema.kindFixed == "fixed"
+  expect "canonical key sets match docs"
+    (okCommon ∧ okParametric ∧ okFixed ∧ okOptCommon ∧
+     okOptParametric ∧ okStatus ∧ okVersion ∧ okKindStrings)
+
+/-! ## Consumer-side: parse tolerance -/
+
+def testParseAcceptsExtraKey : IO UInt32 := do
+  -- A future version may add `alloc_bytes` (issue #6). Today's
+  -- parser must ignore it rather than failing.
+  let row :=
+    "{\"schema_version\":1,\"kind\":\"parametric\",\"function\":\"foo.bar\"," ++
+    "\"param\":42,\"inner_repeats\":1024,\"total_nanos\":3000000," ++
+    "\"per_call_nanos\":2929.6875,\"result_hash\":\"0xdeadbeef\"," ++
+    "\"status\":\"ok\",\"error\":null," ++
+    "\"alloc_bytes\":12345,\"future_field\":\"hello\"}"
+  match parseChildRow row with
+  | .error e =>
+    IO.eprintln s!"expected extra-key row to parse, got error: {e}"
+    return 1
+  | .ok dp =>
+    expect s!"extra-key parametric row parses cleanly: {repr dp}"
+      (dp.param == 42 ∧ dp.innerRepeats == 1024 ∧ dp.totalNanos == 3000000)
+
+def testParseAcceptsMissingOptional : IO UInt32 := do
+  -- Drop `result_hash` and `error` (both optional) and ensure the
+  -- parser still succeeds. `kind` is also optional in v1.
+  let row :=
+    "{\"schema_version\":1,\"function\":\"foo.bar\"," ++
+    "\"param\":7,\"inner_repeats\":2,\"total_nanos\":1000," ++
+    "\"per_call_nanos\":500.0,\"status\":\"ok\"}"
+  match parseChildRow row with
+  | .error e =>
+    IO.eprintln s!"expected missing-optional row to parse, got error: {e}"
+    return 1
+  | .ok dp =>
+    expect s!"missing-optional parametric row: {repr dp}"
+      (dp.param == 7 ∧ dp.innerRepeats == 2 ∧ dp.totalNanos == 1000
+        ∧ dp.resultHash == none ∧ dp.status == .ok)
+
+def testParseRecomputesPerCallWhenAbsent : IO UInt32 := do
+  -- `per_call_nanos` is documented as derived; readers MAY recompute
+  -- it from `total_nanos / inner_repeats`. Pin that fallback.
+  let row :=
+    "{\"schema_version\":1,\"function\":\"foo.bar\"," ++
+    "\"param\":7,\"inner_repeats\":2,\"total_nanos\":1000," ++
+    "\"status\":\"ok\"}"
+  match parseChildRow row with
+  | .error e =>
+    IO.eprintln s!"missing-per_call row failed to parse: {e}"
+    return 1
+  | .ok dp =>
+    -- 1000 / 2 = 500.0 exactly.
+    expect s!"per_call recomputed: {dp.perCallNanos}" (dp.perCallNanos == 500.0)
+
+def testParseRejectsFutureVersion : IO UInt32 := do
+  -- `schema_version > Schema.schemaVersion` must fail with a
+  -- message that names the unsupported version. Silent best-effort
+  -- reads of newer rows would silently corrupt downstream analysis.
+  let row :=
+    "{\"schema_version\":99,\"kind\":\"parametric\",\"function\":\"foo.bar\"," ++
+    "\"param\":1,\"inner_repeats\":1,\"total_nanos\":1," ++
+    "\"per_call_nanos\":1.0,\"status\":\"ok\"}"
+  match parseChildRow row with
+  | .ok dp =>
+    IO.eprintln s!"expected future-version row to fail, got {repr dp}"
+    return 1
+  | .error msg =>
+    expect s!"future-version error mentions '99': {msg}"
+      (containsSub msg "99")
+
+def testParseToleratesMissingVersion : IO UInt32 := do
+  -- Hand-rolled fixtures or pre-versioning rows may omit
+  -- `schema_version`. The parser tolerates that and treats it as v1.
+  let row :=
+    "{\"function\":\"foo.bar\"," ++
+    "\"param\":3,\"inner_repeats\":4,\"total_nanos\":12," ++
+    "\"per_call_nanos\":3.0,\"status\":\"ok\"}"
+  match parseChildRow row with
+  | .error e =>
+    IO.eprintln s!"missing-version row failed to parse: {e}"
+    return 1
+  | .ok dp =>
+    expect s!"missing-version parses: {repr dp}"
+      (dp.param == 3 ∧ dp.innerRepeats == 4)
+
+/-! ## Fixed-row consumer-side mirrors -/
+
+def testFixedParseAcceptsExtraKey : IO UInt32 := do
+  let row :=
+    "{\"schema_version\":1,\"kind\":\"fixed\",\"function\":\"foo.bar\"," ++
+    "\"repeat_index\":0,\"total_nanos\":1234567,\"result_hash\":\"0xcafe\"," ++
+    "\"status\":\"ok\",\"error\":null,\"alloc_bytes\":42}"
+  match parseFixedChildRow row with
+  | .error e =>
+    IO.eprintln s!"fixed extra-key row failed to parse: {e}"
+    return 1
+  | .ok dp =>
+    expect s!"fixed extra-key parses: {repr dp}"
+      (dp.repeatIndex == 0 ∧ dp.totalNanos == 1234567 ∧ dp.status == .ok)
+
+def testFixedParseRejectsFutureVersion : IO UInt32 := do
+  let row :=
+    "{\"schema_version\":42,\"kind\":\"fixed\",\"function\":\"foo.bar\"," ++
+    "\"repeat_index\":0,\"total_nanos\":1,\"status\":\"ok\"}"
+  match parseFixedChildRow row with
+  | .ok dp =>
+    IO.eprintln s!"expected fixed future-version row to fail, got {repr dp}"
+    return 1
+  | .error msg =>
+    expect s!"fixed future-version mentions '42': {msg}" (containsSub msg "42")
+
+def testFixedParseAcceptsMissingOptional : IO UInt32 := do
+  -- Drop `result_hash` and `error`. `kind` stays — fixed parser
+  -- requires it to discriminate from a misrouted parametric row.
+  let row :=
+    "{\"schema_version\":1,\"kind\":\"fixed\",\"function\":\"foo.bar\"," ++
+    "\"repeat_index\":2,\"total_nanos\":99,\"status\":\"ok\"}"
+  match parseFixedChildRow row with
+  | .error e =>
+    IO.eprintln s!"fixed missing-optional row failed: {e}"
+    return 1
+  | .ok dp =>
+    expect s!"fixed missing-optional parses: {repr dp}"
+      (dp.repeatIndex == 2 ∧ dp.totalNanos == 99 ∧ dp.resultHash == none)
+
+/-! ## Negative coverage: missing required fields, wrong kind, old version -/
+
+/-- Helper: assert that `parseChildRow` rejects `row` and that the
+    error message mentions `expectedSubstring`. -/
+private def expectParseError (row expectedSubstring label : String) :
+    IO UInt32 := do
+  match parseChildRow row with
+  | .ok dp =>
+    IO.eprintln s!"FAIL ({label}): expected parse error, got {repr dp}"
+    return 1
+  | .error msg =>
+    if containsSub msg expectedSubstring then return 0
+    else
+      IO.eprintln s!"FAIL ({label}): expected error mentioning '{expectedSubstring}', got: {msg}"
+      return 1
+
+private def expectFixedParseError (row expectedSubstring label : String) :
+    IO UInt32 := do
+  match parseFixedChildRow row with
+  | .ok dp =>
+    IO.eprintln s!"FAIL ({label}): expected parse error, got {repr dp}"
+    return 1
+  | .error msg =>
+    if containsSub msg expectedSubstring then return 0
+    else
+      IO.eprintln s!"FAIL ({label}): expected error mentioning '{expectedSubstring}', got: {msg}"
+      return 1
+
+/-- A canonical valid parametric row, used as the basis for "drop
+    one required key" negative tests. -/
+private def baseValidParametricRow : String :=
+  "{\"schema_version\":1,\"kind\":\"parametric\",\"function\":\"foo.bar\"," ++
+  "\"param\":1,\"inner_repeats\":1,\"total_nanos\":1," ++
+  "\"per_call_nanos\":1.0,\"result_hash\":null," ++
+  "\"status\":\"ok\",\"error\":null}"
+
+private def baseValidFixedRow : String :=
+  "{\"schema_version\":1,\"kind\":\"fixed\",\"function\":\"foo.bar\"," ++
+  "\"repeat_index\":0,\"total_nanos\":1,\"result_hash\":null," ++
+  "\"status\":\"ok\",\"error\":null}"
+
+def testParseRejectsExplicitOldVersion : IO UInt32 :=
+  expectParseError
+    "{\"schema_version\":0,\"kind\":\"parametric\",\"function\":\"foo.bar\",\"param\":1,\"inner_repeats\":1,\"total_nanos\":1,\"status\":\"ok\"}"
+    "0" "parse.explicitOldVersion"
+
+def testFixedParseRejectsExplicitOldVersion : IO UInt32 :=
+  expectFixedParseError
+    "{\"schema_version\":0,\"kind\":\"fixed\",\"function\":\"foo.bar\",\"repeat_index\":0,\"total_nanos\":1,\"status\":\"ok\"}"
+    "0" "fixed.explicitOldVersion"
+
+def testParseRejectsWrongKind : IO UInt32 :=
+  -- A `kind:"fixed"` row must be rejected by the parametric parser.
+  expectParseError
+    "{\"schema_version\":1,\"kind\":\"fixed\",\"function\":\"foo.bar\",\"param\":1,\"inner_repeats\":1,\"total_nanos\":1,\"status\":\"ok\"}"
+    "kind" "parse.wrongKind"
+
+def testFixedParseRejectsWrongKind : IO UInt32 :=
+  -- Symmetric: `kind:"parametric"` (or missing, which defaults to
+  -- parametric) must not parse via the fixed parser.
+  expectFixedParseError
+    "{\"schema_version\":1,\"kind\":\"parametric\",\"function\":\"foo.bar\",\"repeat_index\":0,\"total_nanos\":1,\"status\":\"ok\"}"
+    "kind" "fixed.wrongKind"
+
+def testFixedParseRejectsMissingKind : IO UInt32 :=
+  -- Missing `kind` defaults to parametric per the back-compat rule;
+  -- the fixed parser must reject that.
+  expectFixedParseError
+    "{\"schema_version\":1,\"function\":\"foo.bar\",\"repeat_index\":0,\"total_nanos\":1,\"status\":\"ok\"}"
+    "kind" "fixed.missingKind"
+
+/-- Drop each required field individually from a known-good
+    parametric row and assert the parser refuses each variant. The
+    fixture used for `Lean.Json` munging is built up below. -/
+def testParseRejectsMissingRequired : IO UInt32 := do
+  let droppers : List (String × String) :=
+    [ ("\"function\":\"foo.bar\",", "function")
+    , ("\"param\":1,",              "param")
+    , ("\"inner_repeats\":1,",      "inner_repeats")
+    , ("\"total_nanos\":1,",        "total_nanos")
+    , ("\"status\":\"ok\",",        "status") ]
+  for (substr, fieldName) in droppers do
+    -- Build a row missing exactly this required field.
+    let parts := baseValidParametricRow.splitOn substr
+    if parts.length != 2 then
+      IO.eprintln s!"FAIL: expected unique occurrence of '{substr}' in fixture"
+      return 1
+    let mutilated := String.intercalate "" parts
+    match parseChildRow mutilated with
+    | .ok dp =>
+      IO.eprintln s!"FAIL (parse.missing.{fieldName}): expected parse failure, got {repr dp}"
+      return 1
+    | .error _ => pure ()
+  return 0
+
+def testFixedParseRejectsMissingRequired : IO UInt32 := do
+  let droppers : List (String × String) :=
+    [ ("\"function\":\"foo.bar\",", "function")
+    , ("\"repeat_index\":0,",       "repeat_index")
+    , ("\"total_nanos\":1,",        "total_nanos")
+    , ("\"status\":\"ok\",",        "status") ]
+  for (substr, fieldName) in droppers do
+    let parts := baseValidFixedRow.splitOn substr
+    if parts.length != 2 then
+      IO.eprintln s!"FAIL: expected unique occurrence of '{substr}' in fixed fixture"
+      return 1
+    let mutilated := String.intercalate "" parts
+    match parseFixedChildRow mutilated with
+    | .ok dp =>
+      IO.eprintln s!"FAIL (fixed.missing.{fieldName}): expected parse failure, got {repr dp}"
+      return 1
+    | .error _ => pure ()
+  return 0
+
+/-! ## Driver -/
+
+def runTests : IO UInt32 := do
+  for (label, t) in
+    [ ("canonicalKeyConstants",      testCanonicalKeyConstants)
+    , ("emit.parametric",            testParametricEmitKeys)
+    , ("emit.fixed",                 testFixedEmitKeys)
+    , ("parse.extraKey",             testParseAcceptsExtraKey)
+    , ("parse.missingOptional",      testParseAcceptsMissingOptional)
+    , ("parse.recomputesPerCall",    testParseRecomputesPerCallWhenAbsent)
+    , ("parse.futureVersionRejected",testParseRejectsFutureVersion)
+    , ("parse.explicitOldVersion",   testParseRejectsExplicitOldVersion)
+    , ("parse.missingVersion",       testParseToleratesMissingVersion)
+    , ("parse.wrongKind",            testParseRejectsWrongKind)
+    , ("parse.missingRequired",      testParseRejectsMissingRequired)
+    , ("fixed.extraKey",             testFixedParseAcceptsExtraKey)
+    , ("fixed.futureVersionRejected",testFixedParseRejectsFutureVersion)
+    , ("fixed.explicitOldVersion",   testFixedParseRejectsExplicitOldVersion)
+    , ("fixed.missingOptional",      testFixedParseAcceptsMissingOptional)
+    , ("fixed.wrongKind",            testFixedParseRejectsWrongKind)
+    , ("fixed.missingKind",          testFixedParseRejectsMissingKind)
+    , ("fixed.missingRequired",      testFixedParseRejectsMissingRequired) ]
+  do
+    let code ← t
+    if code != 0 then
+      IO.eprintln s!"FAIL: {label}"
+      return code
+    IO.println s!"  ok  {label}"
+  IO.println "schema tests passed"
+  return 0
+
+/-- The same compiled binary acts as parent (test driver) and child
+    (the `_child` first arg distinguishes them). The parametric and
+    fixed emit-side tests spawn this binary in child mode against
+    `schemaProbe` / `schemaFixedProbe`. -/
+def main (args : List String) : IO UInt32 :=
+  match args with
+  | "_child" :: _ => LeanBench.Cli.dispatch args
+  | _ => runTests


### PR DESCRIPTION
Closes https://github.com/kim-em/lean-bench/issues/14.

## Summary

Locks down the JSONL row format produced by the child and consumed
by the parent, so future feature work — memory metrics
([#6](https://github.com/kim-em/lean-bench/issues/6)),
env metadata ([#11](https://github.com/kim-em/lean-bench/issues/11)),
budgeted runs ([#9](https://github.com/kim-em/lean-bench/issues/9))
— can land additive fields without breaking external tooling.

- **[`doc/schema.md`](doc/schema.md)** documents required vs.
  optional fields per row kind, the integer `schema_version` bump
  policy (additive = optional only; adding a required field or
  promoting optional → required bumps), and the reader/writer
  contract.
- **`LeanBench/Schema.lean`** is the single source of truth for the
  `schemaVersion` constant, the canonical required/optional key
  sets, the `supportedVersions` array, `checkVersion` (strict on
  unsupported versions, lenient on missing version for back-compat),
  and the `checkKind` discriminator.
- **`Child.lean`** now emits `schema_version` and `kind` from those
  constants; in particular, parametric rows now carry
  `"kind":"parametric"` (they previously omitted the discriminator).
- **`Run.lean`** parsers now invoke `checkVersion` + `checkKind` so
  a row with an unsupported `schema_version`, or a `kind` that
  doesn't match the parser, is refused with an explicit message.
  Both parsers now also require `function` so external readers can't
  silently accept a primary-key-less row.
- **`test/LeanBenchTestSchema.lean`** is a new schema-stability test
  exe pinning the exact emitted-key set on both row kinds, the
  `schemaVersion=1` constant, `kind` enforcement, rejection of
  explicit older/newer versions and of missing required fields, and
  tolerance of unknown extra keys and missing optional keys.

## Compatibility expectations (also pinned in `doc/schema.md`)

Readers MUST accept rows whose `schema_version` is in
`supportedVersions`, reject anything outside that set with an
explicit error, treat a missing `schema_version` as v1, ignore
unknown extra keys, tolerate missing optionals, and reject a
mismatched `kind`. Writers MUST emit `schema_version`, every
required field, and a documented `status` string. Adding optional
fields does not require a version bump; adding a required field, or
promoting an optional field to required, does.

## Test plan

- [x] `lake build` — all 83 jobs green.
- [x] `./.lake/build/bin/schema_benchmark_test` — 18/18 schema
  assertions pass (canonical key set, emit shape on both kinds,
  parser tolerance + strictness, missing-required negatives,
  wrong-kind negatives, version-out-of-range negatives).
- [x] All existing tests still pass: `roundtrip`, `child_outcome`,
  `fixed`, `format`, `e2e`, `cli_errors`, `config`, `verify`,
  `kill_path`.
- [x] `fib_benchmark_example list / verify / run` smoke-test:
  example binary still produces the expected report end-to-end with
  the now-enforced `kind` discriminator.
- [ ] CI green on Linux / macOS / Windows.

🤖 Prepared with Claude Code