### PR TITLE
feat: cold/warm cache execution modes (issue #12)

### DIFF
--- a/LeanBench/Child.lean
+++ b/LeanBench/Child.lean
@@ -112,6 +112,7 @@ private def jsonOptHash : Option UInt64 → String
 def emitRow
     (function : Lean.Name) (param innerRepeats totalNanos : Nat)
     (resultHash : Option UInt64) (status : Status)
+    (cacheMode : CacheMode := .warm)
     (errorMsg? : Option String := none) :
     IO Unit := do
   let perCall : Float := totalNanos.toFloat / innerRepeats.toFloat
@@ -124,6 +125,7 @@ def emitRow
       s!"\"inner_repeats\":{innerRepeats}",
       s!"\"total_nanos\":{totalNanos}",
       s!"\"per_call_nanos\":{perCall}",
+      s!"\"cache_mode\":{jsonStr cacheMode.toJsonString}",
       s!"\"result_hash\":{jsonOptHash resultHash}",
       s!"\"status\":{jsonStr status.toJsonString}",
       s!"\"error\":{jsonOptStr errorMsg?}"
@@ -135,23 +137,52 @@ def emitRow
     Catches exceptions thrown by the runner (e.g. a panicking
     function-under-test) and emits a structured `error` row so the
     parent — and `verify` in particular — can show the failure
-    reason rather than just an exit code. -/
-def runChildMode (benchName : Lean.Name) (param targetNanos : Nat) : IO UInt32 := do
+    reason rather than just an exit code.
+
+    `cacheMode` selects between two timing strategies:
+
+    - `.warm` — the autotuner picks an inner-repeat count and runs the
+      function many times in this single child process. This is the
+      v0.1 design and what `targetNanos` is calibrated against.
+    - `.cold` — skip the autotuner; run the function exactly once with
+      `inner_repeats := 1`. The parent respawns this child for every
+      ladder rung, so every measurement starts on a cache state that
+      hasn't seen the previous rung's data. `targetNanos` is unused in
+      this path; the wallclock is whatever a single call takes.
+
+    Both modes go through the same `loop` closure (built by the
+    `setup_benchmark`-generated runner), so prep / blackBox / hashing
+    behave identically — only the iteration count and timing strategy
+    differ. -/
+def runChildMode (benchName : Lean.Name) (param targetNanos : Nat)
+    (cacheMode : CacheMode := .warm) : IO UInt32 := do
   match ← findRuntimeEntry benchName with
   | none =>
     emitRow benchName param 0 0 none
       (.error s!"unregistered benchmark: {benchName}")
-      (some s!"unregistered benchmark: {benchName}")
+      (cacheMode := cacheMode)
+      (errorMsg? := some s!"unregistered benchmark: {benchName}")
     return 1
   | some entry =>
     try
       let loop ← entry.runner param
-      let (count, total, hash) ← autoTune loop targetNanos
-      emitRow benchName param count total hash .ok
+      let (count, total, hash) ← match cacheMode with
+        | .warm => autoTune loop targetNanos
+        | .cold =>
+          -- Single, untuned invocation. The closure does its own
+          -- internal timing around the inner loop body, just like the
+          -- warm path, so spawn / startup costs are excluded by the
+          -- same mechanism. We don't pay an extra warmup probe — the
+          -- whole point of cold is "this is the first call after a
+          -- fresh process".
+          let (t, h) ← loop 1
+          pure (1, t, h)
+      emitRow benchName param count total hash .ok (cacheMode := cacheMode)
       return (0 : UInt32)
     catch e =>
       let msg := s!"runner threw: {e.toString}"
-      emitRow benchName param 0 0 none (.error msg) (some msg)
+      emitRow benchName param 0 0 none (.error msg)
+        (cacheMode := cacheMode) (errorMsg? := some msg)
       return (1 : UInt32)
 
 /-! ## Fixed-benchmark child mode

--- a/LeanBench/Cli.lean
+++ b/LeanBench/Cli.lean
@@ -69,6 +69,16 @@ instance : Cli.ParseableType LeanBench.ParamSchedule where
     | "linear"   => some .linear
     | _          => none
 
+/-- A `CacheMode` `ParseableType` for `Cli`. Recognises `warm` and
+`cold`; case-insensitive so `--cache-mode COLD` works. -/
+instance : Cli.ParseableType LeanBench.CacheMode where
+  name := "CacheMode"
+  parse? s :=
+    match s.toLower with
+    | "warm" => some .warm
+    | "cold" => some .cold
+    | _      => none
+
 namespace Cli
 
 /-- Read a flag's typed value from a `Cli.Parsed` if it was passed.
@@ -90,7 +100,8 @@ def configOverrideFromParsed (p : Cli.Parsed) : ConfigOverride :=
     paramFloor?            := parsedFlag? p "param-floor" Nat
     verdictWarmupFraction? := parsedFlag? p "warmup-fraction" Float
     slopeTolerance?        := parsedFlag? p "slope-tolerance" Float
-    paramSchedule?         := parsedFlag? p "param-schedule" LeanBench.ParamSchedule }
+    paramSchedule?         := parsedFlag? p "param-schedule" LeanBench.ParamSchedule
+    cacheMode?             := parsedFlag? p "cache-mode" LeanBench.CacheMode }
 
 /-- Build a `FixedConfigOverride` from override flags. Only fields
 that share a flag namespace with parametric (`max-seconds-per-call`)
@@ -196,7 +207,9 @@ def runChildCmd (p : Cli.Parsed) : IO UInt32 := do
   else
     let param := (p.flag! "param").as! Nat
     let targetNanos := (p.flag! "target-nanos").as! Nat
-    LeanBench.runChildMode benchStr.toName param targetNanos
+    let cacheMode : CacheMode :=
+      (parsedFlag? p "cache-mode" LeanBench.CacheMode).getD .warm
+    LeanBench.runChildMode benchStr.toName param targetNanos cacheMode
 
 /-! ## Cmd tree definitions -/
 
@@ -225,6 +238,7 @@ Each missing flag leaves the declared value untouched."
     "warmup-fraction" : Float;       "Parametric only: fraction of leading ratios to drop before computing the verdict (e.g. 0.2; JSON-style numbers)."
     "slope-tolerance" : Float;       "Parametric only: verdict is `consistent` iff |β| ≤ this, where β is the log-log slope of C vs param (JSON-style numbers)."
     "param-schedule" : LeanBench.ParamSchedule;  "Parametric only: ladder shape (auto, doubling, or linear). Default auto picks doubling for polynomial growth, linear for exponential."
+    "cache-mode" : LeanBench.CacheMode;           "Parametric only: warm (default) auto-tunes inner repeats inside one child; cold respawns per measurement so cache state is not preserved across rungs. See doc/advanced.md#cache-modes."
     "repeats" : Nat;                 "Fixed only: number of measured invocations after the warmup call (default 5)."
 
   ARGS:
