### PR TITLE
feat: actionable compare-divergence reports (issue #7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .lake/
 build/
 results/
+.codex

--- a/LeanBench/Compare.lean
+++ b/LeanBench/Compare.lean
@@ -38,32 +38,46 @@ private def intersectParams (lists : Array (Array Nat)) : Array Nat := Id.run do
       acc := acc.push p
   return acc
 
-/-- Compute `agreeOnCommon` from the per-function results. -/
-private def computeAgreement
+/-- Compute `agreeOnCommon` from the per-function results.
+First-divergence-first: the earliest entry in `commonParams` where
+any pair disagrees becomes `details[0]`.
+
+The `hashUnavailable` test is registration-keyed (off
+`BenchmarkResult.hashable`), not data-keyed: a hashable benchmark
+whose runs all failed before emitting a hash is NOT misreported as
+"no Hashable instance" — that would falsely point the user at the
+registration when the real issue is the run.
+
+Exposed (not `private`) so the regression test for the
+registration-keyed Hashable check can drive it without needing a
+live registry. -/
+def computeAgreement
     (results : Array BenchmarkResult)
     (commonParams : Array Nat) :
     AgreementStatus := Id.run do
+  let unhashed : Array Lean.Name := results.filterMap fun r =>
+    if !r.hashable then some r.function else none
+  if !unhashed.isEmpty then return .hashUnavailable unhashed
   -- Build (function-name × Std.HashMap Nat (Option UInt64)) per result.
   let perFn : Array (Lean.Name × Std.HashMap Nat (Option UInt64)) := results.map fun r =>
     (r.function, r.points.foldl (fun m dp => m.insert dp.param dp.resultHash) {})
-  -- A function whose return type isn't Hashable will have all `none` hashes.
-  let anyNoHash := perFn.any fun (_, m) =>
-    m.toArray.all (fun (_, h) => h.isNone)
-  if anyNoHash then return .hashUnavailable
-  let mut diverged : Array (Lean.Name × Lean.Name × Nat) := #[]
+  let mut details : Array DivergenceDetail := #[]
   for p in commonParams do
     let hashes : Array (Lean.Name × Option UInt64) := perFn.map fun (n, m) => (n, m.get! p)
     -- Skip params where any function didn't produce a hash (e.g.
     -- killed at cap before emitting). That isn't divergence, just
     -- absence of data.
     if hashes.any (fun (_, h) => h.isNone) then continue
-    if hashes.size ≥ 2 then
-      let (n₀, h₀) := hashes[0]!
-      for i in [1:hashes.size] do
-        let (nᵢ, hᵢ) := hashes[i]!
-        if hᵢ != h₀ then
-          diverged := diverged.push (n₀, nᵢ, p)
-  if diverged.isEmpty then .allAgreed else .divergedAt diverged
+    if hashes.size < 2 then continue
+    let h₀ := hashes[0]!.2.get!
+    let mut dissenters : Array Lean.Name := #[]
+    for i in [1:hashes.size] do
+      let (nᵢ, hᵢ?) := hashes[i]!
+      if hᵢ?.get! != h₀ then
+        dissenters := dissenters.push nᵢ
+    if !dissenters.isEmpty then
+      details := details.push { param := p, hashes, dissenters }
+  if details.isEmpty then .allAgreed else .divergedAt details
 
 /-- Run a `compare` over the listed benchmarks. The same `override`
 applies to every benchmark in the comparison, so e.g.
@@ -83,28 +97,36 @@ def compare (names : List Lean.Name) (override : ConfigOverride := {}) :
 /-- Hash agreement across N fixed-benchmark results. For each
     function we take the *first* `ok` hash (intra-function
     consistency is recorded separately on `FixedResult.hashesAgree`).
-    Any function without a hash → `hashUnavailable`. Otherwise we
-    pairwise compare the first function's hash against each other's;
-    mismatches collect into a `diverged` list. -/
-private def computeFixedAgreement
+    The `hashUnavailable` test is registration-keyed (off
+    `FixedResult.hashable`) — a hashable benchmark whose every
+    repeat failed is NOT misreported as "no Hashable". When all
+    declared-hashable runs at least produced one hash row each, we
+    pairwise compare the first listed function's hash against the
+    rest and pack the result into a `FixedDivergenceDetail`. -/
+def computeFixedAgreement
     (results : Array FixedResult) : FixedAgreementStatus := Id.run do
+  let unhashed : Array Lean.Name := results.filterMap fun r =>
+    if !r.hashable then some r.function else none
+  if !unhashed.isEmpty then return .hashUnavailable unhashed
   let firstHashes : Array (Lean.Name × Option UInt64) := results.map fun r =>
     let h := r.points.findSome? fun dp =>
       match dp.status, dp.resultHash with
       | .ok, some h => some h
       | _,   _      => none
     (r.function, h)
