### PR TITLE
feat: edge-case advisories + custom ladder for fast/slow benchmarks (issue #15)

### DIFF
--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -1,4 +1,5 @@
 import Lean.Data.Name
+import Std.Data.HashSet
 
 /-!
 # `LeanBench.Core` — shared types
@@ -46,6 +47,16 @@ structure DataPoint where
       else, including all rows in `.doubling` mode. Parent-side only —
       not serialized in the child JSONL. -/
   partOfVerdict : Bool := true
+  /-- True when this row's `totalNanos` is below
+      `signalFloorMultiplier × spawnFloorNanos`, i.e. the entire
+      measurement is small enough that subprocess-spawn cost dominates
+      the inner-loop work. Such rows are unreliable as algorithm
+      timing data — they are excluded from the verdict reduction
+      (see `Stats.ratiosFromPoints`) and rendered with a `[<floor]`
+      annotation in the report. Parent-side only; computed after the
+      spawn-floor self-measurement so the child JSONL can stay
+      schema-stable. -/
+  belowSignalFloor : Bool := false
   deriving Repr, Inhabited
 
 /-- Heuristic verdict — see SPEC v0.1: weak labels by design. Decided
@@ -74,14 +85,24 @@ def Verdict.describe : Verdict → String
     run inside that bracket so the high-`n` regime where the model
     dominates overhead is well-sampled.
 
+    `.custom` runs an explicit user-specified list of params, in
+    order, with no doubling probe and no auto-bracketing. Right for
+    workloads where the natural inputs are non-uniform (e.g. file
+    sizes from a corpus) or where the user already knows which
+    `n` matter — see issue #15. The harness still applies the
+    wallclock cap and stops as soon as a row hits it.
+
     `.auto` is the default — at runtime it inspects the declared
-    complexity and resolves to one of the above. The heuristic
-    compares `complexity(2n)/complexity(n)` at two scales: for any
-    `n^k` it is constant (→ doubling); for any `b^n` it grows
-    geometrically (→ linear). -/
+    complexity and resolves to `.doubling` or `.linear`. The
+    heuristic compares `complexity(2n)/complexity(n)` at two scales:
+    for any `n^k` it is constant (→ doubling); for any `b^n` it
+    grows geometrically (→ linear). `.custom` is never auto-picked;
+    it is opt-in only via declaration-time
+    `where { paramSchedule := .custom #[...] }`. -/
 inductive ParamSchedule
   | doubling
   | linear (samples : Nat := 16)
+  | custom (params : Array Nat)
   | auto
   deriving Inhabited, Repr, BEq
 
@@ -182,6 +203,17 @@ structure BenchmarkConfig where
       is not preserved across measurements. The two modes measure
       different things; see `doc/advanced.md#cache-modes`. -/
   cacheMode : CacheMode := .warm
+  /-- Multiplier on the per-spawn floor below which a row's
+      `totalNanos` is treated as dominated by subprocess overhead
+      rather than algorithm work. Rows below this threshold are
+      flagged `belowSignalFloor` (rendered with a `[<floor]`
+      annotation) and excluded from the verdict reduction. Default
+      `10.0` matches the rule of thumb in `doc/quickstart.md` ("any
+      data point with total_nanos smaller than ~10× the spawn floor
+      is noise"). Set to `1.0` to disable the check (every row is
+      retained); values ≤ 0 are rejected by `validate`. See issue
+      #15 for the design discussion. -/
+  signalFloorMultiplier : Float := 10.0
   deriving Inhabited, Repr, BEq
 
 /-- Optional run-time overrides applied on top of a benchmark's
@@ -272,6 +304,24 @@ def BenchmarkConfig.validate (c : BenchmarkConfig) : Except String Unit := do
     .error s!"BenchmarkConfig.verdictWarmupFraction must be in [0, 1); got {c.verdictWarmupFraction}"
   unless c.paramFloor ≤ c.paramCeiling do
     .error s!"BenchmarkConfig.paramFloor must be ≤ paramCeiling; got {c.paramFloor} > {c.paramCeiling}"
+  unless c.signalFloorMultiplier ≥ 1.0 do
+    .error s!"BenchmarkConfig.signalFloorMultiplier must be ≥ 1.0; got {c.signalFloorMultiplier}"
+  -- A `.custom` ladder with an empty params list is almost certainly
+  -- a typo (and would produce an empty result); reject up front.
+  -- Duplicate params are also rejected: the formatter keys the `C`
+  -- column and the warmup-trim dagger by `param`, so two rows with
+  -- the same param would render with the same `C` (and either both
+  -- or neither carry the dagger). That makes the report misleading
+  -- even when the underlying measurements are fine. Codex flagged
+  -- this in the issue #15 review.
+  match c.paramSchedule with
+  | .custom ps =>
+    unless ps.size > 0 do
+      .error s!"BenchmarkConfig.paramSchedule = .custom #[] is empty; supply at least one param"
+    let dedup : Std.HashSet Nat := ps.foldl (·.insert ·) {}
+    unless dedup.size == ps.size do
+      .error s!"BenchmarkConfig.paramSchedule = .custom contains duplicate params; got {ps}"
+  | _ => pure ()
   pure ()
 
 /-- One entry in the benchmark registry. Stored as `Name`s plus a
@@ -305,6 +355,45 @@ structure BenchmarkSpec where
   for the verdict. -/
 abbrev Ratio := Nat × Float
 
+/-- Edge-case classifications surfaced on `BenchmarkResult.advisories`.
+Pure data — the format layer turns each into an actionable message.
+
+A single result may carry multiple advisories: e.g. a benchmark whose
+function is too fast AND whose ladder hit the cap on the largest rung
+gets both `belowSignalFloor` and `truncatedAtCap`. The advisories are
+not mutually exclusive and the format renders them in declaration
+order. See issue #15.
+
+Parent-side only; not serialized in the child JSONL row. -/
+inductive Advisory
+  /-- Every successful row was below the signal-floor threshold —
+      total wall time was dominated by per-spawn overhead, not the
+      algorithm under test. The verdict cannot be trusted; the
+      benchmark is too fast for child-process measurement at the
+      configured params. -/
+  | belowSignalFloor
+  /-- `n` rows out of total `total` were below the signal-floor
+      threshold but at least one row above it survived. The verdict
+      is computed on the surviving rows; the cold leading rungs are
+      noted for context. -/
+  | partiallyBelowSignalFloor (n total : Nat)
+  /-- Every measurement hit the wallclock cap (timed-out or
+      killed-at-cap) — no `ok` row landed at all. The benchmark is
+      too slow at the configured params; bump `--max-seconds-per-call`
+      or lower `--param-ceiling`. -/
+  | allCapped
+  /-- The ladder produced at least one `ok` row but was truncated by
+      the wallclock cap before reaching `paramCeiling`. The
+      `firstFail` param is the rung that was killed; the trimmed
+      tail above it was never measured. -/
+  | truncatedAtCap (firstFail : Nat)
+  /-- After applying both the warmup trim and the signal-floor
+      filter, fewer than 3 rows remain — the verdict reduction has
+      no resolution. Either the ladder is too short or every rung
+      is in an edge regime. -/
+  | tooFewVerdictRows (kept : Nat)
+  deriving Repr, Inhabited, BEq
+
 /-- Result of a single benchmark invocation. -/
 structure BenchmarkResult where
   function   : Lean.Name
@@ -337,6 +426,12 @@ structure BenchmarkResult where
   /-- The harness's own per-spawn floor at the time of this run, for
       comparison against the smallest `totalNanos` recorded. -/
   spawnFloorNanos? : Option Nat := none
+  /-- Edge-case advisories surfaced for this run — see `Advisory`.
+      Empty when the run looks ordinary (most rows above the signal
+      floor, none capped, the ladder ran to completion). The format
+      layer renders these as a hint section after the verdict line.
+      Issue #15. -/
+  advisories : Array Advisory := #[]
   deriving Inhabited, Repr
 
 /-- One diverging param in a `compare`: the param at which results

--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -125,15 +125,51 @@ private def rawRow (cMaybe : Option Float) (dp : DataPoint) : Row :=
   -- Doubling probe rows in `.linear` mode are demoted from the
   -- verdict; mark them so a row with valid timing but `C=—` doesn't
   -- look like a measurement failure.
-  let status :=
+  let probeMarked :=
     if dp.status == .ok && !dp.partOfVerdict then baseStatus ++ " [probe]"
     else baseStatus
+  -- Below-signal-floor rows are excluded from the verdict because
+  -- their per-call time is dominated by subprocess overhead — flag
+  -- them so users see why `C=—` for an `ok` row. Issue #15.
+  let status :=
+    if dp.belowSignalFloor then probeMarked ++ " [<floor]"
+    else probeMarked
   { param       := fmtNatUnderscores dp.param
     perCallNum  := num
     perCallUnit := unit
     repeats     := fmtRepeats dp.innerRepeats
     cStr
     status }
+
+/-- Suggestion suffix used in several advisories. Pinned here so the
+    `where { ... }` literal stays out of `s!"..."` interpolation
+    (Lean's interpolation grammar reserves `{` / `}`). -/
+private def customScheduleHint : String :=
+  "use `where { paramSchedule := .custom #[...] }` to pin a tractable rung set"
+
+/-- Render one `Advisory` for a result as a single advisory line.
+Each message is structured as `‼ <symptom>; <suggestion>` so users
+see both why the harness is concerned and what knob to turn next.
+Issue #15. -/
+private def fmtAdvisory (r : BenchmarkResult) : Advisory → String
+  | .belowSignalFloor =>
+    let floorStr := match r.spawnFloorNanos? with
+      | some n => s!" (per-spawn floor ≈ {fmtNanosStr n})"
+      | none => ""
+    s!"  ‼ every measurement was below {fmtFloat3 r.config.signalFloorMultiplier}× the per-spawn floor{floorStr}; the function is too fast for child-process measurement at the configured params. Try `--param-ceiling` higher, wrap the function in a hot inner loop, or use `setup_fixed_benchmark` for a single-shot reading."
+  | .partiallyBelowSignalFloor n total =>
+    s!"  ‼ {n}/{total} ok rows were below {fmtFloat3 r.config.signalFloorMultiplier}× the per-spawn floor; those rungs are excluded from the verdict. Raise `--param-floor` to skip the cold regime if the trimmed warmup isn't enough."
+  | .allCapped =>
+    s!"  ‼ every measurement hit the wallclock cap (`maxSecondsPerCall = {fmtFloat3 r.config.maxSecondsPerCall}s`); no `ok` row landed. The benchmark is too slow at the configured params. Bump `--max-seconds-per-call`, lower `--param-ceiling`, or " ++ customScheduleHint ++ "."
+  | .truncatedAtCap p =>
+    -- Phrased order-agnostically: "later rungs were skipped" works
+    -- for the doubling/linear ladders (ascending) and for `.custom`
+    -- (whatever order the user listed). Codex flagged that
+    -- "no rungs above this point" was misleading for sparse / non-
+    -- monotone custom ladders.
+    s!"  ‼ ladder stopped at param={p} after hitting the wallclock cap (`maxSecondsPerCall = {fmtFloat3 r.config.maxSecondsPerCall}s`); subsequent rungs in the schedule were skipped. Raise the cap if you need to reach further, or " ++ customScheduleHint ++ "."
+  | .tooFewVerdictRows kept =>
+    s!"  ‼ only {kept} verdict-eligible row(s) survived warmup-trim + signal-floor filter; the verdict is below resolution. Lower `--warmup-fraction`, raise `--param-ceiling`, or " ++ customScheduleHint ++ "."
 
 /-- Render one `BenchmarkResult` as a multi-line block with every
 numeric value bounded to 3 decimals and every column width derived
@@ -206,6 +242,8 @@ def fmtResult (r : BenchmarkResult) : String := Id.run do
   | some n =>
     lines := lines.push s!"  per-spawn floor (harness self-measurement): {fmtNanosStr n}"
   | none => pure ()
+  for adv in r.advisories do
+    lines := lines.push (fmtAdvisory r adv)
   return "\n".intercalate lines.toList
 
 /-- One-line summary of a registered benchmark, used by `list`. -/

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -322,14 +322,43 @@ private def runDoublingProbe (spec : BenchmarkSpec) :
     | _   => firstFail := some param
   return (points, lastOk, firstFail)
 
-/-- Resolve `.auto` to either `.doubling` or a sensible `.linear`. -/
+/-- Resolve `.auto` to either `.doubling` or a sensible `.linear`.
+    `.custom` and the explicit shapes pass through unchanged. -/
 private def resolveSchedule (cfg : BenchmarkConfig) (complexity : Nat → Nat) :
     ParamSchedule :=
   match cfg.paramSchedule with
   | .doubling => .doubling
   | .linear samples => .linear samples
+  | .custom params => .custom params
   | .auto =>
     if autoPicksLinear complexity then .linear 16 else .doubling
+
+/-- Annotate every point with `belowSignalFloor` based on the
+    measured per-spawn floor. A row crosses the threshold when its
+    `totalNanos` is below `multiplier × spawnFloor` — small enough
+    that subprocess overhead dominates the inner-loop work and the
+    measurement is unreliable as algorithm timing.
+
+    `multiplier ≤ 1.0` disables the check (every row is left
+    unflagged); `spawnFloorNanos = 0` (or `none`) likewise leaves
+    everything unflagged because we have no reference to compare
+    against. Issue #15. -/
+def annotateBelowSignalFloor (multiplier : Float)
+    (spawnFloorNanos? : Option Nat) (points : Array DataPoint) :
+    Array DataPoint :=
+  match spawnFloorNanos? with
+  | none => points
+  | some sf =>
+    if multiplier ≤ 1.0 || sf == 0 then points
+    else
+      let threshold : Float := multiplier * sf.toFloat
+      points.map fun dp =>
+        match dp.status with
+        | .ok =>
+          if dp.totalNanos.toFloat < threshold then
+            { dp with belowSignalFloor := true }
+          else dp
+        | _ => dp
 
 /-- Measure the per-spawn floor: spawn the child against the first
     available benchmark with a 1µs target. The result is dominated by
@@ -376,42 +405,59 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
   | .ok () => pure ()
   let spec := { entry.spec with config := cfg }
   let schedule := resolveSchedule cfg entry.complexity
-  let (probePoints, lastOk?, firstFail?) ← runDoublingProbe spec
-  let mut points := probePoints
+  -- `.custom` skips the doubling probe entirely — we walk the
+  -- user-supplied params in order and stop when one hits the cap.
+  -- For all other schedules the probe runs first and then optionally
+  -- a linear bracket sweep is added.
+  let mut points : Array DataPoint := #[]
   match schedule with
-  | .doubling => pure ()
-  | .auto => pure ()  -- unreachable after resolveSchedule
-  | .linear samples =>
-    match lastOk?, firstFail? with
-    | some lastOk, some firstFail =>
-      -- Tighten the bracket using the complexity model + observed
-      -- cost at `lastOk`, so we don't burn the sweep budget on rungs
-      -- that are guaranteed to hit the cap.
-      let lastOkPerCall : Float :=
-        (probePoints.findSome? fun dp =>
-            if dp.param == lastOk && dp.status == .ok then
-              some dp.perCallNanos
-            else none).getD 0.0
-      let capNanos : Float := cfg.maxSecondsPerCall * 1.0e9
-      let effFirstFail :=
-        estimateFirstFail entry.complexity lastOk lastOkPerCall
-          capNanos firstFail
-      let rungs := pickLinearRungs lastOk effFirstFail samples
-      if !rungs.isEmpty then
-        -- Probe rows are bracket-finding only; demote them so they
-        -- don't enter `cMin`/`cMax`/slope.
-        points := points.map ({ · with partOfVerdict := false })
-        for n in rungs do
-          let dp ← runOneBatch spec n
-          points := points.push dp
-          if dp.status != .ok then break
-    | _, _ =>
-      -- No bracket (doubling ran clean to ceiling, or first rung failed).
-      -- Fall back to doubling-only — probe rows already have
-      -- `partOfVerdict := true`.
-      pure ()
+  | .custom params =>
+    for n in params do
+      let dp ← runOneBatch spec n
+      points := points.push dp
+      if dp.status != .ok then break
+  | _ =>
+    let (probePoints, lastOk?, firstFail?) ← runDoublingProbe spec
+    points := probePoints
+    match schedule with
+    | .doubling => pure ()
+    | .custom _ => pure ()  -- unreachable in this branch
+    | .auto => pure ()  -- unreachable after resolveSchedule
+    | .linear samples =>
+      match lastOk?, firstFail? with
+      | some lastOk, some firstFail =>
+        -- Tighten the bracket using the complexity model + observed
+        -- cost at `lastOk`, so we don't burn the sweep budget on rungs
+        -- that are guaranteed to hit the cap.
+        let lastOkPerCall : Float :=
+          (probePoints.findSome? fun dp =>
+              if dp.param == lastOk && dp.status == .ok then
+                some dp.perCallNanos
+              else none).getD 0.0
+        let capNanos : Float := cfg.maxSecondsPerCall * 1.0e9
+        let effFirstFail :=
+          estimateFirstFail entry.complexity lastOk lastOkPerCall
+            capNanos firstFail
+        let rungs := pickLinearRungs lastOk effFirstFail samples
+        if !rungs.isEmpty then
+          -- Probe rows are bracket-finding only; demote them so they
+          -- don't enter `cMin`/`cMax`/slope.
+          points := points.map ({ · with partOfVerdict := false })
+          for n in rungs do
+            let dp ← runOneBatch spec n
+            points := points.push dp
+            if dp.status != .ok then break
+      | _, _ =>
+        -- No bracket (doubling ran clean to ceiling, or first rung failed).
+        -- Fall back to doubling-only — probe rows already have
+        -- `partOfVerdict := true`.
+        pure ()
   let spawnFloor ← measureSpawnFloor
-  let summary := Stats.summarize spec entry.complexity points
+  -- Annotate below-floor rows BEFORE summarising so the verdict
+  -- ratios and the advisory list see the same filtered view.
+  let annotated :=
+    annotateBelowSignalFloor cfg.signalFloorMultiplier spawnFloor points
+  let summary := Stats.summarize spec entry.complexity annotated
   return { summary with spawnFloorNanos? := spawnFloor }
 
 /-! ## Fixed-benchmark orchestration -/

--- a/LeanBench/Stats.lean
+++ b/LeanBench/Stats.lean
@@ -19,8 +19,10 @@ namespace Stats
 
 /-- Compute the per-point ratio C = perCallNanos / complexity(param).
     Skips param=0 and param=1 (denominator may be 0 or 1, noisy),
-    any non-`ok` data points, and any rows flagged as not part of
-    the verdict (doubling-probe rows in `.linear` mode). -/
+    any non-`ok` data points, any rows flagged as not part of the
+    verdict (doubling-probe rows in `.linear` mode), and any rows
+    whose total wall time was dominated by spawn overhead
+    (`belowSignalFloor` — see issue #15). -/
 def ratiosFromPoints
     (complexity : Nat → Nat)
     (points : Array DataPoint) :
@@ -30,6 +32,7 @@ def ratiosFromPoints
     if dp.param < 2 then continue
     if dp.status != .ok then continue
     if !dp.partOfVerdict then continue
+    if dp.belowSignalFloor then continue
     let d := complexity dp.param
     if d == 0 then continue
     acc := acc.push (dp.param, dp.perCallNanos / d.toFloat)
@@ -127,7 +130,65 @@ def deriveVerdict (ratios : Array Ratio)
           else .inconclusive
     (v, some cMin, some cMax, slope?, dropCount)
 
-/-- Build a `BenchmarkResult` from spec + complexity closure + collected points. -/
+/-- Compute the `Advisory` array for a result, given the post-spawn-floor
+    annotated points. Pure — exposed so `runBenchmark` can call it once
+    `belowSignalFloor` flags are settled, and so unit tests can drive
+    it without spawning subprocesses.
+
+    Order matters: a single result can carry multiple advisories
+    (e.g. `belowSignalFloor` + `truncatedAtCap`); the format renders
+    them in the order produced here, which matches the order users
+    typically want to see them — global quality issues first
+    (everything below floor / everything capped), then partial /
+    structural issues (some below floor, ladder truncated, too few
+    verdict rows). -/
+def computeAdvisories (points : Array DataPoint) (verdictRows : Nat) :
+    Array Advisory := Id.run do
+  let mut out : Array Advisory := #[]
+  -- Count `ok` rows (including any flagged below-floor) and how many
+  -- of those `ok` rows were below the signal floor. A row that errored
+  -- isn't a candidate for "below signal floor" advice — its data is
+  -- missing, not noise.
+  let okPoints := points.filter (·.status == .ok)
+  let belowFloor := okPoints.filter (·.belowSignalFloor)
+  if okPoints.isEmpty then
+    -- No `ok` rows at all. If every row hit the cap, that's
+    -- `allCapped`; if every row errored, the result already
+    -- communicates that without an advisory (the table shows
+    -- `[error: ...]` per row).
+    let cappedRows := points.filter fun dp =>
+      dp.status == .timedOut || dp.status == .killedAtCap
+    if !cappedRows.isEmpty && cappedRows.size == points.size then
+      out := out.push .allCapped
+  else if belowFloor.size == okPoints.size then
+    out := out.push .belowSignalFloor
+  else if belowFloor.size > 0 then
+    out := out.push (.partiallyBelowSignalFloor belowFloor.size okPoints.size)
+  -- Truncated-at-cap: at least one `ok` row landed AND somewhere in
+  -- the ladder a row hit the cap. The truncation point is the param
+  -- of the first capped row.
+  if !okPoints.isEmpty then
+    let firstCapped := points.findSome? fun dp =>
+      match dp.status with
+      | .timedOut | .killedAtCap => some dp.param
+      | _ => none
+    match firstCapped with
+    | some p => out := out.push (.truncatedAtCap p)
+    | none => pure ()
+  -- Verdict resolution: too few rows survive the warmup trim + floor
+  -- filter for the slope fit / range check to be meaningful.
+  if verdictRows < 3 && !okPoints.isEmpty then
+    out := out.push (.tooFewVerdictRows verdictRows)
+  return out
+
+/-- Build a `BenchmarkResult` from spec + complexity closure + collected points.
+
+    `points` should already carry `belowSignalFloor` annotations;
+    `runBenchmark` sets those after measuring the spawn floor and
+    before calling `summarize`. The verdict ratios and the advisory
+    list are both derived from the same annotated points, so the
+    "fewer than 3 verdict rows" advisory exactly matches what
+    `deriveVerdict` saw. -/
 def summarize
     (spec : BenchmarkSpec)
     (complexity : Nat → Nat)
@@ -137,6 +198,8 @@ def summarize
   let (verdict, cMin?, cMax?, slope?, dropped) :=
     deriveVerdict ratios spec.config.verdictWarmupFraction
       spec.config.slopeTolerance spec.config.narrowRangeNoiseFloor
+  let kept := ratios.size - dropped
+  let advisories := computeAdvisories points kept
   { function := spec.name
   , complexityFormula := spec.complexityFormula
   , hashable := spec.hashable
@@ -147,7 +210,8 @@ def summarize
   , cMin?
   , cMax?
   , verdictDroppedLeading := dropped
-  , slope? }
+  , slope?
+  , advisories }
 
 end Stats
 end LeanBench

--- a/README.md
+++ b/README.md
@@ -135,7 +135,12 @@ rationale, including limits and known caveats.
 
 Each measurement is a child process, so very fast operations have a
 per-spawn noise floor in the milliseconds. The harness measures this
-floor itself and prints it with every report.
+floor itself and prints it with every report; rows whose total wall
+time is below `signalFloorMultiplier × floor` (default 10×) are
+flagged `[<floor]` and excluded from the verdict, with an actionable
+advisory line at the bottom of the report. For workloads that don't
+fit the built-in `auto` / `doubling` / `linear` ladders, declare a
+custom one with `where { paramSchedule := .custom #[…] }`.
 
 Lean's `Nat` is bignum, the compiler hoists pure work out of loops
 unless its result is observed, and reference-counted sharing can

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -181,6 +181,23 @@ mode is universally better — they measure different things; see
 each. Pin a benchmark in cold mode at declaration time via
 `where { cacheMode := .cold }`.
 
+For workloads that don't fit any built-in ladder — corpus inputs
+where the natural `n` values are non-uniform, or a single-rung
+"this is the size that matters" run — declare a custom ladder:
+
+```lean
+setup_benchmark cornerCase n => n where {
+  paramSchedule := .custom #[1, 100, 10_000, 1_000_000]
+}
+```
+
+`.custom` skips the doubling probe and the linear-bracket sweep
+entirely; the harness walks the declared params in order and stops
+when one hits the wallclock cap. There is no CLI flag for `.custom`
+because the param list can't be cleanly expressed as one — declare
+it at registration time. An empty `.custom #[]` is rejected by
+config validation.
+
 `--warmup-fraction F` drops the leading `F` × ratios.size data points
 from the verdict reduction (the cold regime where per-call overhead
 dominates the declared complexity); the raw ratios array still
@@ -206,9 +223,22 @@ line; its sign tells you the direction of any mismatch (positive →
 actually slower than declared, negative → actually faster).
 
 The harness prints its own per-spawn floor as part of the report. Any
-data point with `total_nanos` smaller than ~10× the spawn floor is
-noise, not algorithm data — interpret it as a lower bound, not a
-measurement.
+data point with `total_nanos` smaller than `signalFloorMultiplier ×
+spawn_floor` (default 10×) is flagged with `[<floor]` in the table
+and excluded from the verdict — its per-call time is dominated by
+subprocess-spawn cost, not the function under test. Tune the
+threshold via `where { signalFloorMultiplier := 5.0 }` (looser) or
+`signalFloorMultiplier := 1.0` to disable the filter entirely.
+
+When the harness can't trust the data — every row was below the
+floor, every row hit the cap, the ladder was truncated by the cap,
+or fewer than three rows survived the verdict reduction — it
+appends one or more `‼` advisory lines after the verdict, each
+naming a concrete knob to turn next (`--max-seconds-per-call`,
+`--param-ceiling`, `paramSchedule := .custom #[...]`,
+`setup_fixed_benchmark`, …). The advisory text is the actionable
+half of issue #15; the underlying classifications live on
+`BenchmarkResult.advisories` for downstream tooling.
 
 ## What `compare` shows on divergence
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -12,6 +12,7 @@ defaultTargets = [
   "child_outcome_benchmark_test", "format_benchmark_test",
   "e2e_benchmark_test", "cli_errors_benchmark_test",
   "schema_benchmark_test", "cache_mode_benchmark_test",
+  "advisory_benchmark_test",
 ]
 
 [[require]]
@@ -117,3 +118,8 @@ root = "LeanBenchTestSchema"
 name = "cache_mode_benchmark_test"
 srcDir = "test"
 root = "LeanBenchTestCacheMode"
+
+[[lean_exe]]
+name = "advisory_benchmark_test"
+srcDir = "test"
+root = "LeanBenchTestAdvisory"

--- a/test/LeanBenchTestAdvisory.lean
+++ b/test/LeanBenchTestAdvisory.lean
@@ -1,0 +1,332 @@
+import LeanBench
+
+/-!
+# Edge-case advisories + custom ladder (issue #15)
+
+Pure unit tests for the issue #15 plumbing: `Advisory`, the
+`belowSignalFloor` per-row flag, the `MeasurementQuality` summary on
+`BenchmarkResult`, and the `.custom` parameter ladder.
+
+Everything in this file runs without spawning a subprocess — it
+operates on hand-built `DataPoint` arrays and drives `Stats.summarize`
+/ `annotateBelowSignalFloor` / `Format.fmtResult` directly. The
+end-to-end "the harness produces these advisories on a real run" test
+lives in the existing `LeanBenchTestE2E` file (which has its own
+trivial-fast benchmark and disables the floor filter).
+-/
+
+open LeanBench
+
+private def mkOk (param : Nat) (totalNanos : Nat) (perCall : Float) : DataPoint :=
+  { param, innerRepeats := 1, totalNanos, perCallNanos := perCall
+  , resultHash := some 1, status := .ok }
+
+private def mkCapped (param : Nat) : DataPoint :=
+  { param, innerRepeats := 0, totalNanos := 0, perCallNanos := 0.0
+  , resultHash := none, status := .killedAtCap }
+
+private def expectEq {α} [BEq α] [Repr α] (label : String) (got want : α) :
+    IO Unit := do
+  unless got == want do
+    throw <| .userError
+      s!"{label}: expected {repr want}, got {repr got}"
+
+private def containsSub (haystack needle : String) : Bool :=
+  ((haystack.splitOn needle).length) > 1
+
+/-! ## `annotateBelowSignalFloor` -/
+
+/-- Rows whose `totalNanos < multiplier × spawnFloor` get flagged;
+    others are left alone. Errored rows are never flagged because
+    their `totalNanos` is meaningless. -/
+def testAnnotateBelowSignalFloor : IO UInt32 := do
+  -- Spawn floor 10ms, multiplier 10×, threshold 100ms.
+  let floor : Option Nat := some 10_000_000
+  let mul : Float := 10.0
+  let pts : Array DataPoint := #[
+    mkOk 2  50_000_000  (50_000_000.0),  -- below threshold
+    mkOk 4 200_000_000 (200_000_000.0),  -- above threshold
+    mkCapped 8                            -- non-ok, never flagged
+  ]
+  let annotated : Array DataPoint :=
+    annotateBelowSignalFloor mul floor pts
+  expectEq "below.row0.flag"  annotated[0]!.belowSignalFloor true
+  expectEq "below.row1.flag"  annotated[1]!.belowSignalFloor false
+  expectEq "below.row2.flag"  annotated[2]!.belowSignalFloor false
+  -- multiplier ≤ 1 disables the check entirely.
+  let disabled : Array DataPoint :=
+    annotateBelowSignalFloor 1.0 floor pts
+  for dp in disabled do
+    expectEq "disabled.flag" dp.belowSignalFloor false
+  -- Missing spawn-floor reading also leaves everything unflagged.
+  let noFloor : Array DataPoint :=
+    annotateBelowSignalFloor mul none pts
+  for dp in noFloor do
+    expectEq "noFloor.flag" dp.belowSignalFloor false
+  return 0
+
+/-! ## `Stats.computeAdvisories` -/
+
+/-- All ok rows below the floor → `belowSignalFloor` advisory. -/
+def testAdvisoryAllBelowFloor : IO UInt32 := do
+  let pts : Array DataPoint := #[
+    { mkOk 2 1 1.0 with belowSignalFloor := true },
+    { mkOk 4 2 2.0 with belowSignalFloor := true } ]
+  let advs := Stats.computeAdvisories pts 0
+  -- Expect at least the `belowSignalFloor` advisory; tooFewVerdictRows
+  -- may also fire because the verdict has zero rows after filtering,
+  -- but `belowSignalFloor` is the headline classification.
+  unless advs.contains .belowSignalFloor do
+    IO.eprintln s!"expected belowSignalFloor advisory, got {repr advs}"
+    return 1
+  return 0
+
+/-- Mixed below-floor + ok-above-floor → `partiallyBelowSignalFloor`. -/
+def testAdvisoryPartialBelowFloor : IO UInt32 := do
+  let pts : Array DataPoint := #[
+    { mkOk 2 1 1.0 with belowSignalFloor := true },
+    mkOk 4 200_000_000 200.0,
+    mkOk 8 400_000_000 400.0 ]
+  let advs := Stats.computeAdvisories pts 2
+  unless advs.contains (.partiallyBelowSignalFloor 1 3) do
+    IO.eprintln s!"expected partiallyBelowSignalFloor 1 3, got {repr advs}"
+    return 1
+  return 0
+
+/-- All rows hit the cap → `allCapped`. -/
+def testAdvisoryAllCapped : IO UInt32 := do
+  let pts : Array DataPoint := #[mkCapped 2, mkCapped 4, mkCapped 8]
+  let advs := Stats.computeAdvisories pts 0
+  unless advs.contains .allCapped do
+    IO.eprintln s!"expected allCapped, got {repr advs}"
+    return 1
+  -- truncatedAtCap requires at least one ok row — must NOT fire here.
+  for adv in advs do
+    match adv with
+    | .truncatedAtCap _ =>
+      IO.eprintln s!"truncatedAtCap should not fire when allCapped: {repr advs}"
+      return 1
+    | _ => pure ()
+  return 0
+
+/-- Some rows ok, then capped → `truncatedAtCap` with the firstFail param. -/
+def testAdvisoryTruncatedAtCap : IO UInt32 := do
+  let pts : Array DataPoint := #[
+    mkOk 2 200_000_000 100.0,
+    mkOk 4 400_000_000 100.0,
+    mkCapped 8 ]
+  let advs := Stats.computeAdvisories pts 2
+  unless advs.contains (.truncatedAtCap 8) do
+    IO.eprintln s!"expected truncatedAtCap 8, got {repr advs}"
+    return 1
+  return 0
+
+/-- Few rows survive the verdict → `tooFewVerdictRows`. -/
+def testAdvisoryTooFewVerdictRows : IO UInt32 := do
+  let pts : Array DataPoint := #[
+    mkOk 2 200_000_000 100.0,
+    mkOk 4 400_000_000 100.0 ]
+  let advs := Stats.computeAdvisories pts 2
+  unless advs.contains (.tooFewVerdictRows 2) do
+    IO.eprintln s!"expected tooFewVerdictRows 2, got {repr advs}"
+    return 1
+  return 0
+
+/-- A clean run with enough rows above the floor → no advisories. -/
+def testAdvisoryOrdinaryRunIsEmpty : IO UInt32 := do
+  let pts : Array DataPoint := #[
+    mkOk 2 200_000_000 100.0,
+    mkOk 4 400_000_000 100.0,
+    mkOk 8 800_000_000 100.0,
+    mkOk 16 1_600_000_000 100.0 ]
+  let advs := Stats.computeAdvisories pts 4
+  unless advs.isEmpty do
+    IO.eprintln s!"expected empty advisories on ordinary run, got {repr advs}"
+    return 1
+  return 0
+
+/-! ## `Format.fmtResult` rendering of advisories + per-row floor mark -/
+
+/-- A row with `belowSignalFloor := true` carries a `[<floor]`
+    annotation in the rendered table. -/
+def testFmtResultBelowFloorMark : IO UInt32 := do
+  let pts : Array DataPoint := #[
+    { mkOk 2 1 1.0 with belowSignalFloor := true },
+    mkOk 4 200_000_000 100.0 ]
+  let result : BenchmarkResult :=
+    { function := `Sample.fast
+    , complexityFormula := "n"
+    , hashable := true
+    , config := { signalFloorMultiplier := 10.0 }
+    , points := pts
+    , ratios := #[(4, 25.0)]
+    , verdict := .inconclusive
+    , cMin? := some 25.0
+    , cMax? := some 25.0
+    , verdictDroppedLeading := 0
+    , slope? := none
+    , spawnFloorNanos? := some 5_000_000
+    , advisories := #[.partiallyBelowSignalFloor 1 2] }
+  let rendered := Format.fmtResult result
+  unless containsSub rendered "[<floor]" do
+    IO.eprintln s!"expected `[<floor]` mark in:\n{rendered}"
+    return 1
+  unless containsSub rendered "1/2 ok rows were below" do
+    IO.eprintln s!"expected partial advisory in:\n{rendered}"
+    return 1
+  return 0
+
+/-- The advisory line is rendered with the `‼` lead and a concrete
+    actionable suggestion. -/
+def testFmtResultAdvisoryLines : IO UInt32 := do
+  let dummyResult : BenchmarkResult :=
+    { function := `Sample.fast
+    , complexityFormula := "n"
+    , hashable := true
+    , config := { maxSecondsPerCall := 1.0, signalFloorMultiplier := 10.0 }
+    , points := #[mkOk 2 1 1.0]
+    , ratios := #[]
+    , verdict := .inconclusive
+    , cMin? := none
+    , cMax? := none
+    , verdictDroppedLeading := 0
+    , slope? := none
+    , spawnFloorNanos? := some 100
+    , advisories := #[
+        .belowSignalFloor,
+        .allCapped,
+        .truncatedAtCap 16,
+        .tooFewVerdictRows 1 ] }
+  let rendered := Format.fmtResult dummyResult
+  let needles : List String := [
+    "‼ every measurement was below",
+    "‼ every measurement hit the wallclock cap",
+    "‼ ladder stopped at param=16 after hitting the wallclock cap",
+    "‼ only 1 verdict-eligible row",
+    -- Suggestions actually point at the new knobs.
+    "paramSchedule := .custom",
+    "--max-seconds-per-call",
+    "--param-ceiling",
+    "setup_fixed_benchmark" ]
+  for needle in needles do
+    unless containsSub rendered needle do
+      IO.eprintln s!"missing '{needle}' in:\n{rendered}"
+      return 1
+  return 0
+
+/-! ## `.custom` ladder semantics
+
+Pure config layer — drive `runBenchmark` with the `.custom` schedule
+and assert the points correspond to the user-specified params. The
+benchmark is the same trivial XOR loop the e2e test uses, with the
+floor filter disabled so the ladder shape is what's under test. -/
+
+namespace LeanBench.Test.Advisory
+
+def littleFnCustom (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 1
+  for _ in [0:n] do
+    x := x ^^^ n.toUInt64
+  return x
+
+setup_benchmark littleFnCustom n => n where {
+  maxSecondsPerCall := 0.5
+  targetInnerNanos := 50_000_000
+  signalFloorMultiplier := 1.0
+  paramSchedule := .custom #[3, 5, 7, 11]
+}
+
+end LeanBench.Test.Advisory
+
+private def customName : Lean.Name := `LeanBench.Test.Advisory.littleFnCustom
+
+/-- A `.custom` ladder runs exactly the user-supplied params, in
+    order, with no doubling probe and no auto-bracketing. -/
+def testCustomLadder : IO UInt32 := do
+  let result ← runBenchmark customName
+  let observed := result.points.map (·.param)
+  -- All-ok prefix — the params are tiny, nothing should hit the cap.
+  -- The ladder is exactly the declared list.
+  expectEq "custom.params" observed #[3, 5, 7, 11]
+  return 0
+
+/-- An empty `.custom` ladder is rejected up front by config validation
+    — better than producing an empty result silently. -/
+def testCustomEmptyRejected : IO UInt32 := do
+  let badCfg : BenchmarkConfig := { paramSchedule := .custom #[] }
+  match badCfg.validate with
+  | .error msg =>
+    if containsSub msg "empty" then return 0
+    IO.eprintln s!"expected 'empty' in error, got: {msg}"
+    return 1
+  | .ok _ =>
+    IO.eprintln "expected validate to reject .custom #[]"
+    return 1
+
+/-- Duplicate params in `.custom` are rejected by validation: the
+    formatter keys `C` lookup by `param`, so two rows with the same
+    param would render with the same ratio and the same warmup
+    dagger, giving a misleading report. Codex flagged this in the
+    issue #15 review. -/
+def testCustomDuplicateRejected : IO UInt32 := do
+  let badCfg : BenchmarkConfig := { paramSchedule := .custom #[1, 2, 2, 4] }
+  match badCfg.validate with
+  | .error msg =>
+    if containsSub msg "duplicate" then return 0
+    IO.eprintln s!"expected 'duplicate' in error, got: {msg}"
+    return 1
+  | .ok _ =>
+    IO.eprintln "expected validate to reject .custom with duplicate params"
+    return 1
+
+/-- `signalFloorMultiplier < 1.0` is rejected by validation. -/
+def testSignalFloorMultiplierValidated : IO UInt32 := do
+  let badCfg : BenchmarkConfig := { signalFloorMultiplier := 0.5 }
+  match badCfg.validate with
+  | .error msg =>
+    if containsSub msg "signalFloorMultiplier" then return 0
+    IO.eprintln s!"expected signalFloorMultiplier message, got: {msg}"
+    return 1
+  | .ok _ =>
+    IO.eprintln "expected validate to reject signalFloorMultiplier < 1.0"
+    return 1
+
+/-! ## Driver -/
+
+def runTests : IO UInt32 := do
+  let mut anyFail : UInt32 := 0
+  for (label, t) in
+    [ ("annotateBelowSignalFloor", testAnnotateBelowSignalFloor),
+      ("advisory.allBelowFloor",   testAdvisoryAllBelowFloor),
+      ("advisory.partialBelowFloor", testAdvisoryPartialBelowFloor),
+      ("advisory.allCapped",       testAdvisoryAllCapped),
+      ("advisory.truncatedAtCap",  testAdvisoryTruncatedAtCap),
+      ("advisory.tooFewVerdictRows", testAdvisoryTooFewVerdictRows),
+      ("advisory.ordinaryRunIsEmpty", testAdvisoryOrdinaryRunIsEmpty),
+      ("fmtResult.belowFloorMark", testFmtResultBelowFloorMark),
+      ("fmtResult.advisoryLines",  testFmtResultAdvisoryLines),
+      ("custom.ladder",            testCustomLadder),
+      ("custom.emptyRejected",     testCustomEmptyRejected),
+      ("custom.duplicateRejected", testCustomDuplicateRejected),
+      ("signalFloorMultiplier.validated", testSignalFloorMultiplierValidated) ]
+  do
+    let code ←
+      try t
+      catch e => do
+        IO.eprintln s!"FAIL: {label}: {e.toString}"
+        pure 1
+    if code != 0 then
+      IO.eprintln s!"FAIL: {label}"
+      anyFail := 1
+    else
+      IO.println s!"  ok  {label}"
+  if anyFail == 0 then
+    IO.println "advisory + custom-ladder tests passed"
+  return anyFail
+
+/-- Same compiled binary is parent and child; `_child` first arg
+    distinguishes them for the custom-ladder run. -/
+def main (args : List String) : IO UInt32 :=
+  match args with
+  | "_child" :: _ => LeanBench.Cli.dispatch args
+  | _ => runTests

--- a/test/LeanBenchTestE2E.lean
+++ b/test/LeanBenchTestE2E.lean
@@ -62,15 +62,27 @@ def littleFnTwin (n : Nat) : UInt64 := Id.run do
 With the default `targetInnerNanos := 500_000_000`, autoTune wants
 ~250ms of inner work per batch — that overshoots a 0.25s cap once the
 final doubling step lands past the half-target. Lower the inner
-target so even slow CI hosts converge before the kill timer fires. -/
+target so even slow CI hosts converge before the kill timer fires.
+
+`signalFloorMultiplier := 1.0` disables the issue #15 below-floor
+filter. The XOR loop is so trivially fast that with the default 10×
+multiplier every row ends up below the floor and `ratios` would be
+empty — that's the expected behavior on real fast benchmarks (issue
+#15 explicitly), but it would mask the e2e regression we want to
+guard here (subprocess pipeline returning real measurements). The
+issue #15 advisory path has dedicated coverage in
+`LeanBenchTestAdvisory.lean`. -/
 setup_benchmark littleFn n => n where {
   maxSecondsPerCall := 0.5, paramCeiling := 8, targetInnerNanos := 50_000_000
+  signalFloorMultiplier := 1.0
 }
 setup_benchmark littleFn' n => n where {
   maxSecondsPerCall := 0.5, paramCeiling := 8, targetInnerNanos := 50_000_000
+  signalFloorMultiplier := 1.0
 }
 setup_benchmark littleFnTwin n => n where {
   maxSecondsPerCall := 0.5, paramCeiling := 8, targetInnerNanos := 50_000_000
+  signalFloorMultiplier := 1.0
 }
 
 end LeanBench.Test.E2E


### PR DESCRIPTION
Closes https://github.com/kim-em/lean-bench/issues/15.

## Summary
- Adds a parent-side `belowSignalFloor` flag on `DataPoint`,
  computed from the measured per-spawn floor and a new
  `BenchmarkConfig.signalFloorMultiplier` (default 10×). Below-floor
  rows are excluded from the verdict reduction and rendered with a
  `[<floor]` annotation in the table.
- Adds an `Advisory` enum (`belowSignalFloor`,
  `partiallyBelowSignalFloor`, `allCapped`, `truncatedAtCap`,
  `tooFewVerdictRows`) computed by `Stats.computeAdvisories` and
  rendered as `‼ <symptom>; <suggestion>` lines after the verdict.
  Each suggestion names a concrete knob to turn next
  (`--max-seconds-per-call`, `--param-ceiling`, `paramSchedule := .custom`,
  `setup_fixed_benchmark`).
- Adds `ParamSchedule.custom (Array Nat)`: declaration-time-only ladder
  for workloads that don't fit the `auto` / `doubling` / `linear`
  shapes (corpus inputs, single-rung 'this size matters' runs).
  Validated non-empty and duplicate-free.

## Acceptance criteria from #15
- [x] Reports distinguish ordinary measurements from edge-case ones
  (per-row `[<floor]`, advisory `‼` block, structured `advisories`
  array on `BenchmarkResult` for downstream tooling).
- [x] Users get actionable guidance when the tool is not a good fit
  (the advisory text names the symptom and the knob; covered by
  `LeanBenchTestAdvisory.testFmtResultAdvisoryLines`).
- [x] At least one mechanism for unusually fast or slow workloads
  (`signalFloorMultiplier` for the fast end; `.custom` ladder +
  existing `--max-seconds-per-call` for the slow end).

## Second-opinion review
Codex reviewed the branch and flagged two real issues, both
addressed before this PR opened:
1. `.custom` initially permitted duplicate params, but the formatter
   keys `C` lookup and the warmup dagger by `param` — duplicates
   would render misleadingly. Now rejected by `validate`.
2. The `truncatedAtCap` advisory said 'no rungs above this point',
   which is wrong for sparse / non-monotone `.custom` ladders.
   Reworded to 'ladder stopped at param=X after hitting the
   wallclock cap; subsequent rungs in the schedule were skipped'.

## Test plan
- [x] New `LeanBenchTestAdvisory.lean` covers `annotateBelowSignalFloor`,
  every `Advisory` case, both formatter changes, `.custom` dispatch,
  empty/duplicate `.custom` rejection, and `signalFloorMultiplier`
  validation.
- [x] All 11 existing test executables pass locally.
- [x] `lake build` is clean on every target.

## Notes
- The e2e fixture's trivial XOR loop is exactly the kind of benchmark
  the new floor filter is meant to flag. It now opts out via
  `signalFloorMultiplier := 1.0` so the e2e regression for
  'subprocess pipeline returns real measurements' still has rows in
  `ratios`. The advisory path has dedicated coverage in the new test.
- `--param-schedule custom` is intentionally NOT exposed on the CLI:
  the param array can't be cleanly expressed as a single argument,
  and `.custom` is opt-in by design (auto-detect never picks it).

🤖 Prepared with Claude Code