@@ -239,6 +253,8 @@ def childSub : Cmd := `[Cli|
     bench : String;        "Benchmark name to dispatch."
     param : Nat;           "Parametric: parameter value to invoke the function with."
     "target-nanos" : Nat;  "Parametric: inner-tuning target wall-time (ns)."
+    "cache-mode" : LeanBench.CacheMode;
+                           "Parametric: warm (default — auto-tune inside this child) or cold (single untuned invocation; parent respawns per rung)."
     fixed;                 "Fixed: dispatch the fixed-benchmark single-invocation runner instead of the parametric autotuner."
     "repeat-index" : Nat;  "Fixed: 0-based repeat index to record on the emitted JSONL row."
 ]
@@ -259,6 +275,7 @@ to every benchmark in the comparison."
     "warmup-fraction" : Float;       "Parametric only: fraction of leading ratios to drop before computing the verdict (e.g. 0.2; JSON-style numbers)."
     "slope-tolerance" : Float;       "Parametric only: verdict is `consistent` iff |β| ≤ this, where β is the log-log slope of C vs param (JSON-style numbers)."
     "param-schedule" : LeanBench.ParamSchedule;  "Parametric only: ladder shape (auto, doubling, or linear). Default auto picks doubling for polynomial growth, linear for exponential."
+    "cache-mode" : LeanBench.CacheMode;           "Parametric only: warm (default) auto-tunes inner repeats inside one child; cold respawns per measurement so cache state is not preserved across rungs. See doc/advanced.md#cache-modes."
     "repeats" : Nat;                 "Fixed only: number of measured invocations after the warmup call (default 5)."
 
   ARGS:

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -96,10 +96,14 @@ measured is the asymptotic cost of the algorithm under hot
 microarchitectural state.
 
 `.cold` respawns the child for every ladder rung and runs the
-function exactly once per spawn, so cache state is not preserved
-across measurements. What's measured includes cache refill, branch
-predictor warmup, allocator first-touch, and any per-call overhead
-the warm path amortises away.
+function exactly once per spawn, so the harness no longer
+intentionally preserves intra-child state across measurements.
+What's measured includes cache refill, branch-predictor warmup,
+allocator first-touch, and any per-call overhead the warm path
+amortises away. Note that "cold" here means "no harness-side
+warmup," not "guaranteed cold hardware" — the OS / CPU may still
+carry parts of the working set across spawns; see
+`doc/advanced.md#cache-modes`.
 
 Neither mode is "more correct" — they measure different things. Read
 the docs in `doc/advanced.md#cache-modes` for when each is

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -85,6 +85,35 @@ inductive ParamSchedule
   | auto
   deriving Inhabited, Repr, BEq
 
+/-- Cache-state policy for a parametric benchmark.
+
+`.warm` (the default) is the current behaviour: the child auto-tunes
+an inner-repeat count, runs the function many times in a single
+spawn, and reports per-call time over a steady-state batch. CPU
+caches, branch predictors, JIT-style code paths in the runtime, and
+the GC's live set are all primed across the repeats — what's
+measured is the asymptotic cost of the algorithm under hot
+microarchitectural state.
+
+`.cold` respawns the child for every ladder rung and runs the
+function exactly once per spawn, so cache state is not preserved
+across measurements. What's measured includes cache refill, branch
+predictor warmup, allocator first-touch, and any per-call overhead
+the warm path amortises away.
+
+Neither mode is "more correct" — they measure different things. Read
+the docs in `doc/advanced.md#cache-modes` for when each is
+appropriate. The wire format records the mode used on every
+parametric JSONL row so post-hoc analysis can keep them apart. -/
+inductive CacheMode
+  | warm
+  | cold
+  deriving Inhabited, Repr, BEq
+
+def CacheMode.toJsonString : CacheMode → String
+  | .warm => "warm"
+  | .cold => "cold"
+
 /-- Per-benchmark configuration. Defaults are the v0.1 contract.
 
 Override defaults in two ways:
@@ -143,6 +172,12 @@ structure BenchmarkConfig where
       the declared complexity at runtime and picks `.doubling` for
       polynomial growth, `.linear` for exponential. -/
   paramSchedule : ParamSchedule := .auto
+  /-- Cache-state policy — see `CacheMode`. `.warm` (default) is the
+      current inner-repeat-in-child design; `.cold` respawns for every
+      rung and runs the function exactly once per spawn so cache state
+      is not preserved across measurements. The two modes measure
+      different things; see `doc/advanced.md#cache-modes`. -/
+  cacheMode : CacheMode := .warm
   deriving Inhabited, Repr, BEq
 
 /-- Optional run-time overrides applied on top of a benchmark's
@@ -176,6 +211,9 @@ structure ConfigOverride where
       switches the shape (e.g. declared `.doubling`, CLI `.linear`),
       the macro-default sample count is used. -/
   paramSchedule?         : Option ParamSchedule := none
+  /-- Override the cache-state policy. CLI exposes this as
+      `--cache-mode warm|cold`. -/
+  cacheMode?             : Option CacheMode := none
   deriving Inhabited, Repr
 
 /-- Merge a CLI `paramSchedule` override on top of a declared
@@ -207,7 +245,8 @@ def ConfigOverride.apply (o : ConfigOverride) (c : BenchmarkConfig) :
     verdictWarmupFraction := o.verdictWarmupFraction?.getD c.verdictWarmupFraction
     slopeTolerance        := o.slopeTolerance?.getD        c.slopeTolerance
     killGraceMs           := o.killGraceMs?.getD           c.killGraceMs
-    paramSchedule         := mergeParamSchedule o.paramSchedule? c.paramSchedule }
+    paramSchedule         := mergeParamSchedule o.paramSchedule? c.paramSchedule
+    cacheMode             := o.cacheMode?.getD             c.cacheMode }
 
 /-- Validate a `BenchmarkConfig`. The macro accepts arbitrary user
 expressions and the CLI accepts arbitrary JSON-style numbers, so

--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -139,7 +139,11 @@ private def rawRow (cMaybe : Option Float) (dp : DataPoint) : Row :=
 numeric value bounded to 3 decimals and every column width derived
 from the data so decimal points align. -/
 def fmtResult (r : BenchmarkResult) : String := Id.run do
-  let headerLine := s!"{r.function}    expected complexity: {r.complexityFormula}"
+  let modeTag : String :=
+    match r.config.cacheMode with
+    | .warm => "warm"
+    | .cold => "cold"
+  let headerLine := s!"{r.function}    expected complexity: {r.complexityFormula}    [{modeTag} cache]"
   let ratioMap : Std.HashMap Nat Float :=
     r.ratios.foldl (fun m (p, c) => m.insert p c) {}
   let droppedParams : Array Nat :=

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -333,13 +333,26 @@ private def resolveSchedule (cfg : BenchmarkConfig) (complexity : Nat → Nat) :
 
 /-- Measure the per-spawn floor: spawn the child against the first
     available benchmark with a 1µs target. The result is dominated by