-  if firstHashes.any (fun (_, h) => h.isNone) then return .hashUnavailable
   if firstHashes.size < 2 then return .allAgreed
-  let (n₀, h₀?) := firstHashes[0]!
-  let h₀ := h₀?.get!
-  let mut diverged : Array (Lean.Name × Lean.Name) := #[]
+  -- A hashable benchmark with no successful repeats has `none` here.
+  -- Treat that as "no comparable data" rather than divergence — falling
+  -- through to the divergence loop with `none` would crash on `.get!`.
+  if firstHashes.any (fun (_, h) => h.isNone) then return .allAgreed
+  let h₀ := firstHashes[0]!.2.get!
+  let mut dissenters : Array Lean.Name := #[]
   for i in [1:firstHashes.size] do
     let (nᵢ, hᵢ?) := firstHashes[i]!
-    let hᵢ := hᵢ?.get!
-    if hᵢ != h₀ then
-      diverged := diverged.push (n₀, nᵢ)
-  if diverged.isEmpty then .allAgreed else .diverged diverged
+    if hᵢ?.get! != h₀ then
+      dissenters := dissenters.push nᵢ
+  if dissenters.isEmpty then .allAgreed
+  else .diverged { hashes := firstHashes, dissenters }
 
 /-- Run a `compare` over fixed benchmarks. -/
 def compareFixed (names : List Lean.Name)

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -269,6 +269,12 @@ structure BenchmarkResult where
       source (e.g. `"2 ^ n"`). Echoed back in the result header so
       reports stay readable without needing the env around. -/
   complexityFormula : String
+  /-- True iff the function's return type has a `Hashable` instance —
+      mirrored from `BenchmarkSpec.hashable` so cross-result tooling
+      (`compare`, exporters) can distinguish "this benchmark has no
+      Hashable instance" from "this benchmark's runs all failed
+      before a hash was emitted". -/
+  hashable   : Bool := false
   config     : BenchmarkConfig
   points     : Array DataPoint
   ratios     : Array Ratio
@@ -290,11 +296,48 @@ structure BenchmarkResult where
   spawnFloorNanos? : Option Nat := none
   deriving Inhabited, Repr
 
-/-- Whether two functions in a `compare` agree on shared params. -/
+/-- One diverging param in a `compare`: the param at which results
+disagreed, the full hash table of each compared function at that
+param (in CLI argument order, so reports can render an "all
+implementations side-by-side" view), and the names of the
+implementations whose hash differed from the baseline (the first
+entry in `hashes`). -/
+structure DivergenceDetail where
+  /-- The shared param at which the disagreement was observed. -/
+  param      : Nat
+  /-- One entry per compared function, in the order the user passed
+      them on the command line. The hash is `Option UInt64` so
+      functions that produced no hash at this param (e.g. an early
+      `killed_at_cap` row) still appear in the table — the formatter
+      shows them as `hash=—` to make the absence visible. The first
+      entry is the comparison baseline. -/
+  hashes     : Array (Lean.Name × Option UInt64)
+  /-- Names of implementations whose hash at this param differed
+      from the baseline (the first entry in `hashes`). Today's
+      agreement check is baseline-pivoted so this is exactly what's
+      computed; if a future check moves to all-pairwise comparison
+      the format would extend to a richer relation. Functions whose
+      hash was absent at this param do NOT appear here — that's
+      data missing, not data disagreeing. -/
+  dissenters : Array Lean.Name
+  deriving Inhabited, Repr
+
+/-- Whether the implementations in a `compare` agree on shared
+params. The `divergedAt` payload preserves first-divergence order:
+`details[0]` is the earliest common param where any disagreement was
+observed, so reports can highlight it as the place to start
+debugging. -/
 inductive AgreementStatus
   | allAgreed
-  | divergedAt (entries : Array (Lean.Name × Lean.Name × Nat))
-  | hashUnavailable
+  /-- One entry per diverging param. The first entry is the earliest
+      common param (in `commonParams` order) where any pair of
+      implementations disagreed. -/
+  | divergedAt (details : Array DivergenceDetail)
+  /-- Hash agreement could not be checked because at least one
+      compared function's return type lacks a `Hashable` instance.
+      The payload names the offending functions so the user knows
+      which registration to fix. -/
+  | hashUnavailable (unhashed : Array Lean.Name)
   deriving Repr, Inhabited
 
 structure ComparisonReport where
@@ -400,6 +443,11 @@ structure FixedDataPoint where
 /-- Result of a single fixed-benchmark run. -/
 structure FixedResult where
   function   : Lean.Name
+  /-- True iff the registered value's underlying type has a
+      `Hashable` instance — mirrored from `FixedSpec.hashable`. Same
+      role as on `BenchmarkResult`: distinguishes "no Hashable" from
+      "no successful repeat" in `compare` reporting. -/
+  hashable   : Bool := false
   config     : FixedBenchmarkConfig
   points     : Array FixedDataPoint
   /-- Median wall time across `ok` repeats (ns). `none` if no
@@ -415,11 +463,32 @@ structure FixedResult where
   hashesAgree  : Bool
   deriving Inhabited, Repr
 
-/-- Whether two fixed benchmarks in a `compare` agree on output. -/
+/-- A single fixed-benchmark divergence record: the per-function
+hash table (one entry per compared function, CLI argument order)
+plus the explicit list of disagreeing pairs against the first
+implementation. Mirrors `DivergenceDetail` minus the `param` field —
+fixed benchmarks have no parameter sweep. -/
+structure FixedDivergenceDetail where
+  /-- One entry per compared function, in CLI argument order. The
+      hash is the function's *first* `ok` repeat hash (intra-function
+      consistency across repeats is recorded separately on
+      `FixedResult.hashesAgree`). `none` if the function produced no
+      `ok` repeat with a hash. The first entry is the comparison
+      baseline. -/
+  hashes     : Array (Lean.Name × Option UInt64)
+  /-- Names of implementations whose first-`ok` hash differed from
+      the baseline. -/
+  dissenters : Array Lean.Name
+  deriving Inhabited, Repr
+
+/-- Whether the implementations in a fixed `compare` agree on
+output. -/
 inductive FixedAgreementStatus
   | allAgreed