-    spawn cost when the inner work is trivial. -/
+    spawn cost when the inner work is trivial.
+
+    The probe forces `cacheMode := .warm` and `targetInnerNanos :=
+    1_000` regardless of how the first registered benchmark was
+    declared. The point of this number is to characterise the
+    harness's own startup cost — it should not vary depending on
+    whether the user happened to register a cold-mode benchmark
+    first. With warm + tiny target the autotuner converges in a
+    single iteration and the wallclock is dominated by spawn /
+    process-init / IPC, which is exactly what we want to report. -/
 def measureSpawnFloor : IO (Option Nat) := do
   let entries ← allRuntimeEntries
   if entries.isEmpty then return none
   let entry := entries[0]!
+  let probeCfg : BenchmarkConfig :=
+    { entry.spec.config with
+        targetInnerNanos := 1_000
+        cacheMode := .warm }
   let t₀ ← IO.monoNanosNow
-  let _ ← runOneBatch { entry.spec with config := { entry.spec.config with targetInnerNanos := 1_000 } } 0
+  let _ ← runOneBatch { entry.spec with config := probeCfg } 0
   let t₁ ← IO.monoNanosNow
   return some (t₁ - t₀)
 

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -147,11 +147,16 @@ def runOneBatch (spec : BenchmarkSpec) (param : Nat) : IO DataPoint := do
   let target := spec.config.targetInnerNanos
   let deadlineMs : UInt32 :=
     (spec.config.maxSecondsPerCall * 1000.0 + spec.config.killGraceMs.toFloat).toUInt32
+  -- The cache-mode flag is passed positionally (`--cache-mode warm` /
+  -- `cold`) so the child knows which timing strategy to use. The
+  -- existing `--target-nanos` is unused in cold mode but still passed
+  -- for parser symmetry.
   let args : Array String := #[
     "_child",
     "--bench", spec.name.toString (escape := false),
     "--param", toString param,
-    "--target-nanos", toString target
+    "--target-nanos", toString target,
+    "--cache-mode", spec.config.cacheMode.toJsonString
   ]
   let child ← IO.Process.spawn {
     cmd := exe

--- a/LeanBench/Schema.lean
+++ b/LeanBench/Schema.lean
@@ -62,7 +62,22 @@ def optionalCommonKeys : Array String :=
 
 /-- Optional keys emitted only on parametric rows today. -/
 def optionalParametricKeys : Array String :=
-  #["per_call_nanos"]
+  #["per_call_nanos", "cache_mode"]
+
+/-! ## Cache-mode strings
+
+Mirrors `CacheMode.toJsonString`. Pinned here so the schema-stability
+test can assert the wire-format strings without depending on the
+enum's `toJsonString` implementation. -/
+
+def cacheModeWarm : String := "warm"
+def cacheModeCold : String := "cold"
+
+/-- Every documented cache-mode string. Readers MUST accept any of
+    these as `CacheMode` values; producers MUST emit one of these
+    on parametric rows that carry `cache_mode`. -/
+def cacheModeStrings : Array String :=
+  #[cacheModeWarm, cacheModeCold]
 
 /-! ## Version handling
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -30,19 +30,20 @@ runtime looks fine.
 Acceptance: a benchmark whose function allocates a list proportional
 to `n` shows `allocBytes` growing approximately linearly.
 
-## F4. Cold vs warm cache
+## F4. Cold vs warm cache (shipped — issue #12)
 
-Config flag `coldCache : Bool := false`. When true, the parent
-respawns the child for every individual measurement (no inner
-repeats). When false (default), inner repeats happen as today.
-
-Plugs into the existing `BenchmarkConfig` / `ConfigOverride` plumbing
-shipped in #5: a new field with a sensible default, exposed via
-`setup_benchmark … where { coldCache := true }` and a matching
-`--cold-cache` CLI flag.
-
-Acceptance: a benchmark with non-trivial memory layout shows distinct
-per-call times in cold vs warm mode.
+Implemented as a `cacheMode : CacheMode` config field (`.warm` /
+`.cold`, default `.warm`) exposed via
+`setup_benchmark … where { cacheMode := .cold }` at declaration time
+and `--cache-mode warm|cold` on `run` / `compare` at run time. Cold
+mode skips the in-child auto-tuner: the child runs the function
+exactly once per spawn (`inner_repeats := 1`) and the parent
+respawns the child for every ladder rung, so cache state is not
+preserved across measurements. The emitted JSONL row carries
+`cache_mode: "warm" | "cold"` and the result table tags each block
+with `[warm cache]` / `[cold cache]`. See
+[`doc/advanced.md#cache-modes`](doc/advanced.md#cache-modes) for the
+"what is being measured?" framing.
 
 ## F5. Baseline-diff
 

--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -104,6 +104,59 @@ chronically noisier hardware.
 Together they're enough to tell "off by a polynomial factor" from
 "off by a constant factor but drifting" from "just noisy".
 
+## Cache modes
+
+`--cache-mode warm` (the default) and `--cache-mode cold` measure
+different things, and the right choice depends on what you're
+investigating. The result table tags every run with `[warm cache]` or
+`[cold cache]` and the JSONL row carries the same discriminator as
+`cache_mode: "warm" | "cold"` so post-hoc analysis can keep them
+apart.
+
+**Warm mode** is the v0.1 design. The child runs an auto-tuned
+inner-repeat loop in a single subprocess: `inner_repeats` is picked
+to land just past `targetInnerNanos / 2` of inner work. CPU caches,
+branch predictors, the runtime's adaptive code paths, and the GC's
+live set all reach steady state across the repeats. The reported
+per-call time is `total_nanos / inner_repeats` — the asymptotic cost
+of the algorithm under hot microarchitectural state. This is what
+you want when you're measuring the algorithm itself: tightening a
+hot loop, comparing two implementations, or fitting a complexity
+model.
+
+**Cold mode** respawns the child for every rung of the ladder and
+runs the function exactly once per spawn (`inner_repeats := 1`,
+`auto-tune` skipped). Each measurement starts on a process whose
+caches have not seen the previous rung's data; whatever the runtime
+amortises in the warm path you pay in full here. The reported
+per-call time includes cache refill, branch predictor warmup,
+allocator first-touch, and any per-call setup that the warm loop's
+auto-tuner would otherwise hide. This is what you want when you're
+investigating locality (does the working set fit in L1/L2?),
+first-touch costs (is page-fault overhead dominating?), or whether
+the warm steady-state numbers under-report what a real workload
+will see.
+
+The trade-off: cold measurements are noisier per data point. With
+`inner_repeats := 1`, the per-spawn floor and OS jitter both fall on
+a single sample — there is no internal averaging. The verdict's
+slope and `cMin/cMax` checks still work, but expect a wider tolerance
+band and a higher chance of the verdict landing on `inconclusive`
+purely from noise. If you're interpreting cold numbers as algorithm
+data rather than locality data, raise `--max-seconds-per-call` so
+the larger rungs run long enough to dwarf the per-spawn floor.
+
+Either mode can be pinned at declaration time
+(`where { cacheMode := .warm }` / `.cold`) or selected per-run via
+the CLI (`--cache-mode warm|cold` on `run` / `compare`). The CLI
+override layers on top of the declared mode, like every other
+config knob.
+
+When in doubt, run both: `lake exe bench run myFn --cache-mode warm`
+gives the steady-state cost; `lake exe bench run myFn --cache-mode cold`
+exposes the cold-state cost. The gap between the two is the warm-up
+budget your real workload either can or cannot afford to amortise.
+
 ## The per-spawn floor
 
 Every result includes

--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -126,16 +126,23 @@ model.
 
 **Cold mode** respawns the child for every rung of the ladder and
 runs the function exactly once per spawn (`inner_repeats := 1`,
-`auto-tune` skipped). Each measurement starts on a process whose
-caches have not seen the previous rung's data; whatever the runtime
-amortises in the warm path you pay in full here. The reported
-per-call time includes cache refill, branch predictor warmup,
-allocator first-touch, and any per-call setup that the warm loop's
-auto-tuner would otherwise hide. This is what you want when you're
-investigating locality (does the working set fit in L1/L2?),
-first-touch costs (is page-fault overhead dominating?), or whether
-the warm steady-state numbers under-report what a real workload
-will see.
+`auto-tune` skipped). The harness no longer intentionally preserves
+intra-child state across measurements; whatever the warm loop
+amortises across many iterations of one process you pay in full
+here. The reported per-call time includes cache refill of whatever
+the previous spawn evicted, branch-predictor warmup, allocator
+first-touch, and any per-call setup that the auto-tuner would hide.
+This is what you want when you're investigating locality (does the
+working set fit in L1/L2?), first-touch costs, or whether the warm
+steady-state numbers under-report what a real workload will see.
+
+Note: cold mode is "no harness-side warmup," not "guaranteed cold
+hardware." The OS can still keep recently-touched pages, the CPU
+front-end can still hold recently-decoded code, and a system under
+light load may carry parts of the working set across processes.
+Spawning a fresh process is a strong knob, not a deterministic
+flush — read it as "we are no longer doing anything to keep the
+caches warm," not "we have evicted them."
 
 The trade-off: cold measurements are noisier per data point. With
 `inner_repeats := 1`, the per-spawn floor and OS jitter both fall on

--- a/doc/pitfalls.md
+++ b/doc/pitfalls.md
@@ -274,13 +274,17 @@ What this means in practice:
   but for very fast operations on small `param` you can see flat or
   non-monotone per-call times until `param` grows past where startup
   dominates.
-- **A single child process means no warm cache between params.**
-  Each measurement is a fresh subprocess, by design (so the wall
-  cap is enforceable without external `timeout(1)`). The flip side
-  is no L1/L2 carry-over, no JIT-style steady state. If your
-  algorithm's real-world performance depends on staying warm, the
-  benchmark numbers are a lower bound on cold throughput, not a
-  prediction of hot throughput.
+- **A single child process per param means no warm cache *between*
+  params.** Each measurement is a fresh subprocess, by design (so
+  the wall cap is enforceable without external `timeout(1)`). The
+  flip side is no L1/L2 carry-over, no JIT-style steady state across
+  rungs. The default `warm` mode does still amortise within a rung —
+  the auto-tuner runs the function many times inside a single
+  spawn, so caches and branch predictors reach steady state for that
+  param. If you want the cold per-call cost (cache refill on every
+  measurement, no internal averaging), use `--cache-mode cold` and
+  read [advanced.md#cache-modes](advanced.md#cache-modes). The two
+  modes measure different things; either can be appropriate.
 
 For exponential-complexity benchmarks, the ladder shifts from
 doubling to a linear sweep over `(lastOk, firstFail)` and the

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -156,6 +156,7 @@ Available flags:
 | `--warmup-fraction`      | Float          | `verdictWarmupFraction`   |
 | `--slope-tolerance`      | Float          | `slopeTolerance`          |
 | `--param-schedule`       | ParamSchedule  | `paramSchedule`           |
+| `--cache-mode`           | CacheMode      | `cacheMode`               |
 
 `--param-schedule` accepts `auto` (default — pick from declared
 complexity), `doubling`, or `linear`. Use `--param-schedule linear`
@@ -168,6 +169,17 @@ the sample count: `--param-schedule linear` on a benchmark already
 declared with `.linear 32` keeps the declared `32`, since the flag
 only carries the schedule kind. Switching from `.auto` / `.doubling`
 to `.linear` via the CLI uses the macro-default 16 samples.
+
+`--cache-mode warm|cold` selects what is being measured. The default
+`warm` is the v0.1 design: the child auto-tunes an inner-repeat count
+and runs the function many times in a single spawn, so caches and
+branch predictors are primed across the repeats. `cold` respawns the
+child for every ladder rung and runs the function exactly once per
+spawn, so cache state is not preserved across measurements. Neither
+mode is universally better — they measure different things; see
+[advanced.md#cache-modes](advanced.md#cache-modes) for when to use
+each. Pin a benchmark in cold mode at declaration time via
+`where { cacheMode := .cold }`.
 
 `--warmup-fraction F` drops the leading `F` × ratios.size data points
 from the verdict reduction (the cold regime where per-call overhead

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -107,6 +107,7 @@ it explicitly; producing a row without `kind` is a writer bug.
 | key                | type             | meaning |
 |--------------------|------------------|---------|
 | `per_call_nanos`   | number           | `total_nanos / inner_repeats` precomputed. Derived; readers MAY recompute it from `total_nanos` and `inner_repeats` when absent. |
+| `cache_mode`       | string           | `"warm"` (auto-tuned inner repeats inside one child, the v0.1 default) or `"cold"` (single untuned invocation; the parent respawns the child for every ladder rung). Absence is tolerated for back-compat with rows produced before issue #12 and treated as `"warm"`. See [`advanced.md#cache-modes`](advanced.md#cache-modes). |
 
 ### Reserved-for-future-use fields
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -11,7 +11,7 @@ defaultTargets = [
   "fixed_benchmark_test",
   "child_outcome_benchmark_test", "format_benchmark_test",
   "e2e_benchmark_test", "cli_errors_benchmark_test",
-  "schema_benchmark_test",
+  "schema_benchmark_test", "cache_mode_benchmark_test",
 ]
 
 [[require]]
@@ -112,3 +112,8 @@ root = "LeanBenchTestCliErrors"
 name = "schema_benchmark_test"
 srcDir = "test"
 root = "LeanBenchTestSchema"
+
+[[lean_exe]]
+name = "cache_mode_benchmark_test"
+srcDir = "test"
+root = "LeanBenchTestCacheMode"

--- a/test/LeanBenchTestCacheMode.lean
+++ b/test/LeanBenchTestCacheMode.lean
@@ -1,0 +1,327 @@
+import LeanBench
+
+/-!
+# Cache-mode tests (issue #12)
+
+Pin the warm/cold execution-mode plumbing end-to-end:
+
+- `setup_benchmark … where { cacheMode := .cold }` is plumbed onto
+  the runtime spec.
+- `--cache-mode cold` round-trips through the CLI parser into a
+  `ConfigOverride`, layers correctly on top of declared config, and
+  rejects unknown spellings.
+- `ConfigOverride.apply` carries the cache mode through.
+- The child path actually behaves differently: warm produces an
+  auto-tuned `inner_repeats > 1`, cold produces `inner_repeats = 1`.
+- The emitted JSONL row carries the `cache_mode` discriminator string
+  on the parametric path.
+- Older fixtures missing `cache_mode` parse without error
+  (back-compat: it's an additive optional field).
+
+The same compiled binary acts as parent (the test driver) and child
+(when the parent's `runOneBatch` spawns it via `_child`).
+-/
+
+open LeanBench
+
+namespace LeanBench.Test.CacheMode
+
+/-- A trivially-fast `Nat → UInt64`. The benchmark is intentionally
+    cheap so warm-mode autotune ramps `inner_repeats` past 1 quickly,
+    making the warm-vs-cold count distinction observable in a fast
+    test. -/
+def cacheProbeFn (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 1
+  for _ in [0:n] do x := x ^^^ n.toUInt64
+  return x
+
+setup_benchmark cacheProbeFn n => n where {
+  maxSecondsPerCall := 0.5
+  paramCeiling := 8
+  targetInnerNanos := 50_000_000
+}
+
+/-- Same body, declared with `where { cacheMode := .cold }` so we can
+    pin the declaration-time override path without going through the
+    CLI. -/
+def cacheProbeColdFn (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 1
+  for _ in [0:n] do x := x ^^^ n.toUInt64
+  return x
+
+setup_benchmark cacheProbeColdFn n => n where {
+  maxSecondsPerCall := 0.5
+  paramCeiling := 4
+  targetInnerNanos := 50_000_000
+  cacheMode := .cold
+}
+
+end LeanBench.Test.CacheMode
+
+private def warmName : Lean.Name := `LeanBench.Test.CacheMode.cacheProbeFn
+private def coldName : Lean.Name := `LeanBench.Test.CacheMode.cacheProbeColdFn
+
+/-- Substring containment helper. -/
+private def containsSub (haystack needle : String) : Bool :=
+  ((haystack.splitOn needle).length) > 1
+
+private def expectEq {α} [BEq α] [Repr α] (label : String) (got want : α) :
+    IO UInt32 := do
+  unless got == want do
+    IO.eprintln s!"FAIL: {label}: expected {repr want}, got {repr got}"
+    return 1
+  return 0
+
+/-! ## Pure: defaults, override application, structural equalities -/
+
+def testDefaultIsWarm : IO UInt32 := do
+  let cfg : BenchmarkConfig := {}
+  expectEq "default cacheMode" cfg.cacheMode .warm
+
+def testCacheModeJsonStrings : IO UInt32 := do
+  -- Pinned wire-format strings, mirrored on `Schema.cacheModeWarm`/
+  -- `cacheModeCold` and consumed by external tools.
+  let r1 ← expectEq "warm.toJsonString" CacheMode.warm.toJsonString "warm"
+  if r1 != 0 then return r1
+  let r2 ← expectEq "cold.toJsonString" CacheMode.cold.toJsonString "cold"
+  if r2 != 0 then return r2
+  let r3 ← expectEq "schema.warm" Schema.cacheModeWarm "warm"
+  if r3 != 0 then return r3
+  let r4 ← expectEq "schema.cold" Schema.cacheModeCold "cold"
+  if r4 != 0 then return r4
+  expectEq "schema.cacheModeStrings"
+    Schema.cacheModeStrings #["warm", "cold"]
+
+def testApplyCarriesCacheMode : IO UInt32 := do
+  -- `none` keeps the declared value; `some` replaces it. Same shape
+  -- as every other `ConfigOverride.apply` field — pinning it here
+  -- guards against a copy-paste miss in `apply`.
+  let baseWarm : BenchmarkConfig := { cacheMode := .warm }
+  let baseCold : BenchmarkConfig := { cacheMode := .cold }
+  let empty : ConfigOverride := {}
+  let toCold : ConfigOverride := { cacheMode? := some .cold }
+  let toWarm : ConfigOverride := { cacheMode? := some .warm }
+  let r1 ← expectEq "empty keeps warm" (empty.apply baseWarm).cacheMode .warm
+  if r1 != 0 then return r1
+  let r2 ← expectEq "empty keeps cold" (empty.apply baseCold).cacheMode .cold
+  if r2 != 0 then return r2
+  let r3 ← expectEq "override flips warm→cold"
+    (toCold.apply baseWarm).cacheMode .cold
+  if r3 != 0 then return r3
+  expectEq "override flips cold→warm"
+    (toWarm.apply baseCold).cacheMode .warm
+
+/-! ## Declaration-time `where { cacheMode := .cold }` plumbing -/
+
+def testDeclaredCacheModeIsRegistered : IO UInt32 := do
+  match ← findRuntimeEntry coldName with
+  | none =>
+    IO.eprintln s!"FAIL: registry lookup failed for {coldName}"
+    return 1
+  | some entry =>
+    expectEq "registered cacheMode" entry.spec.config.cacheMode .cold
+
+def testDeclaredDefaultIsWarm : IO UInt32 := do
+  match ← findRuntimeEntry warmName with
+  | none =>
+    IO.eprintln s!"FAIL: registry lookup failed for {warmName}"
+    return 1
+  | some entry =>
+    expectEq "registered default cacheMode" entry.spec.config.cacheMode .warm
+
+/-! ## CLI parser round-trip -/
+
+private def parseRunArgs (argv : List String) : IO Cli.Parsed := do
+  match LeanBench.Cli.topCmd.process argv with
+  | .ok (_, parsed) => return parsed
+  | .error (_, msg) =>
+    throw <| .userError s!"unexpected parse failure for argv {argv}: {msg}"
+
+def testCliCacheModeRoundtrips : IO UInt32 := do
+  -- Both spellings, plus a case-insensitive variant, must parse into
+  -- the right `ConfigOverride`. Missing flag is `none`.
+  for (s, expected) in [("warm", CacheMode.warm),
+                        ("cold", CacheMode.cold),
+                        ("COLD", CacheMode.cold),
+                        ("Warm", CacheMode.warm)] do
+    let parsed ← parseRunArgs ["run", "cacheProbeFn", "--cache-mode", s]
+    let ovr := LeanBench.Cli.configOverrideFromParsed parsed
+    let r ← expectEq s!"--cache-mode {s}" ovr.cacheMode? (some expected)
+    if r != 0 then return r
+  -- Missing flag → none, declared default propagates.
+  let parsed ← parseRunArgs ["run", "cacheProbeFn"]
+  let ovr := LeanBench.Cli.configOverrideFromParsed parsed
+  expectEq "missing flag" ovr.cacheMode? (none : Option CacheMode)
+
+def testCliCacheModeRejectsBogus : IO UInt32 := do
+  -- An unrecognised spelling must be rejected by the parser, not
+  -- silently dropped to `none` (which would look like "use the
+  -- declared default" and confuse the user).
+  match LeanBench.Cli.topCmd.process
+      ["run", "cacheProbeFn", "--cache-mode", "lukewarm"] with
+  | .ok _ =>
+    IO.eprintln "FAIL: expected --cache-mode lukewarm to be rejected"
+    return 1
+  | .error _ => return 0
+
+def testCliCompareAcceptsCacheMode : IO UInt32 := do
+  -- The compare subcommand has its own [Cli|] flag block; the flag must
+  -- appear there too, otherwise --cache-mode is silently a `run`-only
+  -- knob.
+  let parsed ← parseRunArgs
+    ["compare", "cacheProbeFn", "cacheProbeColdFn", "--cache-mode", "cold"]
+  let ovr := LeanBench.Cli.configOverrideFromParsed parsed
+  expectEq "compare.cacheMode" ovr.cacheMode? (some CacheMode.cold)
+
+/-! ## Behavioural: the child actually behaves differently in cold mode -/
+
+/-- Spawn the cold-declared benchmark and assert the child reports
+    `inner_repeats = 1`. Warm mode would auto-tune up to a power of
+    two ≥ 2; this is the strongest cheap signal that the cold path
+    really runs. -/
+def testColdRunHasOneInnerRepeat : IO UInt32 := do
+  match ← findRuntimeEntry coldName with
+  | none =>
+    IO.eprintln s!"FAIL: {coldName} unregistered"
+    return 1
+  | some entry =>
+    let dp ← runOneBatch entry.spec 4
+    match dp.status with
+    | .ok =>
+      if dp.innerRepeats == 1 then return 0
+      IO.eprintln s!"FAIL: cold inner_repeats expected 1, got {dp.innerRepeats}"
+      return 1
+    | s =>
+      IO.eprintln s!"FAIL: cold child not ok: {repr s}"
+      return 1
+
+/-- And the warm path produces `inner_repeats > 1`, so the test isn't
+    accidentally passing because both paths happen to land on 1. -/
+def testWarmRunAutotunes : IO UInt32 := do
+  match ← findRuntimeEntry warmName with
+  | none =>
+    IO.eprintln s!"FAIL: {warmName} unregistered"
+    return 1
+  | some entry =>
+    let dp ← runOneBatch entry.spec 4
+    match dp.status with
+    | .ok =>
+      if dp.innerRepeats > 1 then return 0
+      IO.eprintln s!"FAIL: warm inner_repeats expected > 1, got {dp.innerRepeats}"
+      return 1
+    | s =>
+      IO.eprintln s!"FAIL: warm child not ok: {repr s}"
+      return 1
+
+/-- Run-time CLI override: the parametric ladder runs in cold mode
+    when the spec was declared warm but the override flips it. Mirror
+    of `testColdRunHasOneInnerRepeat` but going through `apply`. -/
+def testCliColdOverrideTakesEffect : IO UInt32 := do
+  match ← findRuntimeEntry warmName with
+  | none =>
+    IO.eprintln s!"FAIL: {warmName} unregistered"
+    return 1
+  | some entry =>
+    let cfg : BenchmarkConfig :=
+      ({ cacheMode? := some .cold } : ConfigOverride).apply entry.spec.config
+    let spec := { entry.spec with config := cfg }
+    let dp ← runOneBatch spec 4
+    match dp.status with
+    | .ok =>
+      if dp.innerRepeats == 1 then return 0
+      IO.eprintln s!"FAIL: cold-override inner_repeats expected 1, got {dp.innerRepeats}"
+      return 1
+    | s =>
+      IO.eprintln s!"FAIL: cold-override child not ok: {repr s}"
+      return 1
+
+/-! ## Wire format: cache_mode appears on emitted rows; absence is tolerated -/
+
+/-- Spawn the binary in `_child` mode with `--cache-mode cold` and
+    inspect the raw JSONL line. The point is to pin the wire-format
+    string, not the parser's view. -/
+private def spawnRawChild (args : List String) : IO String := do
+  let exe := (← IO.appPath).toString
+  let child ← IO.Process.spawn {
+    cmd := exe
+    args := args.toArray
+    stdout := .piped
+    stderr := .piped
+    stdin := .null
+  }
+  let stdout ← child.stdout.readToEnd
+  let _ ← child.wait
+  return stdout.trimAscii.toString
+
+def testEmittedRowCarriesCacheMode : IO UInt32 := do
+  for (mode, expected) in [("warm", "warm"), ("cold", "cold")] do
+    let line ← spawnRawChild
+      ["_child", "--bench", warmName.toString (escape := false),
+       "--param", "2", "--target-nanos", "1000000",
+       "--cache-mode", mode]
+    match Lean.Json.parse line with
+    | .error e =>
+      IO.eprintln s!"FAIL: row failed to parse: {e}; line: {line}"
+      return 1
+    | .ok j =>
+      match j.getObjValAs? String "cache_mode" with
+      | .ok s =>
+        unless s == expected do
+          IO.eprintln s!"FAIL: expected cache_mode={expected}, got {s}"
+          return 1
+      | .error _ =>
+        IO.eprintln s!"FAIL: row missing cache_mode field; line: {line}"
+        return 1
+  return 0
+
+def testParseToleratesMissingCacheMode : IO UInt32 := do
+  -- Hand-rolled fixtures and pre-issue-12 rows omit `cache_mode`.
+  -- The parser must still succeed (additive optional field).
+  let row :=
+    "{\"schema_version\":1,\"function\":\"foo.bar\"," ++
+    "\"param\":7,\"inner_repeats\":2,\"total_nanos\":1000," ++
+    "\"per_call_nanos\":500.0,\"status\":\"ok\"}"
+  match parseChildRow row with
+  | .error e =>
+    IO.eprintln s!"FAIL: missing cache_mode row failed to parse: {e}"
+    return 1
+  | .ok dp =>
+    expectEq "missing-cache-mode parse" dp.status .ok
+
+/-! ## Driver -/
+
+def runTests : IO UInt32 := do
+  let mut anyFail : UInt32 := 0
+  for (label, t) in
+    [ ("default.isWarm",                   testDefaultIsWarm),
+      ("jsonStrings",                      testCacheModeJsonStrings),
+      ("apply.carriesCacheMode",           testApplyCarriesCacheMode),
+      ("declared.coldRegistered",          testDeclaredCacheModeIsRegistered),
+      ("declared.defaultWarm",             testDeclaredDefaultIsWarm),
+      ("cli.cacheModeRoundtrips",          testCliCacheModeRoundtrips),
+      ("cli.cacheModeRejectsBogus",        testCliCacheModeRejectsBogus),
+      ("cli.compareAcceptsCacheMode",      testCliCompareAcceptsCacheMode),
+      ("behaviour.coldOneInnerRepeat",     testColdRunHasOneInnerRepeat),
+      ("behaviour.warmAutotunes",          testWarmRunAutotunes),
+      ("behaviour.cliColdOverride",        testCliColdOverrideTakesEffect),
+      ("wire.rowCarriesCacheMode",         testEmittedRowCarriesCacheMode),
+      ("wire.parseToleratesMissing",       testParseToleratesMissingCacheMode) ]
+  do
+    let code ← t
+    if code != 0 then
+      IO.eprintln s!"FAIL: {label}"
+      anyFail := 1
+    else
+      IO.println s!"  ok  {label}"
+  if anyFail == 0 then
+    IO.println "cache-mode tests passed"
+  return anyFail
+
+/-- The same compiled binary acts as parent (test driver) and child
+    (single-batch runner spawned by `runOneBatch` and the raw
+    `spawnRawChild` fixture). The `_child` first arg distinguishes
+    them. -/
+def main (args : List String) : IO UInt32 :=
+  match args with
+  | "_child" :: _ => LeanBench.Cli.dispatch args
+  | _ => runTests

--- a/test/LeanBenchTestCacheMode.lean
+++ b/test/LeanBenchTestCacheMode.lean
@@ -274,6 +274,91 @@ def testEmittedRowCarriesCacheMode : IO UInt32 := do
         return 1
   return 0
 
+/-! ## Edge interactions: kill cap + linear schedule -/
+
+namespace LeanBench.Test.CacheMode
+
+/-- Deliberately-slow benchmark to force the kill-on-cap path under
+    cold mode. The body burns enough CPU at `param ≥ 256` that a
+    single call exceeds 100ms; with `maxSecondsPerCall := 0` the
+    parent fires SIGTERM ~immediately. -/
+def coldKillFn (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 0
+  for _ in [0:n] do
+    for _ in [0:100_000] do
+      x := x ^^^ n.toUInt64
+  return x
+
+setup_benchmark coldKillFn n => n where { cacheMode := .cold }
+
+/-- Linear-schedule cold-mode benchmark. Tiny work so the doubling
+    probe walks past `paramCeiling` cleanly and we can observe sweep
+    rows landing on `inner_repeats = 1` even under the linear
+    bracket. -/
+def coldLinearFn (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 1
+  for _ in [0:n] do x := x ^^^ n.toUInt64
+  return x
+
+setup_benchmark coldLinearFn n => n where {
+  cacheMode := .cold
+  paramSchedule := .linear 4
+  paramCeiling := 16
+  maxSecondsPerCall := 0.5
+  targetInnerNanos := 50_000_000
+}
+
+end LeanBench.Test.CacheMode
+
+private def coldKillName : Lean.Name := `LeanBench.Test.CacheMode.coldKillFn
+private def coldLinearName : Lean.Name := `LeanBench.Test.CacheMode.coldLinearFn
+
+/-- The kill-on-cap path applies in cold mode too: the parent's
+    deadline is mode-agnostic, so a slow function under
+    `--cache-mode cold` with `maxSecondsPerCall := 0` still synthesises
+    a `killedAtCap` row rather than hanging. -/
+def testColdKillPathFires : IO UInt32 := do
+  match ← findRuntimeEntry coldKillName with
+  | none =>
+    IO.eprintln s!"FAIL: {coldKillName} unregistered"
+    return 1
+  | some entry =>
+    let tightCfg : BenchmarkConfig :=
+      { entry.spec.config with
+          maxSecondsPerCall := 0
+          killGraceMs := 100 }
+    let dp ← runOneBatch { entry.spec with config := tightCfg } 1_000_000
+    match dp.status with
+    | .killedAtCap => return 0
+    | s =>
+      IO.eprintln s!"FAIL: cold-mode kill expected killedAtCap, got {repr s}"
+      return 1
+
+/-- Cold mode under the linear schedule: every sweep row must still
+    land on `inner_repeats = 1`. Probe rows from the doubling probe
+    keep `partOfVerdict = false`; sweep rows keep `partOfVerdict =
+    true` and `inner_repeats = 1`. We don't pin which rungs land in
+    which bracket (that's the schedule's job, not the cache mode's),
+    only that no row escapes the cold path's "single invocation"
+    contract. -/
+def testColdUnderLinearScheduleSingleInvocation : IO UInt32 := do
+  let result ← runBenchmark coldLinearName
+  if result.points.isEmpty then
+    IO.eprintln "FAIL: cold+linear produced no points"
+    return 1
+  for dp in result.points do
+    -- Error / killed rows have inner_repeats = 0; ok rows MUST be 1.
+    if dp.status == .ok && dp.innerRepeats != 1 then
+      IO.eprintln s!"FAIL: cold+linear ok row has inner_repeats={dp.innerRepeats}; expected 1; row={repr dp}"
+      return 1
+  -- Sanity check: at least one ok row must be present, otherwise the
+  -- assertion above is vacuous.
+  let okCount := result.points.filter (·.status == .ok) |>.size
+  if okCount == 0 then
+    IO.eprintln s!"FAIL: cold+linear had no ok rows; points={repr result.points}"
+    return 1
+  return 0
+
 def testParseToleratesMissingCacheMode : IO UInt32 := do
   -- Hand-rolled fixtures and pre-issue-12 rows omit `cache_mode`.
   -- The parser must still succeed (additive optional field).
@@ -304,6 +389,8 @@ def runTests : IO UInt32 := do
       ("behaviour.coldOneInnerRepeat",     testColdRunHasOneInnerRepeat),
       ("behaviour.warmAutotunes",          testWarmRunAutotunes),
       ("behaviour.cliColdOverride",        testCliColdOverrideTakesEffect),
+      ("edges.coldKillPathFires",          testColdKillPathFires),
+      ("edges.coldLinearSingleInvocation", testColdUnderLinearScheduleSingleInvocation),
       ("wire.rowCarriesCacheMode",         testEmittedRowCarriesCacheMode),
       ("wire.parseToleratesMissing",       testParseToleratesMissingCacheMode) ]
   do

--- a/test/LeanBenchTestFormat.lean
+++ b/test/LeanBenchTestFormat.lean
@@ -202,7 +202,7 @@ def testFmtFixedSpec : IO UInt32 := do
 
 def testFmtResult : IO UInt32 := do
   let expected :=
-    "Sample.linearFn    expected complexity: n\n" ++
+    "Sample.linearFn    expected complexity: n    [warm cache]\n" ++
     "  param  per-call    repeats  C\n" ++
     "      2   25.000 ns  ×2^2     C=12.500\n" ++
     "      4   50.000 ns  ×2^2     C=12.500\n" ++
@@ -210,16 +210,32 @@ def testFmtResult : IO UInt32 := do
     "  verdict: consistent with declared complexity (cMin=12.500, cMax=12.500, β=+0.000)"
   snapshot "fmtResult" expected (Format.fmtResult sampleResult)
 
+/-- Cold-mode snapshot. Exercises the same code path as `fmtResult`
+    above, but with the `[cold cache]` tag swapped in. Pinned so a
+    silent regression that drops the cold tag (or accidentally tags
+    every result as warm) breaks here. -/
+def testFmtResultCold : IO UInt32 := do
+  let coldResult : BenchmarkResult :=
+    { sampleResult with config := { sampleResult.config with cacheMode := .cold } }
+  let expected :=
+    "Sample.linearFn    expected complexity: n    [cold cache]\n" ++
+    "  param  per-call    repeats  C\n" ++
+    "      2   25.000 ns  ×2^2     C=12.500\n" ++
+    "      4   50.000 ns  ×2^2     C=12.500\n" ++
+    "      8  100.000 ns  ×2^2     C=12.500\n" ++
+    "  verdict: consistent with declared complexity (cMin=12.500, cMax=12.500, β=+0.000)"
+  snapshot "fmtResult.cold" expected (Format.fmtResult coldResult)
+
 def testFmtComparison : IO UInt32 := do
   let expected :=
-    "Sample.linearFn    expected complexity: n\n" ++
+    "Sample.linearFn    expected complexity: n    [warm cache]\n" ++
     "  param  per-call    repeats  C\n" ++
     "      2   25.000 ns  ×2^2     C=12.500\n" ++
     "      4   50.000 ns  ×2^2     C=12.500\n" ++
     "      8  100.000 ns  ×2^2     C=12.500\n" ++
     "  verdict: consistent with declared complexity (cMin=12.500, cMax=12.500, β=+0.000)\n" ++
     "\n" ++
-    "Sample.otherFn    expected complexity: n\n" ++
+    "Sample.otherFn    expected complexity: n    [warm cache]\n" ++
     "  param  per-call    repeats  C\n" ++
     "      2   50.000 ns  ×2^2     C=25.000\n" ++
     "      4  100.000 ns  ×2^2     C=25.000\n" ++
@@ -351,6 +367,7 @@ def main : IO UInt32 := do
       ("fmtSpec.noHash", testFmtSpecNoHash),
       ("fmtFixedSpec", testFmtFixedSpec),
       ("fmtResult", testFmtResult),
+      ("fmtResult.cold", testFmtResultCold),
       ("fmtComparison", testFmtComparison),
       ("fmtComparison.multi", testFmtComparisonMulti),
       ("fmtComparison.hashUnavailable", testFmtComparisonHashUnavailable),

--- a/test/LeanBenchTestSchema.lean
+++ b/test/LeanBenchTestSchema.lean
@@ -196,7 +196,7 @@ def testCanonicalKeyConstants : IO UInt32 := do
   let okOptCommon :=
     Schema.optionalCommonKeys == #["kind", "result_hash", "error"]
   let okOptParametric :=
-    Schema.optionalParametricKeys == #["per_call_nanos"]
+    Schema.optionalParametricKeys == #["per_call_nanos", "cache_mode"]
   let okStatus :=
     Schema.statusStrings ==
       #["ok", "timed_out", "killed_at_cap", "error"]


### PR DESCRIPTION
## Summary

Adds a `cacheMode : CacheMode := .warm` field to `BenchmarkConfig` (plus a matching `--cache-mode warm|cold` CLI flag) so users can opt into cold-cache measurement on the parametric path. Closes [#12](https://github.com/kim-em/lean-bench/issues/12).

- `warm` (default) is the v0.1 design: the child auto-tunes an inner-repeat count and runs the function many times in a single spawn — caches and branch predictors reach steady state across the repeats.
- `cold` skips the autotuner: the child runs the function exactly once (`inner_repeats := 1`) and the parent respawns the child for every ladder rung, so no intra-child state is preserved across measurements.

The chosen mode appears as a `[warm cache]` / `[cold cache]` tag in the result block and as `cache_mode: "warm" | "cold"` on every parametric JSONL row (additive optional field — no schema bump, back-compat parser tolerates legacy rows missing it).

## Plumbing

- New `CacheMode` inductive in `LeanBench.Core` with a `toJsonString` helper. `BenchmarkConfig.cacheMode` defaults to `.warm`. `ConfigOverride.cacheMode?` layers via `apply` and is built from `--cache-mode` by `configOverrideFromParsed`.
- `Run.runOneBatch` adds `--cache-mode <mode>` to the child argv.
- `Child.runChildMode` takes a `CacheMode`; in `.cold` it bypasses `autoTune` and calls `loop 1` directly. `emitRow` writes the `cache_mode` field on every parametric row.
- `Schema` registers `cache_mode` in `optionalParametricKeys` and exposes `cacheModeWarm` / `cacheModeCold` / `cacheModeStrings`.
- `Format.fmtResult` includes the cache-mode tag in the header.
- `measureSpawnFloor` forces `.warm` + `targetInnerNanos := 1_000` on the probe so the harness self-measurement doesn't drift when the first registered benchmark happens to be cold.

## Tests

New `test/LeanBenchTestCacheMode.lean`:

- defaults are `.warm`; pinned wire strings (`warm`, `cold`)
- `ConfigOverride.apply` carries the mode through
- `where { cacheMode := .cold }` lands on the registry
- `--cache-mode warm|cold|COLD|Warm` round-trips through both `run` and `compare`; `--cache-mode lukewarm` is rejected
- behavioural check: warm autotunes `inner_repeats > 1`, cold lands on exactly `1`
- a CLI cold override on a warm-declared benchmark takes effect
- the `cache_mode` field actually appears on the emitted JSONL row
- legacy rows missing `cache_mode` still parse (additive field)
- cold-mode kill-on-cap fires (parent deadline is mode-agnostic)
- cold-mode under `.linear` schedule still produces only `inner_repeats := 1` ok rows

`test/LeanBenchTestFormat.lean` gets a new `fmtResult.cold` snapshot, and the existing snapshots are updated to include the `[warm cache]` tag.

## Documentation

- `doc/advanced.md` gets a new "Cache modes" section explaining the trade-off and when to use each. The wording is deliberately framed as "what is being measured" rather than "which mode is better."
- `doc/quickstart.md` adds `--cache-mode` to the CLI flag table and a paragraph.
- `doc/pitfalls.md`'s warm/cold caveat now points at the new section and is amended for accuracy.
- `doc/schema.md` documents `cache_mode` as an additive optional parametric field.
- `PLAN.md` marks F4 as shipped.

## Review

Got a second-opinion pass from Codex; addressed all blocking and nice-to-have feedback in commit bfa12cf (stale format snapshots, the `measureSpawnFloor` interaction, softened "cold" wording, and cold+kill / cold+linear edge tests).

## Test plan

- [x] `lake build` clean
- [x] `cache_mode_benchmark_test` passes (15 sub-tests)
- [x] `format_benchmark_test` passes (snapshots updated, including a cold-mode pin)
- [x] every existing test exe (roundtrip / kill-path / config / fixed / child-outcome / cli-errors / verify / e2e / schema) still passes
- [x] manual end-to-end: `lake exe fib_benchmark_example run goodFib --cache-mode warm` and `--cache-mode cold` both produce the right tag and visibly different per-call profiles

🤖 Prepared with Claude Code