-  | diverged (entries : Array (Lean.Name × Lean.Name))
-  | hashUnavailable
+  | diverged (detail : FixedDivergenceDetail)
+  /-- At least one function's return type lacks `Hashable`. The
+      payload names the offending functions. -/
+  | hashUnavailable (unhashed : Array Lean.Name)
   deriving Repr, Inhabited
 
 structure FixedComparisonReport where

--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -257,6 +257,46 @@ def fmtFixedResult (r : FixedResult) : String := Id.run do
   lines := lines.push hashLine
   return "\n".intercalate lines.toList
 
+/-- `0xDEADBEEF` rendering for an `Option UInt64`; `—` when absent
+    (e.g. a function whose return type lacks `Hashable`, or a row
+    whose child died before emitting a hash). -/
+private def fmtOptHashHex : Option UInt64 → String
+  | none   => "—"
+  | some h => s!"0x{String.ofList (Nat.toDigits 16 h.toNat)}"
+
+/-- One indented line per compared function: `<name> hash=<hex>`,
+    annotated with how it relates to the baseline (the first entry
+    in `hashes`). Used by both parametric and fixed comparison
+    reporters so the layout stays consistent.
+
+    `dissenters` is the names whose hash differed from the
+    baseline's; everyone else is silently agreeing or has no hash to
+    compare. -/
+private def fmtHashTable
+    (hashes     : Array (Lean.Name × Option UInt64))
+    (dissenters : Array Lean.Name) : Array String := Id.run do
+  if hashes.isEmpty then return #[]
+  let baselineName : Lean.Name := hashes[0]!.1
+  let dissenterSet : Std.HashSet Lean.Name :=
+    dissenters.foldl (init := {}) (fun s n => s.insert n)
+  let nameStrs : Array String := hashes.map fun (n, _) => n.toString
+  let nameWidth :=
+    nameStrs.foldl (fun m s => max m s.length) 0
+  let mut lines : Array String := #[]
+  let mut i : Nat := 0
+  for (n, h) in hashes do
+    let suffix : String :=
+      if n == baselineName && !dissenters.isEmpty then
+        "    (baseline)"
+      else if dissenterSet.contains n then
+        s!"    differs from {baselineName}"
+      else ""
+    lines := lines.push <|
+      "    " ++ rightpad nameStrs[i]! nameWidth ++
+      "  hash=" ++ fmtOptHashHex h ++ suffix
+    i := i + 1
+  return lines
+
 /-- Render a fixed-benchmark comparison report: one block per
     function plus a relative-timing line and the hash-agreement
     summary. -/
@@ -286,11 +326,19 @@ def fmtFixedComparison (rep : FixedComparisonReport) : String := Id.run do
     | none =>
       lines := lines.push s!"relative median: baseline {baseline.function} has no successful repeats"
   | none => pure ()
-  let agreeStr := match rep.agreeOnHash with
-    | .allAgreed => "all functions agree on output"
-    | .hashUnavailable => "hash unavailable for one or more functions: cannot compare outputs"
-    | .diverged entries => s!"DIVERGED on {entries.size} (function, function) pairs"
-  lines := lines.push s!"agreement: {agreeStr}"
+  match rep.agreeOnHash with
+  | .allAgreed =>
+    lines := lines.push "agreement: all functions agree on output"
+  | .hashUnavailable unhashed =>
+    let names := String.intercalate ", " (unhashed.toList.map (·.toString))
+    lines := lines.push s!"agreement: cannot check — no Hashable instance for: {names}"
+    lines := lines.push "  (register a Hashable instance on the return type to enable comparison)"
+  | .diverged detail =>
+    lines := lines.push s!"agreement: DIVERGED — implementations disagree on output:"
+    for line in fmtHashTable detail.hashes detail.dissenters do
+      lines := lines.push line
+    lines := lines.push
+      "  (only result hashes are available; see doc/quickstart.md for what to expect)"
   return "\n".intercalate lines.toList
 
 /-- Render one verify report. Passing reports render as a single
@@ -349,7 +397,15 @@ def fmtCombinedVerify (r : CombinedVerifyReports) : String := Id.run do
   return "\n".intercalate lines.toList
 
 /-- Render a `ComparisonReport` as a per-function block list plus a
-    summary noting the common-param intersection. -/
+    summary noting the common-param intersection.
+
+    On divergence, the summary is structured to be debuggable: the
+    earliest common param with disagreement is named, every compared
+    function's hash at that param is laid out side-by-side, and
+    later-diverging params are listed compactly. The hash-only
+    output is what users see today; full result previews are not
+    yet recorded — see [`doc/quickstart.md`](../../doc/quickstart.md)
+    for what to expect when only hashes are available. -/
 def fmtComparison (rep : ComparisonReport) : String := Id.run do
   let mut lines : Array String := #[]
   for r in rep.results do
@@ -357,11 +413,28 @@ def fmtComparison (rep : ComparisonReport) : String := Id.run do
     lines := lines.push ""
   let common := rep.commonParams.toList.map toString
   lines := lines.push s!"common params (apples-to-apples): {String.intercalate ", " common}"
-  let agreeStr := match rep.agreeOnCommon with
-    | .allAgreed => "all functions agree on common params"
-    | .hashUnavailable => "no Hashable instance: cannot compare outputs"
-    | .divergedAt entries => s!"DIVERGED on {entries.size} (function, function, param) triples"
-  lines := lines.push s!"agreement: {agreeStr}"
+  match rep.agreeOnCommon with
+  | .allAgreed =>
+    lines := lines.push "agreement: all functions agree on common params"
+  | .hashUnavailable unhashed =>
+    let names := String.intercalate ", " (unhashed.toList.map (·.toString))
+    lines := lines.push s!"agreement: cannot check — no Hashable instance for: {names}"
+    lines := lines.push "  (register a Hashable instance on the return type to enable comparison)"
+  | .divergedAt details =>
+    let n := details.size
+    let plural := if n == 1 then "param" else "params"
+    let first := details[0]!
+    lines := lines.push <|
+      s!"agreement: DIVERGED on {n} {plural} — earliest divergence at param={first.param}:"
+    for line in fmtHashTable first.hashes first.dissenters do
+      lines := lines.push line
+    if details.size > 1 then
+      let later := details.extract 1 details.size
+      let laterParams := String.intercalate ", "
+        (later.toList.map (fun d => toString d.param))
+      lines := lines.push s!"  also diverged at: {laterParams}"
+    lines := lines.push
+      "  (only result hashes are available; see doc/quickstart.md for what to expect)"
   return "\n".intercalate lines.toList
 
 end Format

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -561,6 +561,7 @@ def runFixedBenchmark (name : Lean.Name)
   let hashesAgree := computeHashAgreement points
   return {
     function := name
+    hashable := entry.spec.hashable
     config := cfg
     points
     medianNanos?

--- a/LeanBench/Stats.lean
+++ b/LeanBench/Stats.lean
@@ -139,6 +139,7 @@ def summarize
       spec.config.slopeTolerance spec.config.narrowRangeNoiseFloor
   { function := spec.name
   , complexityFormula := spec.complexityFormula
+  , hashable := spec.hashable
   , config := spec.config
   , points
   , ratios

--- a/PLAN.md
+++ b/PLAN.md
@@ -55,13 +55,25 @@ implementation; baseline-diff flags the regression.
 
 ## F6. Output-hash divergence reports
 
-When `compare` finds two functions disagree on `agreeOnCommon`, the
-report includes a hex preview of each function's output (or first
-N bytes if it can serialize) so the divergence is debuggable.
+The hash-only side landed in issue #7: `compare` now reports the
+earliest diverging param, names the implementations involved, lays
+the per-function hash table side-by-side, and tags each dissenter
+with the baseline it disagrees with. What's still missing is a
+*preview* of each function's actual output (first N bytes /
+serialized prefix) so the divergence is fully debuggable without
+re-running the function in a Lean file.
+
+Plan: add an optional `result_preview : string | null` field to the
+JSONL row (additive — no schema bump needed; see
+[`doc/schema.md`](doc/schema.md)), populate it from `setup_benchmark`
+when `ToString α` synthesizes (truncated to ~80 characters), and
+extend the formatter to surface the preview alongside the hash on
+the divergence line.
 
 Acceptance: comparing `goodFib` and a deliberately-buggy `goodFib'`
-emits a diff report that names both implementations and shows the
-first-diverging param.
+emits a divergence report whose earliest-divergence block carries a
+visible string preview of each implementation's return value at
+that param, in addition to the hash.
 
 ## F7. CI-budget mode
 

--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -12,8 +12,8 @@ through its own (auto-picked) ladder, then prints:
 - the `commonParams` intersection (the params at which every
   function produced an `ok` row)
 - `agreement` over those params: all agreed, diverged at specific
-  (function, function, param) triples, or hash unavailable (when at
-  least one function's return type lacks `Hashable`)
+  params, or hash unavailable (when at least one function's return
+  type lacks `Hashable`)
 
 A function whose ladder stops early (because its complexity rises
 faster) doesn't break the comparison — its rows are preserved and
@@ -23,7 +23,37 @@ The Hashable opt-in: `setup_benchmark` synthesizes `Hashable α`
 once at registration. If it succeeds, every measurement records the
 hash and `compare` checks them. If not, `runChecked` still forces
 the result (so the benchmark measures real work) but writes
-`result_hash := none`, and `compare` reports `hashUnavailable`.
+`result_hash := none`, and `compare` reports `hashUnavailable` and
+names the offending registration so you know which return type to
+fix.
+
+### Reading a divergence report
+
+When `compare` finds disagreement, the summary highlights the
+**earliest** common param at which any pair of implementations
+produced different output, lays the per-function hash table out
+side-by-side, and tags each non-baseline implementation with the
+baseline it disagrees with. The first listed implementation
+(`compare A B C` → `A`) is the comparison baseline. Example:
+
+```
+common params (apples-to-apples): 2, 4, 8
+agreement: DIVERGED on 2 params — earliest divergence at param=4:
+    Sample.linearFn  hash=0xabc    (baseline)
+    Sample.otherFn   hash=0xdef    differs from Sample.linearFn
+  also diverged at: 8
+  (only result hashes are available; see doc/quickstart.md for what to expect)
+```
+
+Hashes are reported as hex literals. The `also diverged at:` line
+lists every later common param where any pair still disagreed —
+useful for telling "one off-by-one bug at small n" from "the two
+implementations are entirely different functions". Result *previews*
+(short string snapshots of the actual return values) are not
+recorded today — the wire format only carries hashes, and a 64-bit
+hash gives no way to recover the input. See
+[quickstart.md](quickstart.md#what-compare-shows-on-divergence) for
+the recommended debugging workflow when only hashes are available.
 
 ## Reading the verdict
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -198,6 +198,48 @@ data point with `total_nanos` smaller than ~10× the spawn floor is
 noise, not algorithm data — interpret it as a lower bound, not a
 measurement.
 
+## What `compare` shows on divergence
+
+`compare A B [C …]` runs each named benchmark, intersects their
+common params, and hashes every result. When the hashes disagree
+the report highlights the earliest common param where any pair
+disagreed, lays the per-function hash table side-by-side, and tags
+each dissenting implementation with the baseline it disagrees with
+(the first listed implementation). Later disagreements appear on a
+compact `also diverged at:` line so you can tell a one-off
+mismatch from a fundamental disagreement.
+
+```
+agreement: DIVERGED on 2 params — earliest divergence at param=4:
+    MyApp.fastSort  hash=0xabc    (baseline)
+    MyApp.slowSort  hash=0xdef    differs from MyApp.fastSort
+  also diverged at: 8
+```
+
+Today only hashes are recorded — no string preview of the result is
+captured. A 64-bit hash tells you *that* two implementations
+disagree but not *what* the outputs were. The recommended workflow
+when you see a divergence:
+
+1. Note the earliest diverging param `n` and the implementations
+   involved from the report.
+2. Run each implementation directly at that input and inspect the
+   results yourself, e.g. via `#eval MyApp.fastSort (gen 4)` and
+   `#eval MyApp.slowSort (gen 4)` in a Lean file alongside the
+   benchmarks. Pick a small `n` so the output is human-readable.
+3. If the implementations take a prepared input (`with prep := …`),
+   construct that input the same way the prep does and feed it to
+   both directly.
+
+If at least one of the compared functions has a non-`Hashable`
+return type, `compare` cannot check agreement at all and reports
+`agreement: cannot check — no Hashable instance for: <name(s)>`.
+The fix is to add `deriving Hashable` (or write a manual instance)
+on the return type so the harness can record hashes. Future
+versions may add an optional preview field on top of the hashes;
+the wire format already tolerates additive optional fields without
+a schema bump (see [`schema.md`](schema.md)).
+
 ## Fixed-problem benchmarks
 
 Sometimes you don't have a parameter to walk: there's a single hard

--- a/test/LeanBenchTestE2E.lean
+++ b/test/LeanBenchTestE2E.lean
@@ -171,6 +171,73 @@ def testCompareDiverges : IO UInt32 := do
     IO.eprintln s!"expected divergence, got {repr s}"
     return 1
 
+/-- Regression: `hashUnavailable` must key off the registered
+    `Hashable` flag, not the data. A hashable benchmark whose runs
+    all failed (every row is `error` / `killed_at_cap` with
+    `resultHash := none`) used to be misreported as
+    `hashUnavailable`, falsely pointing the user at the registration.
+    This test pipes a hand-crafted pair of "all-error" hashable
+    results through `computeAgreement` and asserts the result is
+    `allAgreed` (no observed divergence), not `hashUnavailable`. -/
+def testHashUnavailableIsRegistrationKeyed : IO UInt32 := do
+  -- Two hashable benchmarks whose every row is an error row with no
+  -- hash — same-shaped data both sides, so even if a buggy check
+  -- somehow read the row data it would not see divergence.
+  let errorPoint : DataPoint :=
+    { param := 1, innerRepeats := 0, totalNanos := 0
+    , perCallNanos := 0.0, resultHash := none
+    , status := .error "synthesised for test", partOfVerdict := true }
+  let mkResult (n : Lean.Name) : BenchmarkResult :=
+    { function := n
+    , complexityFormula := "n"
+    , hashable := true
+    , config := {}
+    , points := #[errorPoint]
+    , ratios := #[]
+    , verdict := .inconclusive
+    , cMin? := none
+    , cMax? := none
+    , verdictDroppedLeading := 0
+    , slope? := none
+    , spawnFloorNanos? := none }
+  let results : Array BenchmarkResult :=
+    #[mkResult `regressionA, mkResult `regressionB]
+  match computeAgreement results #[1] with
+  | .hashUnavailable names =>
+    IO.eprintln s!"REGRESSION: hashUnavailable fired on hashable benchmarks; names={names.toList}"
+    return 1
+  | .divergedAt _ =>
+    IO.eprintln "REGRESSION: divergence reported for matching empty data"
+    return 1
+  | .allAgreed => return 0
+
+/-- Sibling regression for fixed benchmarks: a hashable
+    fixed-benchmark with no successful repeats must not be reported
+    as `hashUnavailable`. -/
+def testFixedHashUnavailableIsRegistrationKeyed : IO UInt32 := do
+  let errorRepeat : FixedDataPoint :=
+    { repeatIndex := 0, totalNanos := 0, resultHash := none
+    , status := .error "synthesised for test" }
+  let mkResult (n : Lean.Name) : FixedResult :=
+    { function := n
+    , hashable := true
+    , config := {}
+    , points := #[errorRepeat]
+    , medianNanos? := none
+    , minNanos? := none
+    , maxNanos? := none
+    , hashesAgree := true }
+  let results : Array FixedResult :=
+    #[mkResult `fixedA, mkResult `fixedB]
+  match computeFixedAgreement results with
+  | .hashUnavailable names =>
+    IO.eprintln s!"REGRESSION: fixed hashUnavailable fired on hashable benchmarks; names={names.toList}"
+    return 1
+  | .diverged _ =>
+    IO.eprintln "REGRESSION: fixed divergence reported for empty data"
+    return 1
+  | .allAgreed => return 0
+
 def testCompareAgrees : IO UInt32 := do
   -- littleFn and littleFnTwin are byte-identical, so the comparison
   -- must report agreement.
@@ -227,7 +294,11 @@ def runTests : IO UInt32 := do
       ("runBenchmark.happy", testRunBenchmarkHappyPath),
       ("runBenchmark.unregistered", testRunBenchmarkUnregistered),
       ("compare.agrees", testCompareAgrees),
-      ("compare.diverges", testCompareDiverges) ]
+      ("compare.diverges", testCompareDiverges),
+      ("compare.hashUnavailableIsRegistrationKeyed",
+        testHashUnavailableIsRegistrationKeyed),
+      ("fixedCompare.hashUnavailableIsRegistrationKeyed",
+        testFixedHashUnavailableIsRegistrationKeyed) ]
   do
     let code ← t
     if code != 0 then

--- a/test/LeanBenchTestFixed.lean
+++ b/test/LeanBenchTestFixed.lean
@@ -174,11 +174,11 @@ def testCompare : IO UInt32 := do
     return 1
   match report.agreeOnHash with
   | .allAgreed => pure ()
-  | .hashUnavailable =>
-    IO.eprintln "expected allAgreed (both benchmarks are Hashable)"
+  | .hashUnavailable unhashed =>
+    IO.eprintln s!"expected allAgreed (both benchmarks are Hashable); unhashed={unhashed.toList}"
     return 1
-  | .diverged entries =>
-    IO.eprintln s!"expected allAgreed, got divergence: {repr entries}"
+  | .diverged detail =>
+    IO.eprintln s!"expected allAgreed, got divergence: {repr detail}"
     return 1
   -- The formatter must surface the relative-timing line.
   let rendered := Format.fmtFixedComparison report

--- a/test/LeanBenchTestFormat.lean
+++ b/test/LeanBenchTestFormat.lean
@@ -77,6 +77,7 @@ private def linearPoints : Array DataPoint := #[
 private def sampleResult : BenchmarkResult :=
   { function := sampleSpec.name
   , complexityFormula := sampleSpec.complexityFormula
+  , hashable := true
   , config := sampleSpec.config
   , points := linearPoints
   , ratios := #[(2, 12.5), (4, 12.5), (8, 12.5)]
@@ -92,6 +93,7 @@ private def sampleResult : BenchmarkResult :=
 private def sampleResult2 : BenchmarkResult :=
   { function := `Sample.otherFn
   , complexityFormula := "n"
+  , hashable := true
   , config := {}
   , points := #[
       { param := 2, innerRepeats := 4, totalNanos := 200
@@ -111,10 +113,31 @@ private def sampleResult2 : BenchmarkResult :=
   , slope? := some 0.0
   , spawnFloorNanos? := none }
 
+private def sampleDivergence : DivergenceDetail :=
+  { param := 2
+  , hashes     := #[(`Sample.linearFn, some 0xabc), (`Sample.otherFn, some 0xdef)]
+  , dissenters := #[`Sample.otherFn] }
+
 private def sampleComparison : ComparisonReport :=
   { results := #[sampleResult, sampleResult2]
   , commonParams := #[2, 4, 8]
-  , agreeOnCommon := .divergedAt #[(`Sample.linearFn, `Sample.otherFn, 2)] }
+  , agreeOnCommon := .divergedAt #[sampleDivergence] }
+
+/-- Multi-divergence variant: same earliest-diverging param 2 plus
+    follow-on divergences at 4 and 8, used to pin the
+    `also diverged at:` line. -/
+private def sampleComparisonMulti : ComparisonReport :=
+  { sampleComparison with
+    agreeOnCommon := .divergedAt #[
+      sampleDivergence,
+      { sampleDivergence with param := 4 },
+      { sampleDivergence with param := 8 } ] }
+
+/-- Hash-unavailable variant: one of the compared functions has no
+    Hashable instance, so we can't check agreement at all. -/
+private def sampleComparisonHashUnavailable : ComparisonReport :=
+  { sampleComparison with
+    agreeOnCommon := .hashUnavailable #[`Sample.otherFn] }
 
 private def fixedPoints : Array FixedDataPoint := #[
   { repeatIndex := 0, totalNanos := 1_000_000
@@ -126,6 +149,7 @@ private def fixedPoints : Array FixedDataPoint := #[
 
 private def sampleFixedResult : FixedResult :=
   { function := sampleFixedSpec.name
+  , hashable := true
   , config := sampleFixedSpec.config
   , points := fixedPoints
   , medianNanos? := some 1_050_000
@@ -203,8 +227,39 @@ def testFmtComparison : IO UInt32 := do
     "  verdict: consistent with declared complexity (cMin=25.000, cMax=25.000, β=+0.000)\n" ++
     "\n" ++
     "common params (apples-to-apples): 2, 4, 8\n" ++
-    "agreement: DIVERGED on 1 (function, function, param) triples"
+    "agreement: DIVERGED on 1 param — earliest divergence at param=2:\n" ++
+    "    Sample.linearFn  hash=0xabc    (baseline)\n" ++
+    "    Sample.otherFn   hash=0xdef    differs from Sample.linearFn\n" ++
+    "  (only result hashes are available; see doc/quickstart.md for what to expect)"
   snapshot "fmtComparison" expected (Format.fmtComparison sampleComparison)
+
+/-- Multi-divergence: the earliest diverging param is highlighted
+    with a hash table; later params land on a compact summary line. -/
+def testFmtComparisonMulti : IO UInt32 := do
+  let rendered := Format.fmtComparison sampleComparisonMulti
+  let needles : List String := [
+    "DIVERGED on 3 params — earliest divergence at param=2:",
+    "Sample.linearFn  hash=0xabc    (baseline)",
+    "Sample.otherFn   hash=0xdef    differs from Sample.linearFn",
+    "also diverged at: 4, 8" ]
+  for needle in needles do
+    if !((rendered.splitOn needle).length > 1) then
+      IO.eprintln s!"FAIL fmtComparison.multi: missing '{needle}' in:\n{rendered}"
+      return 1
+  return 0
+
+/-- Hash-unavailable: the report names the offending function and
+    points the user at the fix. -/
+def testFmtComparisonHashUnavailable : IO UInt32 := do
+  let rendered := Format.fmtComparison sampleComparisonHashUnavailable
+  let needles : List String := [
+    "agreement: cannot check — no Hashable instance for: Sample.otherFn",
+    "register a Hashable instance" ]
+  for needle in needles do
+    if !((rendered.splitOn needle).length > 1) then
+      IO.eprintln s!"FAIL fmtComparison.hashUnavailable: missing '{needle}' in:\n{rendered}"
+      return 1
+  return 0
 
 def testFmtFixedResult : IO UInt32 := do
   let expected :=
@@ -297,6 +352,8 @@ def main : IO UInt32 := do
       ("fmtFixedSpec", testFmtFixedSpec),
       ("fmtResult", testFmtResult),
       ("fmtComparison", testFmtComparison),
+      ("fmtComparison.multi", testFmtComparisonMulti),
+      ("fmtComparison.hashUnavailable", testFmtComparisonHashUnavailable),
       ("fmtFixedResult", testFmtFixedResult),
       ("fmtFixedComparison", testFmtFixedComparison),
       ("fmtVerifyReport.pass", testFmtVerifyPass),


### PR DESCRIPTION
## Summary
- Replace the one-line `DIVERGED on N (function, function, param) triples` summary in `compare` with a multi-line block highlighting the **earliest common param** at which implementations disagreed, the per-function hash table laid out side-by-side (baseline tagged, dissenters annotated), and a compact `also diverged at:` line for follow-on divergences.
- Fix `hashUnavailable` to key off the registered `Hashable` flag, not data — a hashable benchmark whose every row failed is no longer misreported as "no Hashable instance."
- Add regression tests + docs (`doc/quickstart.md`, `doc/advanced.md`) explaining what users see when only hashes are available.

Closes https://github.com/kim-em/lean-bench/issues/7.

## Output before / after

Before:

```
common params (apples-to-apples): 2, 4, 8
agreement: DIVERGED on 1 (function, function, param) triples
```

After:

```
common params (apples-to-apples): 2, 4, 8
agreement: DIVERGED on 1 param — earliest divergence at param=2:
    Sample.linearFn  hash=0xabc    (baseline)
    Sample.otherFn   hash=0xdef    differs from Sample.linearFn
  (only result hashes are available; see doc/quickstart.md for what to expect)
```

## Acceptance criteria
- [x] `compare` reports the earliest shared parameter with divergence — `details[0]` in `AgreementStatus.divergedAt`, surfaced as `earliest divergence at param=N`.
- [x] The output names the implementations involved — every compared function appears in the hash table; dissenters annotated.
- [x] When result previews are available, the report includes them — conditional acceptance, see "Scope" below.
- [x] Documentation explains what users should expect when only hashes are available — `doc/quickstart.md#what-compare-shows-on-divergence`, `doc/advanced.md#reading-a-divergence-report`.

## Key changes
- `AgreementStatus.divergedAt` carries `Array DivergenceDetail` (param + per-function hash table + dissenter names) preserving first-divergence order. `FixedAgreementStatus` mirrors with `FixedDivergenceDetail`.
- `hashUnavailable (unhashed : Array Lean.Name)` now keyed off `BenchmarkResult.hashable` / `FixedResult.hashable`. Names the offending registrations.
- Snapshot test pinning the new format; e2e regression tests for the registration-keyed `hashUnavailable` check (parametric + fixed).

## Scope: previews
Result previews (string serializations of return values) are deliberately out of scope for this PR. The issue's third acceptance criterion is conditional ("when result previews are available"), and the fourth ("docs explain what users see when only hashes are available") clearly anticipates a hash-only mode as a supported state. The wire format already tolerates additive optional fields without a schema bump (see `doc/schema.md`), so adding a `result_preview` field in a follow-up PR is a clean extension. PLAN.md F6 has been updated to scope that follow-up.

## Test plan
- [x] `lake build` clean.
- [x] All 10 test executables pass: `roundtrip`, `verify`, `kill_path`, `config`, `fixed`, `child_outcome`, `format`, `e2e`, `cli_errors`, `schema`.
- [x] New format snapshot tests pin the multi-line divergence block, the `also diverged at:` follow-on, and the `hashUnavailable` payload.
- [x] New e2e regression tests confirm `hashUnavailable` does NOT fire for hashable benchmarks whose every row failed (parametric + fixed).
- [x] Codex review (https://github.com/kim-em/lean-bench/issues/7) raised the registration-keyed-Hashable concern and a `pairs` over-promise; both addressed (renamed to `dissenters`, behavior fixed, regression test added).

🤖 Prepared with Claude Code