### PR TITLE
feat: outer trials + per-param statistical summaries (issue #4)

### DIFF
--- a/LeanBench/Cli.lean
+++ b/LeanBench/Cli.lean
@@ -101,7 +101,8 @@ def configOverrideFromParsed (p : Cli.Parsed) : ConfigOverride :=
     verdictWarmupFraction? := parsedFlag? p "warmup-fraction" Float
     slopeTolerance?        := parsedFlag? p "slope-tolerance" Float
     paramSchedule?         := parsedFlag? p "param-schedule" LeanBench.ParamSchedule
-    cacheMode?             := parsedFlag? p "cache-mode" LeanBench.CacheMode }
+    cacheMode?             := parsedFlag? p "cache-mode" LeanBench.CacheMode
+    outerTrials?           := parsedFlag? p "outer-trials" Nat }
 
 /-- Build a `FixedConfigOverride` from override flags. Only fields
 that share a flag namespace with parametric (`max-seconds-per-call`)
@@ -239,6 +240,7 @@ Each missing flag leaves the declared value untouched."
     "slope-tolerance" : Float;       "Parametric only: verdict is `consistent` iff |β| ≤ this, where β is the log-log slope of C vs param (JSON-style numbers)."
     "param-schedule" : LeanBench.ParamSchedule;  "Parametric only: ladder shape (auto, doubling, or linear). Default auto picks doubling for polynomial growth, linear for exponential."
     "cache-mode" : LeanBench.CacheMode;           "Parametric only: warm (default) auto-tunes inner repeats inside one child; cold respawns per measurement so cache state is not preserved across rungs. See doc/advanced.md#cache-modes."
+    "outer-trials" : Nat;            "Parametric only: number of independent outer trials per ladder rung (default 1). Bumping this above 1 runs N child spawns per param and reports per-param median / min / max / spread; trades runtime for stability. See doc/advanced.md#outer-trials."
     "repeats" : Nat;                 "Fixed only: number of measured invocations after the warmup call (default 5)."
 
   ARGS:
@@ -276,6 +278,7 @@ to every benchmark in the comparison."
     "slope-tolerance" : Float;       "Parametric only: verdict is `consistent` iff |β| ≤ this, where β is the log-log slope of C vs param (JSON-style numbers)."
     "param-schedule" : LeanBench.ParamSchedule;  "Parametric only: ladder shape (auto, doubling, or linear). Default auto picks doubling for polynomial growth, linear for exponential."
     "cache-mode" : LeanBench.CacheMode;           "Parametric only: warm (default) auto-tunes inner repeats inside one child; cold respawns per measurement so cache state is not preserved across rungs. See doc/advanced.md#cache-modes."
+    "outer-trials" : Nat;            "Parametric only: number of independent outer trials per ladder rung (default 1). Bumping this above 1 runs N child spawns per param and reports per-param median / min / max / spread; trades runtime for stability. See doc/advanced.md#outer-trials."
     "repeats" : Nat;                 "Fixed only: number of measured invocations after the warmup call (default 5)."
 
   ARGS:

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -400,11 +400,15 @@ can read at a glance.
 Issue #4. -/
 structure TrialSummary where
   param          : Nat
-  /-- Number of `ok` trials that contributed to the summary. Trials
-      that timed out / were killed / errored are not counted; the
-      summary may have `okCount < BenchmarkConfig.outerTrials`. `0`
-      should not occur — the harness emits a `TrialSummary` only when
-      at least one trial succeeded. -/
+  /-- Number of verdict-eligible `ok` trials that contributed to the
+      summary. Trials that timed out / were killed / errored are not
+      counted, and neither are doubling-probe rows in `.linear`
+      mode (`partOfVerdict := false`) nor rows that fell below the
+      signal floor (`belowSignalFloor := true`); the summary covers
+      the same row set as `Stats.ratiosFromPoints`. The summary may
+      have `okCount < BenchmarkConfig.outerTrials`; `0` should not
+      occur because the harness emits a `TrialSummary` only when at
+      least one trial survived all of those filters. -/
   okCount        : Nat
   /-- Median of `perCallNanos` over the `okCount` trials. Upper
       middle on even sample counts (matches `Stats.medianFloat`). -/
@@ -492,14 +496,19 @@ structure BenchmarkResult where
       layer renders these as a hint section after the verdict line.
       Issue #15. -/
   advisories : Array Advisory := #[]
-  /-- One entry per param that produced at least one `ok` trial, in
-      ladder order. With `outerTrials := 1` (the v0.1 default) each
-      entry trivially has `okCount = 1` and `relativeSpread = 0.0`;
-      with `outerTrials > 1` the entry summarises the cluster of
+  /-- One entry per **verdict-eligible** param, in ladder order — the
+      same param set `Stats.ratiosFromPoints` returns. Doubling-probe
+      rows in `.linear` mode and rows below the signal floor are
+      excluded both here and from the verdict reduction, so this
+      array reflects exactly the data the verdict was computed from.
+      With `outerTrials := 1` (the v0.1 default) each entry trivially
+      has `okCount = 1` and `relativeSpread = 0.0`; with
+      `outerTrials > 1` the entry summarises the cluster of
       independent measurements at that param (median / min / max /
-      spread). The verdict ratios are computed from `medianPerCallNanos`
-      so a single noisy trial doesn't shift the slope fit. The full
-      per-trial points stay on `points` for downstream tooling and
+      spread). The verdict ratios are computed from
+      `medianPerCallNanos` so a single noisy trial doesn't shift the
+      slope fit. The full per-trial points (including probe and
+      below-floor rows) stay on `points` for downstream tooling and
       raw inspection. Issue #4. -/
   trialSummaries : Array TrialSummary := #[]
   deriving Inhabited, Repr

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -57,6 +57,12 @@ structure DataPoint where
       spawn-floor self-measurement so the child JSONL can stay
       schema-stable. -/
   belowSignalFloor : Bool := false
+  /-- 0-based index across the `outerTrials` independent measurements
+      taken at this `param`. `0` for benchmarks declared with the v0.1
+      default `outerTrials := 1` (so all existing fixtures parse
+      unchanged). Parent-side only — not serialized in the child JSONL;
+      the parent assigns it after each spawn returns. Issue #4. -/
+  trialIndex   : Nat := 0
   deriving Repr, Inhabited
 
 /-- Heuristic verdict — see SPEC v0.1: weak labels by design. Decided
@@ -214,6 +220,19 @@ structure BenchmarkConfig where
       retained); values ≤ 0 are rejected by `validate`. See issue
       #15 for the design discussion. -/
   signalFloorMultiplier : Float := 10.0
+  /-- Number of independent outer trials per measured rung. `1` (the
+      default) is the v0.1 behaviour: one batch per param. Bumping
+      this above 1 runs `outerTrials` separate child spawns per rung
+      and aggregates the per-call timings into a per-param median /
+      min / max / spread on `BenchmarkResult.trialSummaries`. The
+      raw per-trial points are preserved on `BenchmarkResult.points`
+      so downstream tooling and the divergence reporter stay
+      apples-to-apples. The verdict ratios are computed from the
+      median per param, so a single noisy trial no longer shifts the
+      slope fit on its own. Trade-off: total wall time scales linearly
+      with `outerTrials`. CI tunes this via `--outer-trials` to trade
+      runtime for stability. Issue #4. -/
+  outerTrials : Nat := 1
   deriving Inhabited, Repr, BEq
 
 /-- Optional run-time overrides applied on top of a benchmark's
@@ -250,6 +269,9 @@ structure ConfigOverride where
   /-- Override the cache-state policy. CLI exposes this as
       `--cache-mode warm|cold`. -/
   cacheMode?             : Option CacheMode := none
+  /-- Override the number of outer trials per measured rung. CLI
+      exposes this as `--outer-trials N`. Issue #4. -/
+  outerTrials?           : Option Nat := none
   deriving Inhabited, Repr
 
 /-- Merge a CLI `paramSchedule` override on top of a declared
@@ -282,7 +304,8 @@ def ConfigOverride.apply (o : ConfigOverride) (c : BenchmarkConfig) :
     slopeTolerance        := o.slopeTolerance?.getD        c.slopeTolerance
     killGraceMs           := o.killGraceMs?.getD           c.killGraceMs
     paramSchedule         := mergeParamSchedule o.paramSchedule? c.paramSchedule
-    cacheMode             := o.cacheMode?.getD             c.cacheMode }
+    cacheMode             := o.cacheMode?.getD             c.cacheMode
+    outerTrials           := o.outerTrials?.getD           c.outerTrials }
 
 /-- Validate a `BenchmarkConfig`. The macro accepts arbitrary user
 expressions and the CLI accepts arbitrary JSON-style numbers, so
@@ -306,6 +329,8 @@ def BenchmarkConfig.validate (c : BenchmarkConfig) : Except String Unit := do
     .error s!"BenchmarkConfig.paramFloor must be ≤ paramCeiling; got {c.paramFloor} > {c.paramCeiling}"
   unless c.signalFloorMultiplier ≥ 1.0 do
     .error s!"BenchmarkConfig.signalFloorMultiplier must be ≥ 1.0; got {c.signalFloorMultiplier}"
+  unless c.outerTrials ≥ 1 do
+    .error s!"BenchmarkConfig.outerTrials must be ≥ 1; got {c.outerTrials}"
   -- A `.custom` ladder with an empty params list is almost certainly
   -- a typo (and would produce an empty result); reject up front.
   -- Duplicate params are also rejected: the formatter keys the `C`
@@ -354,6 +379,41 @@ structure BenchmarkSpec where
 /-- `(param, C = perCallNanos / complexity param)`. Source of truth
   for the verdict. -/
 abbrev Ratio := Nat × Float
+
+/-- Aggregate timing summary for one `param` across all `outerTrials`
+independent measurements at that param.
+
+The fields capture the raw shape of the trial cluster — median, min,
+max, and a relative-spread number — without committing to any
+distributional model. With `outerTrials = 1` the harness still emits
+one summary per ok param (median = min = max, spread = 0); the same
+shape works for both `--outer-trials 1` and `--outer-trials N`, so
+downstream tooling doesn't need a special case.
+
+`perCallNanos` is in nanoseconds. `relativeSpread` is `(max - min) /
+median` — `0.10` means the worst trial was 10% above the best
+relative to the median. It is intentionally NOT a confidence interval
+or standard deviation: the v0.2 measurement model does not commit to
+a noise distribution; this is a robust shape descriptor that users
+can read at a glance.
+
+Issue #4. -/
+structure TrialSummary where
+  param          : Nat
+  /-- Number of `ok` trials that contributed to the summary. Trials
+      that timed out / were killed / errored are not counted; the
+      summary may have `okCount < BenchmarkConfig.outerTrials`. `0`
+      should not occur — the harness emits a `TrialSummary` only when
+      at least one trial succeeded. -/
+  okCount        : Nat
+  /-- Median of `perCallNanos` over the `okCount` trials. Upper
+      middle on even sample counts (matches `Stats.medianFloat`). -/
+  medianPerCallNanos : Float
+  minPerCallNanos    : Float
+  maxPerCallNanos    : Float
+  /-- `(max - min) / median`, clamped to `0.0` when `median = 0.0`. -/
+  relativeSpread     : Float
+  deriving Repr, Inhabited
 
 /-- Edge-case classifications surfaced on `BenchmarkResult.advisories`.
 Pure data — the format layer turns each into an actionable message.
@@ -432,6 +492,16 @@ structure BenchmarkResult where
       layer renders these as a hint section after the verdict line.
       Issue #15. -/
   advisories : Array Advisory := #[]
+  /-- One entry per param that produced at least one `ok` trial, in
+      ladder order. With `outerTrials := 1` (the v0.1 default) each
+      entry trivially has `okCount = 1` and `relativeSpread = 0.0`;
+      with `outerTrials > 1` the entry summarises the cluster of
+      independent measurements at that param (median / min / max /
+      spread). The verdict ratios are computed from `medianPerCallNanos`
+      so a single noisy trial doesn't shift the slope fit. The full
+      per-trial points stay on `points` for downstream tooling and
+      raw inspection. Issue #4. -/
+  trialSummaries : Array TrialSummary := #[]
   deriving Inhabited, Repr
 
 /-- One diverging param in a `compare`: the param at which results

--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -114,7 +114,7 @@ private def fmtRepeats (n : Nat) : String :=
     if (1 <<< k) == n then s!"×2^{k}"
     else s!"×{n}"
 
-private def rawRow (cMaybe : Option Float) (dp : DataPoint) : Row :=
+private def rawRow (cMaybe : Option Float) (totalTrials : Nat) (dp : DataPoint) : Row :=
   let (num, unit) := match dp.status with
     | .ok => fmtNanos dp.perCallNanos.toUInt64.toNat
     | _   => ("—", "")
@@ -131,9 +131,17 @@ private def rawRow (cMaybe : Option Float) (dp : DataPoint) : Row :=
   -- Below-signal-floor rows are excluded from the verdict because
   -- their per-call time is dominated by subprocess overhead — flag
   -- them so users see why `C=—` for an `ok` row. Issue #15.
-  let status :=
+  let withFloor :=
     if dp.belowSignalFloor then probeMarked ++ " [<floor]"
     else probeMarked
+  -- With `outerTrials > 1` (issue #4), the table shows multiple rows
+  -- per `param` — one per trial. Annotate each so the user can tell
+  -- raw rows apart at a glance and so the same `C=` repeated across a
+  -- cluster doesn't look like duplication.
+  let status :=
+    if totalTrials > 1 then
+      withFloor ++ s!" [trial {dp.trialIndex + 1}/{totalTrials}]"
+    else withFloor
   { param       := fmtNatUnderscores dp.param
     perCallNum  := num
     perCallUnit := unit
@@ -171,6 +179,82 @@ private def fmtAdvisory (r : BenchmarkResult) : Advisory → String
   | .tooFewVerdictRows kept =>
     s!"  ‼ only {kept} verdict-eligible row(s) survived warmup-trim + signal-floor filter; the verdict is below resolution. Lower `--warmup-fraction`, raise `--param-ceiling`, or " ++ customScheduleHint ++ "."
 
+/-- Render the per-param trial-summary block. One header line plus
+one data line per `TrialSummary`. Returns `#[]` when there is nothing
+useful to show:
+
+- `outerTrials ≤ 1`: every summary trivially has min = median = max,
+  spread = 0; printing it is noise.
+- empty `trialSummaries`: no verdict-eligible rows landed.
+
+Each data line shows the param, ok-trial count out of the configured
+trials, median per-call time, min, max, and the relative spread as a
+percentage. The point is to expose a stability number per param at a
+glance — a row with `spread=2.0%` is a tight cluster, `spread=80.0%`
+is unreliable. Issue #4. -/
+private def fmtTrialSummaries (r : BenchmarkResult) : Array String :=
+  Id.run do
+    if r.config.outerTrials ≤ 1 then return #[]
+    if r.trialSummaries.isEmpty then return #[]
+    let totalTrials := r.config.outerTrials
+    let numStrs (xs : Array Float) : Array String × Array String :=
+      let pairs := xs.map fun x =>
+        if x ≤ 0.0 then ("—", "")
+        else fmtNanos x.toUInt64.toNat
+      (pairs.map (·.1), pairs.map (·.2))
+    let medians := r.trialSummaries.map (·.medianPerCallNanos)
+    let mins    := r.trialSummaries.map (·.minPerCallNanos)
+    let maxs    := r.trialSummaries.map (·.maxPerCallNanos)
+    let (medianNums, medianUnits) := numStrs medians
+    let (minNums, minUnits)       := numStrs mins
+    let (maxNums, maxUnits)       := numStrs maxs
+    let medianAligned := alignDecimals medianNums
+    let minAligned    := alignDecimals minNums
+    let maxAligned    := alignDecimals maxNums
+    let trialsCol := r.trialSummaries.map fun s =>
+      s!"{s.okCount}/{totalTrials}"
+    let paramCol  := r.trialSummaries.map fun s =>
+      fmtNatUnderscores s.param
+    let spreadCol := r.trialSummaries.map fun s =>
+      fmtFloat3 (s.relativeSpread * 100.0) ++ "%"
+    let unitW (us : Array String) := us.foldl (fun m u => max m u.length) 0
+    let medianUnitW := unitW medianUnits
+    let minUnitW    := unitW minUnits
+    let maxUnitW    := unitW maxUnits
+    let wParam   := paramCol.foldl (fun m s => max m s.length) "param".length
+    let wTrials  := trialsCol.foldl (fun m s => max m s.length) "trials".length
+    let medianNumW := if medianAligned.isEmpty then 0 else medianAligned[0]!.length
+    let minNumW    := if minAligned.isEmpty    then 0 else minAligned[0]!.length
+    let maxNumW    := if maxAligned.isEmpty    then 0 else maxAligned[0]!.length
+    let medianColW := max "median".length (medianNumW + 1 + medianUnitW)
+    let minColW    := max "min".length    (minNumW + 1 + minUnitW)
+    let maxColW    := max "max".length    (maxNumW + 1 + maxUnitW)
+    let wSpread  := spreadCol.foldl (fun m s => max m s.length) "spread".length
+    let mut lines : Array String :=
+      #[s!"  trial summaries ({totalTrials} trials per param; spread = (max-min)/median):"]
+    lines := lines.push <|
+      "    " ++ leftpad "param" wParam ++
+      "  "  ++ rightpad "trials" wTrials ++
+      "  "  ++ rightpad "median" medianColW ++
+      "  "  ++ rightpad "min" minColW ++
+      "  "  ++ rightpad "max" maxColW ++
+      "  "  ++ rightpad "spread" wSpread
+    for i in [0 : r.trialSummaries.size] do
+      let medianCell :=
+        medianAligned[i]! ++ " " ++ rightpad medianUnits[i]! medianUnitW
+      let minCell :=
+        minAligned[i]! ++ " " ++ rightpad minUnits[i]! minUnitW
+      let maxCell :=
+        maxAligned[i]! ++ " " ++ rightpad maxUnits[i]! maxUnitW
+      lines := lines.push <|
+        "    " ++ leftpad paramCol[i]! wParam ++
+        "  "  ++ rightpad trialsCol[i]! wTrials ++
+        "  "  ++ rightpad medianCell medianColW ++
+        "  "  ++ rightpad minCell minColW ++
+        "  "  ++ rightpad maxCell maxColW ++
+        "  "  ++ rightpad spreadCol[i]! wSpread
+    return lines
+
 /-- Render one `BenchmarkResult` as a multi-line block with every
 numeric value bounded to 3 decimals and every column width derived
 from the data so decimal points align. -/
@@ -184,8 +268,9 @@ def fmtResult (r : BenchmarkResult) : String := Id.run do
     r.ratios.foldl (fun m (p, c) => m.insert p c) {}
   let droppedParams : Array Nat :=
     (r.ratios.extract 0 r.verdictDroppedLeading).map (·.1)
+  let totalTrials := r.config.outerTrials
   let raws : Array Row := r.points.map fun dp =>
-    let row := rawRow (ratioMap.get? dp.param) dp
+    let row := rawRow (ratioMap.get? dp.param) totalTrials dp
     if droppedParams.contains dp.param then
       { row with status := row.status ++ " †" }
     else row
@@ -242,6 +327,8 @@ def fmtResult (r : BenchmarkResult) : String := Id.run do
   | some n =>
     lines := lines.push s!"  per-spawn floor (harness self-measurement): {fmtNanosStr n}"
   | none => pure ()
+  for line in fmtTrialSummaries r do
+    lines := lines.push line
   for adv in r.advisories do
     lines := lines.push (fmtAdvisory r adv)
   return "\n".intercalate lines.toList

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -300,11 +300,20 @@ private def pickLinearRungs (lastOk firstFail samples : Nat) : Array Nat :=
 
 /-- Run a single rung, taking `trials` independent outer measurements.
     Each call to `runOneBatch` is one fresh child spawn; per-trial
-    points are tagged with `trialIndex` 0..trials-1. If the first
-    trial at this rung fails (timed out / killed / errored) we stop
-    immediately rather than re-spawning at a known-bad rung — the
-    one failed row is enough for `lastOk` / `firstFail` bracketing
-    and for the user-facing report. Issue #4. -/
+    points are tagged with `trialIndex` 0..trials-1.
+
+    Always runs all `trials` spawns regardless of intermediate
+    failures: a transient first-trial timeout shouldn't poison the
+    whole rung's data (Codex flagged this as a stability regression
+    when `outerTrials > 1`). The ladder-continuation decision is
+    made by the caller from `rung.any (·.status == .ok)`, so a
+    rung whose first trial flaked but later trials succeeded is
+    still treated as `lastOk`-eligible.
+
+    Cost is bounded: each spawn is independently capped by
+    `maxSecondsPerCall`, so the worst case at a known-cap rung is
+    `trials × maxSecondsPerCall`. Users opted into that cost when
+    they bumped `outerTrials`. Issue #4. -/
 private def runRungTrials (spec : BenchmarkSpec) (param : Nat)
     (trials : Nat) : IO (Array DataPoint) := do
   let mut acc : Array DataPoint := #[]
@@ -312,8 +321,14 @@ private def runRungTrials (spec : BenchmarkSpec) (param : Nat)
   for i in [0 : trials] do
     let dp ← runOneBatch spec param
     acc := acc.push { dp with trialIndex := i }
-    if dp.status != .ok then break
   return acc
+
+/-- Did any trial at this rung succeed? Drives the ladder-continuation
+    decision: the rung counts as `ok` for `lastOk` / sweep-progress as
+    long as at least one of its `outerTrials` measurements landed.
+    Issue #4. -/
+private def rungAnyOk (rung : Array DataPoint) : Bool :=
+  rung.any (fun dp => dp.status == .ok)
 
 /-- Run the static doubling ladder. Returns `(points, lastOk?, firstFail?)`:
 
@@ -322,11 +337,22 @@ private def runRungTrials (spec : BenchmarkSpec) (param : Nat)
 - `firstFail?` is the first param after `lastOk` whose status was non-ok
   (none if the ladder ran to ceiling without failing).
 
-Each rung runs `cfg.outerTrials` independent measurements; the rung's
-status for the bracket-finding decision is the status of the *first*
-trial (i.e. if the first trial succeeds we keep going; if it fails
-the rung is the bracket boundary, regardless of whether later trials
-would have succeeded — which they shouldn't, given the first failed).
+In `.linear` mode the doubling probe exists only to find the
+productive band — its rows get `partOfVerdict := false` later and
+never enter the verdict reduction. So the probe runs **one trial per
+rung** regardless of `outerTrials`: there is no statistical value in
+spending `outerTrials × probeRungs` spawns on rows the verdict will
+discard. Codex flagged this as wasted cost for `--outer-trials 5
+--param-schedule linear`. The verdict-eligible sweep rungs (added
+later by `runBenchmark`) still run the full `outerTrials` cluster.
+
+In `.doubling` mode every probe rung also enters the verdict, so
+running `outerTrials` per rung does matter — but we still only do
+one trial here; `runBenchmark` runs the remaining `outerTrials - 1`
+trials at every probe rung that survived in a second pass below
+(see `topUpDoublingTrials`). That keeps the bracket-finding cost at
+`O(ladder)` regardless of `outerTrials` while preserving the median
+trial cluster on the rungs that count.
 
 Probe rows are returned with whatever `partOfVerdict` `runOneBatch`
 chose (defaults to true); the caller flips them as needed. -/
@@ -338,14 +364,42 @@ private def runDoublingProbe (spec : BenchmarkSpec) :
   let mut firstFail : Option Nat := none
   for param in ladder do
     if firstFail.isSome then break
-    let rung ← runRungTrials spec param spec.config.outerTrials
+    -- Probe runs one trial per rung — see the docstring rationale.
+    let rung ← runRungTrials spec param 1
     points := points ++ rung
-    -- The first trial decides the bracket: subsequent trials at this
-    -- rung are aggregate evidence, not bracket-finding evidence.
-    match rung[0]!.status with
-    | .ok => lastOk := some param
-    | _   => firstFail := some param
+    if rungAnyOk rung then lastOk := some param
+    else firstFail := some param
   return (points, lastOk, firstFail)
+
+/-- After the doubling probe, top up the trials at every successful
+    probe rung so each verdict-eligible param ends up with
+    `outerTrials` measurements. Only called in `.doubling` mode (where
+    probe rows ARE the verdict data); in `.linear` mode probe rows are
+    demoted to `partOfVerdict := false` and the linear sweep provides
+    the trial cluster on its own.
+
+    Trials added here are tagged with `trialIndex` 1..outerTrials-1
+    (the probe contributed index 0). If a top-up trial fails, it still
+    gets recorded — we want the user to see the flake rather than have
+    it silently dropped — but it doesn't change `lastOk`/`firstFail`
+    since those were settled by the probe. Issue #4. -/
+private def topUpDoublingTrials (spec : BenchmarkSpec)
+    (probePoints : Array DataPoint) : IO (Array DataPoint) := do
+  let extraTrials := spec.config.outerTrials - 1
+  if extraTrials == 0 then return probePoints
+  -- Distinct ok params in probe order.
+  let mut seen : Std.HashSet Nat := {}
+  let mut okParams : Array Nat := #[]
+  for dp in probePoints do
+    if dp.status == .ok && !seen.contains dp.param then
+      seen := seen.insert dp.param
+      okParams := okParams.push dp.param
+  let mut acc := probePoints
+  for p in okParams do
+    for i in [0 : extraTrials] do
+      let dp ← runOneBatch spec p
+      acc := acc.push { dp with trialIndex := i + 1 }
+  return acc
 
 /-- Resolve `.auto` to either `.doubling` or a sensible `.linear`.
     `.custom` and the explicit shapes pass through unchanged. -/
@@ -440,32 +494,32 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
     for n in params do
       let rung ← runRungTrials spec n cfg.outerTrials
       points := points ++ rung
-      if rung[0]!.status != .ok then break
+      -- Stop the ladder only when EVERY trial at this rung failed.
+      -- A transient first-trial timeout no longer poisons the rest
+      -- of the schedule (Codex review).
+      unless rungAnyOk rung do break
   | _ =>
     let (probePoints, lastOk?, firstFail?) ← runDoublingProbe spec
     points := probePoints
     match schedule with
-    | .doubling => pure ()
+    | .doubling =>
+      -- Probe rows ARE the verdict data here. Top up every successful
+      -- probe rung to `outerTrials` measurements.
+      points ← topUpDoublingTrials spec points
     | .custom _ => pure ()  -- unreachable in this branch
     | .auto => pure ()  -- unreachable after resolveSchedule
     | .linear samples =>
       match lastOk?, firstFail? with
       | some lastOk, some firstFail =>
-        -- Tighten the bracket using the complexity model + observed
-        -- cost at `lastOk`. Use the median of the trial cluster at
-        -- `lastOk` so a single noisy probe trial doesn't shift the
-        -- extrapolation. With outerTrials = 1 this is just the one
-        -- observed perCallNanos.
-        let lastOkPerCalls : Array Float :=
-          probePoints.filterMap fun dp =>
-            if dp.param == lastOk && dp.status == .ok then
-              some dp.perCallNanos
-            else none
+        -- The probe ran one trial per rung; for the bracket-tightening
+        -- extrapolation use that single perCallNanos directly. (No
+        -- median needed because there's no cluster yet — the cluster
+        -- is built later by the sweep.)
         let lastOkPerCall : Float :=
-          if lastOkPerCalls.isEmpty then 0.0
-          else
-            let sorted := lastOkPerCalls.qsort (· < ·)
-            sorted[sorted.size / 2]!
+          (probePoints.findSome? fun dp =>
+              if dp.param == lastOk && dp.status == .ok then
+                some dp.perCallNanos
+              else none).getD 0.0
         let capNanos : Float := cfg.maxSecondsPerCall * 1.0e9
         let effFirstFail :=
           estimateFirstFail entry.complexity lastOk lastOkPerCall
@@ -478,12 +532,13 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
           for n in rungs do
             let rung ← runRungTrials spec n cfg.outerTrials
             points := points ++ rung
-            if rung[0]!.status != .ok then break
+            -- Stop the sweep only when EVERY trial at this rung failed.
+            unless rungAnyOk rung do break
       | _, _ =>
         -- No bracket (doubling ran clean to ceiling, or first rung failed).
-        -- Fall back to doubling-only — probe rows already have
-        -- `partOfVerdict := true`.
-        pure ()
+        -- Fall back to doubling-only — top up trials so the verdict
+        -- cluster is the full configured size.
+        points ← topUpDoublingTrials spec points
   let spawnFloor ← measureSpawnFloor
   -- Annotate below-floor rows BEFORE summarising so the verdict
   -- ratios and the advisory list see the same filtered view.

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -298,12 +298,35 @@ private def pickLinearRungs (lastOk firstFail samples : Nat) : Array Nat :=
     let last := min (firstFail - 1) (lastOk + samples)
     (Array.range (last - lastOk)).map (lastOk + 1 + ·)
 
+/-- Run a single rung, taking `trials` independent outer measurements.
+    Each call to `runOneBatch` is one fresh child spawn; per-trial
+    points are tagged with `trialIndex` 0..trials-1. If the first
+    trial at this rung fails (timed out / killed / errored) we stop
+    immediately rather than re-spawning at a known-bad rung — the
+    one failed row is enough for `lastOk` / `firstFail` bracketing
+    and for the user-facing report. Issue #4. -/
+private def runRungTrials (spec : BenchmarkSpec) (param : Nat)
+    (trials : Nat) : IO (Array DataPoint) := do
+  let mut acc : Array DataPoint := #[]
+  let trials := max 1 trials
+  for i in [0 : trials] do
+    let dp ← runOneBatch spec param
+    acc := acc.push { dp with trialIndex := i }
+    if dp.status != .ok then break
+  return acc
+
 /-- Run the static doubling ladder. Returns `(points, lastOk?, firstFail?)`:
 
 - `lastOk?` is the largest param whose status was `.ok` (none if no row
   was ok),
 - `firstFail?` is the first param after `lastOk` whose status was non-ok
   (none if the ladder ran to ceiling without failing).
+
+Each rung runs `cfg.outerTrials` independent measurements; the rung's
+status for the bracket-finding decision is the status of the *first*
+trial (i.e. if the first trial succeeds we keep going; if it fails
+the rung is the bracket boundary, regardless of whether later trials
+would have succeeded — which they shouldn't, given the first failed).
 
 Probe rows are returned with whatever `partOfVerdict` `runOneBatch`
 chose (defaults to true); the caller flips them as needed. -/
@@ -315,9 +338,11 @@ private def runDoublingProbe (spec : BenchmarkSpec) :
   let mut firstFail : Option Nat := none
   for param in ladder do
     if firstFail.isSome then break
-    let dp ← runOneBatch spec param
-    points := points.push dp
-    match dp.status with
+    let rung ← runRungTrials spec param spec.config.outerTrials
+    points := points ++ rung
+    -- The first trial decides the bracket: subsequent trials at this
+    -- rung are aggregate evidence, not bracket-finding evidence.
+    match rung[0]!.status with
     | .ok => lastOk := some param
     | _   => firstFail := some param
   return (points, lastOk, firstFail)
@@ -413,9 +438,9 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
   match schedule with
   | .custom params =>
     for n in params do
-      let dp ← runOneBatch spec n
-      points := points.push dp
-      if dp.status != .ok then break
+      let rung ← runRungTrials spec n cfg.outerTrials
+      points := points ++ rung
+      if rung[0]!.status != .ok then break
   | _ =>
     let (probePoints, lastOk?, firstFail?) ← runDoublingProbe spec
     points := probePoints
@@ -427,13 +452,20 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
       match lastOk?, firstFail? with
       | some lastOk, some firstFail =>
         -- Tighten the bracket using the complexity model + observed
-        -- cost at `lastOk`, so we don't burn the sweep budget on rungs
-        -- that are guaranteed to hit the cap.
+        -- cost at `lastOk`. Use the median of the trial cluster at
+        -- `lastOk` so a single noisy probe trial doesn't shift the
+        -- extrapolation. With outerTrials = 1 this is just the one
+        -- observed perCallNanos.
+        let lastOkPerCalls : Array Float :=
+          probePoints.filterMap fun dp =>
+            if dp.param == lastOk && dp.status == .ok then
+              some dp.perCallNanos
+            else none
         let lastOkPerCall : Float :=
-          (probePoints.findSome? fun dp =>
-              if dp.param == lastOk && dp.status == .ok then
-                some dp.perCallNanos
-              else none).getD 0.0
+          if lastOkPerCalls.isEmpty then 0.0
+          else
+            let sorted := lastOkPerCalls.qsort (· < ·)
+            sorted[sorted.size / 2]!
         let capNanos : Float := cfg.maxSecondsPerCall * 1.0e9
         let effFirstFail :=
           estimateFirstFail entry.complexity lastOk lastOkPerCall
@@ -444,9 +476,9 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
           -- don't enter `cMin`/`cMax`/slope.
           points := points.map ({ · with partOfVerdict := false })
           for n in rungs do
-            let dp ← runOneBatch spec n
-            points := points.push dp
-            if dp.status != .ok then break
+            let rung ← runRungTrials spec n cfg.outerTrials
+            points := points ++ rung
+            if rung[0]!.status != .ok then break
       | _, _ =>
         -- No bracket (doubling ran clean to ceiling, or first rung failed).
         -- Fall back to doubling-only — probe rows already have

--- a/LeanBench/Stats.lean
+++ b/LeanBench/Stats.lean
@@ -21,13 +21,24 @@ namespace Stats
     any pre-filtering (we don't know what 'invalid' means here).
     Returns `0.0` on an empty array — callers should check before
     calling and skip the param entirely if no usable data exists.
-    Upper-middle on even sample counts to match `Run.medianNat`'s
-    convention (conservative for regression flagging). -/
+
+    Standard textbook median: odd `size` → middle element; even
+    `size` → mean of the two middle elements. Codex flagged the
+    earlier upper-middle variant as a systematic upward bias when
+    `okCount` happens to be even (a real possibility once failures
+    or floor-filtering knock trials out of the cluster). Mean-of-
+    middles is unbiased under any symmetric noise distribution and
+    matches what users expect when they read "median" in the
+    report. -/
 def medianFloat (xs : Array Float) : Float :=
   if xs.isEmpty then 0.0
   else
     let sorted := xs.qsort (· < ·)
-    sorted[sorted.size / 2]!
+    let n := sorted.size
+    if n % 2 == 1 then
+      sorted[n / 2]!
+    else
+      (sorted[n / 2 - 1]! + sorted[n / 2]!) / 2.0
 
 /-- Verdict-eligible per-call timings at `param` from `points`. Skips
     rows that error / time out / are doubling-probe rows / are below

--- a/LeanBench/Stats.lean
+++ b/LeanBench/Stats.lean
@@ -17,25 +17,73 @@ open Lean
 namespace LeanBench
 namespace Stats
 
-/-- Compute the per-point ratio C = perCallNanos / complexity(param).
-    Skips param=0 and param=1 (denominator may be 0 or 1, noisy),
-    any non-`ok` data points, any rows flagged as not part of the
-    verdict (doubling-probe rows in `.linear` mode), and any rows
-    whose total wall time was dominated by spawn overhead
-    (`belowSignalFloor` — see issue #15). -/
+/-- Median of an `Array Float`. The caller is expected to have done
+    any pre-filtering (we don't know what 'invalid' means here).
+    Returns `0.0` on an empty array — callers should check before
+    calling and skip the param entirely if no usable data exists.
+    Upper-middle on even sample counts to match `Run.medianNat`'s
+    convention (conservative for regression flagging). -/
+def medianFloat (xs : Array Float) : Float :=
+  if xs.isEmpty then 0.0
+  else
+    let sorted := xs.qsort (· < ·)
+    sorted[sorted.size / 2]!
+
+/-- Verdict-eligible per-call timings at `param` from `points`. Skips
+    rows that error / time out / are doubling-probe rows / are below
+    the signal floor — same filter as `ratiosFromPoints`. Exposed
+    (not `private`) for the `TrialSummary` reduction in `summarize`. -/
+def verdictPerCallsAt (param : Nat) (points : Array DataPoint) :
+    Array Float :=
+  points.filterMap fun dp =>
+    if dp.param == param && dp.status == .ok && dp.partOfVerdict
+        && !dp.belowSignalFloor then
+      some dp.perCallNanos
+    else none
+
+/-- Distinct verdict-eligible params from `points`, in ladder order
+    (first-occurrence). Used to drive both `ratiosFromPoints` and the
+    `TrialSummary` reduction so the two stay in lockstep. -/
+private def verdictParamsInOrder (points : Array DataPoint) : Array Nat :=
+  Id.run do
+    let mut acc : Array Nat := #[]
+    let mut seen : Std.HashSet Nat := {}
+    for dp in points do
+      if dp.status != .ok then continue
+      if !dp.partOfVerdict then continue
+      if dp.belowSignalFloor then continue
+      unless seen.contains dp.param do
+        seen := seen.insert dp.param
+        acc := acc.push dp.param
+    return acc
+
+/-- Compute the per-param ratio C = median(perCallNanos at param) /
+    complexity(param), one entry per distinct verdict-eligible param.
+    Skips param=0 and param=1 (denominator may be 0 or 1, noisy), any
+    non-`ok` data points, doubling-probe rows in `.linear` mode, and
+    rows whose total wall time was dominated by spawn overhead
+    (`belowSignalFloor` — see issue #15).
+
+    With `outerTrials = 1` (the v0.1 default) each param has exactly
+    one verdict-eligible row, so the median is that single row's
+    `perCallNanos` — i.e. behaviour is identical to v0.1. With
+    `outerTrials > 1` the slope fit and the `cMin`/`cMax` range check
+    both see one robust per-param point rather than `outerTrials`
+    co-located samples that would corrupt the fit's degrees of
+    freedom. Issue #4. -/
 def ratiosFromPoints
     (complexity : Nat → Nat)
     (points : Array DataPoint) :
     Array Ratio := Id.run do
   let mut acc : Array Ratio := #[]
-  for dp in points do
-    if dp.param < 2 then continue
-    if dp.status != .ok then continue
-    if !dp.partOfVerdict then continue
-    if dp.belowSignalFloor then continue
-    let d := complexity dp.param
+  for p in verdictParamsInOrder points do
+    if p < 2 then continue
+    let d := complexity p
     if d == 0 then continue
-    acc := acc.push (dp.param, dp.perCallNanos / d.toFloat)
+    let perCalls := verdictPerCallsAt p points
+    if perCalls.isEmpty then continue
+    let median := medianFloat perCalls
+    acc := acc.push (p, median / d.toFloat)
   return acc
 
 /-- OLS slope of the points `(x, y)`. `none` if there are fewer than
@@ -181,6 +229,34 @@ def computeAdvisories (points : Array DataPoint) (verdictRows : Nat) :
     out := out.push (.tooFewVerdictRows verdictRows)
   return out
 
+/-- Per-param trial summaries. Walks `points` once, groups verdict-
+    eligible `ok` rows by `param`, and emits one `TrialSummary` per
+    param with median / min / max / relative-spread over the cluster.
+    Order is first-occurrence in `points`, matching `ratiosFromPoints`.
+
+    A param with zero verdict-eligible rows is skipped (its ratio is
+    skipped too, so the two stay aligned). With `outerTrials = 1` each
+    summary has `okCount = 1`, `relativeSpread = 0.0`, and
+    `min = median = max`. -/
+def trialSummariesFromPoints (points : Array DataPoint) :
+    Array TrialSummary := Id.run do
+  let mut acc : Array TrialSummary := #[]
+  for p in verdictParamsInOrder points do
+    let perCalls := verdictPerCallsAt p points
+    if perCalls.isEmpty then continue
+    let median := medianFloat perCalls
+    let lo := perCalls.foldl min perCalls[0]!
+    let hi := perCalls.foldl max perCalls[0]!
+    let spread :=
+      if median > 0.0 then (hi - lo) / median else 0.0
+    acc := acc.push {
+      param := p, okCount := perCalls.size,
+      medianPerCallNanos := median,
+      minPerCallNanos := lo,
+      maxPerCallNanos := hi,
+      relativeSpread := spread }
+  return acc
+
 /-- Build a `BenchmarkResult` from spec + complexity closure + collected points.
 
     `points` should already carry `belowSignalFloor` annotations;
@@ -200,6 +276,7 @@ def summarize
       spec.config.slopeTolerance spec.config.narrowRangeNoiseFloor
   let kept := ratios.size - dropped
   let advisories := computeAdvisories points kept
+  let trialSummaries := trialSummariesFromPoints points
   { function := spec.name
   , complexityFormula := spec.complexityFormula
   , hashable := spec.hashable
@@ -211,7 +288,8 @@ def summarize
   , cMax?
   , verdictDroppedLeading := dropped
   , slope?
-  , advisories }
+  , advisories
+  , trialSummaries }
 
 end Stats
 end LeanBench

--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -164,6 +164,82 @@ gives the steady-state cost; `lake exe bench run myFn --cache-mode cold`
 exposes the cold-state cost. The gap between the two is the warm-up
 budget your real workload either can or cannot afford to amortise.
 
+## Outer trials
+
+`--outer-trials N` (declaration-time `where { outerTrials := N }`)
+runs `N` independent measurements per ladder rung instead of one,
+and reports a per-param summary alongside the raw rows. Default is
+`1` — i.e. the v0.1 single-batch-per-param behaviour. Cost scales
+linearly with `N`: `--outer-trials 5` runs roughly 5× as long as
+`--outer-trials 1` on the same ladder.
+
+Each "outer trial" is one full child spawn — independent of the
+intra-child auto-tune loop in warm mode and independent of the
+cold-mode single-spawn-per-rung policy. Trials at the same param
+share the same `param`, but otherwise the harness does nothing to
+correlate them: each gets a fresh process with its own caches,
+allocator state, and OS scheduling.
+
+What you see in the report when `outerTrials > 1`:
+
+- The main table shows every per-trial row, tagged with
+  `[trial k/N]` so you can read the spread directly. The `C=` column
+  on each row is the same per-param ratio (computed from the median),
+  not the per-trial ratio — that's deliberate, the verdict cares
+  about per-param consistency, not per-trial scatter.
+- A `trial summaries` block after the verdict lists one line per
+  ok param with median, min, max, and `spread = (max - min) / median`.
+  A spread of `2.0%` is a tight cluster; `80.0%` is unreliable and
+  worth investigating (CPU thermals, GC pressure, neighbour load).
+
+What the verdict does with multiple trials:
+
+- The slope fit and `cMin/cMax` range check both see one robust
+  median per param, not `N` co-located samples per param. So
+  `--outer-trials 5` does **not** make the slope tolerance look
+  artificially tight by inflating sample count; it just gives you
+  a more trustworthy median.
+- Trials that fail (timed out, killed at cap, errored) don't enter
+  the median — the `okCount` field on each `TrialSummary` says how
+  many of the configured trials actually contributed.
+
+What this is not:
+
+- A statistical framework. There are no confidence intervals,
+  t-tests, bootstrap resamples, or outlier rejection. The summary
+  is descriptive: "here is the shape of the cluster you measured."
+  If you want hypothesis testing across runs, layer a separate tool
+  on top of the JSONL output (which preserves every per-trial row).
+- A noise filter. A high `spread` means the harness is reporting
+  noise honestly, not hiding it. Investigate the cause; don't
+  raise `outerTrials` further hoping the median converges.
+- An override for `signalFloorMultiplier`. A row that would be
+  flagged below the signal floor on a single-trial run is still
+  flagged below the signal floor on a multi-trial run; the median
+  is computed from `ok` rows that survived the same floor filter.
+
+When to bump `outerTrials`:
+
+- Borderline verdict. The benchmark sits near the slope-tolerance
+  edge on a single-shot run; you want to know whether the verdict
+  is a property of the algorithm or a property of yesterday's load
+  average.
+- Noisy CI. The bench job intermittently flags as inconclusive even
+  though the local laptop is rock-solid. `--outer-trials 3` or `5`
+  in CI smooths the noise without changing what the harness reports.
+- Cold-mode investigation. With `--cache-mode cold`, every rung is
+  already a single-shot timing — high noise per data point is part
+  of the design. `--outer-trials 3` gives you back the median /
+  range view that warm-mode auto-tuning produced for free.
+
+When to leave it at `1`:
+
+- Default exploration. One-batch-per-param is fast and the v0.1
+  defaults already capture the shape on most hardware.
+- Tight CI budgets. If `--max-seconds-per-call` is already a
+  binding constraint, multiplying every rung by `N` may push the
+  whole job over its time budget — measure first, multiply second.
+
 ## The per-spawn floor
 
 Every result includes
@@ -181,8 +257,9 @@ times until the param grows past where startup dominates.
 ## What this library is not
 
 - A statistical benchmarking framework. No CIs, no t-tests, no
-  outlier rejection. v0.1 uses one batch per param and trusts the
-  auto-tuner.
+  outlier rejection. The default is one batch per param; bumping
+  `--outer-trials` reports per-param median / min / max / spread
+  but is not a substitute for proper statistical analysis.
 - A profiler. Per-call time is wall time; we don't break it down
   by function or measure allocations. (Allocation tracking is on
   the v0.2 roadmap, F3.)

--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -188,20 +188,39 @@ What you see in the report when `outerTrials > 1`:
   not the per-trial ratio — that's deliberate, the verdict cares
   about per-param consistency, not per-trial scatter.
 - A `trial summaries` block after the verdict lists one line per
-  ok param with median, min, max, and `spread = (max - min) / median`.
-  A spread of `2.0%` is a tight cluster; `80.0%` is unreliable and
-  worth investigating (CPU thermals, GC pressure, neighbour load).
+  **verdict-eligible** param (i.e. params that contributed to the
+  slope fit) with median, min, max, and
+  `spread = (max - min) / median`. A spread of `2.0%` is a tight
+  cluster; `80.0%` is unreliable and worth investigating (CPU
+  thermals, GC pressure, neighbour load). Doubling-probe rows in
+  `.linear` mode and rows below the signal floor are excluded from
+  the summary, matching what the verdict reduction sees, so the
+  block reflects the same data the verdict was computed from.
 
 What the verdict does with multiple trials:
 
-- The slope fit and `cMin/cMax` range check both see one robust
-  median per param, not `N` co-located samples per param. So
-  `--outer-trials 5` does **not** make the slope tolerance look
-  artificially tight by inflating sample count; it just gives you
-  a more trustworthy median.
+- The slope fit and `cMin/cMax` range check see one median per
+  verdict-eligible param, not `N` co-located samples that would
+  pseudo-replicate the rung and overweight it. Bumping
+  `--outer-trials 5` does **not** artificially tighten the slope
+  fit by inflating the apparent sample count; it just gives you a
+  more trustworthy median per rung.
 - Trials that fail (timed out, killed at cap, errored) don't enter
   the median — the `okCount` field on each `TrialSummary` says how
-  many of the configured trials actually contributed.
+  many of the configured trials actually contributed. With
+  `okCount = 1` (only one trial survived) the median is just that
+  one observation; with `okCount = 0` the param is dropped entirely
+  rather than appearing as a median of nothing.
+- The sweep no longer terminates on a flaky single trial. As long
+  as at least one trial at a rung succeeds, the ladder progresses;
+  the rung is treated as "failed" only when *every* configured
+  trial at that rung errors / times out / hits the cap.
+- In `.linear` ladder mode the doubling probe runs one trial per
+  rung regardless of `outerTrials`, since probe rows are
+  bracket-finding only and never enter the verdict reduction. In
+  `.doubling` mode every probe rung that succeeded is topped up to
+  the full `outerTrials` cluster after the probe completes, so the
+  verdict sees the same trial count at every rung.
 
 What this is not:
 

--- a/doc/pitfalls.md
+++ b/doc/pitfalls.md
@@ -285,6 +285,15 @@ What this means in practice:
   measurement, no internal averaging), use `--cache-mode cold` and
   read [advanced.md#cache-modes](advanced.md#cache-modes). The two
   modes measure different things; either can be appropriate.
+- **Single-shot per param is fragile near the boundary.** The
+  default `--outer-trials 1` collects one batch per ladder rung,
+  and a single noisy spawn at the high end can flip a verdict from
+  consistent to inconclusive. Bump `--outer-trials 3` (or higher)
+  to get a per-param median + spread; the verdict then sees the
+  median per param, not a single noisy sample. See
+  [advanced.md#outer-trials](advanced.md#outer-trials) for what
+  the summary block reports and what its limits are. Cost scales
+  linearly with the trial count, so it's a deliberate trade.
 
 For exponential-complexity benchmarks, the ladder shifts from
 doubling to a linear sweep over `(lastOk, firstFail)` and the

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -157,6 +157,7 @@ Available flags:
 | `--slope-tolerance`      | Float          | `slopeTolerance`          |
 | `--param-schedule`       | ParamSchedule  | `paramSchedule`           |
 | `--cache-mode`           | CacheMode      | `cacheMode`               |
+| `--outer-trials`         | Nat            | `outerTrials`             |
 
 `--param-schedule` accepts `auto` (default — pick from declared
 complexity), `doubling`, or `linear`. Use `--param-schedule linear`
@@ -180,6 +181,15 @@ mode is universally better — they measure different things; see
 [advanced.md#cache-modes](advanced.md#cache-modes) for when to use
 each. Pin a benchmark in cold mode at declaration time via
 `where { cacheMode := .cold }`.
+
+`--outer-trials N` runs `N` independent measurements per ladder rung
+and reports per-param median / min / max / spread instead of a single
+sample. Default `1` matches the v0.1 behaviour. Bumping to `3` or `5`
+trades wall time for stability — useful on noisy CI hosts or when a
+verdict is borderline. The raw per-trial points stay in the result so
+nothing is lost. See [advanced.md#outer-trials](advanced.md#outer-trials)
+for how to read the summary block and what its limits are. Pin at
+declaration time via `where { outerTrials := 3 }`.
 
 For workloads that don't fit any built-in ladder — corpus inputs
 where the natural `n` values are non-uniform, or a single-rung

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -12,7 +12,7 @@ defaultTargets = [
   "child_outcome_benchmark_test", "format_benchmark_test",
   "e2e_benchmark_test", "cli_errors_benchmark_test",
   "schema_benchmark_test", "cache_mode_benchmark_test",
-  "advisory_benchmark_test",
+  "advisory_benchmark_test", "outer_trials_benchmark_test",
 ]
 
 [[require]]
@@ -123,3 +123,8 @@ root = "LeanBenchTestCacheMode"
 name = "advisory_benchmark_test"
 srcDir = "test"
 root = "LeanBenchTestAdvisory"
+
+[[lean_exe]]
+name = "outer_trials_benchmark_test"
+srcDir = "test"
+root = "LeanBenchTestOuterTrials"

--- a/test/LeanBenchTestOuterTrials.lean
+++ b/test/LeanBenchTestOuterTrials.lean
@@ -1,0 +1,325 @@
+import LeanBench
+
+/-!
+# Outer trials + per-param trial summaries (issue #4)
+
+Pure unit tests for the issue #4 plumbing: `BenchmarkConfig.outerTrials`,
+`Stats.medianFloat`, `Stats.ratiosFromPoints` aggregating multiple trials
+per param via the median, `Stats.trialSummariesFromPoints` shape, and
+`Format.fmtResult` rendering of the per-param summary block.
+
+Plus one end-to-end run via the same trivially-fast XOR benchmark used
+by `LeanBenchTestE2E`, with `outerTrials := 3`, asserting that:
+- the result has exactly `outerTrials` per-param data points for ok
+  rungs
+- `trialSummaries` has one entry per ok param with the right `okCount`
+- the formatter shows the trial-summary block when `outerTrials > 1`
+-/
+
+open LeanBench
+
+namespace LeanBench.Test.OuterTrials
+
+/-- A trivially-fast `Nat → UInt64` (same shape as the e2e benchmark). -/
+def littleFnTrials (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 1
+  for _ in [0:n] do
+    x := x ^^^ n.toUInt64
+  return x
+
+setup_benchmark littleFnTrials n => n where {
+  maxSecondsPerCall := 0.5, paramCeiling := 8, targetInnerNanos := 50_000_000
+  signalFloorMultiplier := 1.0
+  outerTrials := 3
+}
+
+end LeanBench.Test.OuterTrials
+
+private def trialsName : Lean.Name := `LeanBench.Test.OuterTrials.littleFnTrials
+
+private def expectEq {α} [BEq α] [Repr α] (label : String) (got want : α) :
+    IO Unit := do
+  unless got == want do
+    throw <| .userError
+      s!"{label}: expected {repr want}, got {repr got}"
+
+private def containsSub (haystack needle : String) : Bool :=
+  ((haystack.splitOn needle).length) > 1
+
+private def mkOk (param : Nat) (perCall : Float) (trial : Nat := 0) : DataPoint :=
+  { param, innerRepeats := 1, totalNanos := perCall.toUInt64.toNat
+  , perCallNanos := perCall, resultHash := some 1
+  , status := .ok, trialIndex := trial }
+
+/-! ## `BenchmarkConfig.validate` rejects `outerTrials = 0`. -/
+
+example : (BenchmarkConfig.validate { outerTrials := 0 }).isOk = false := by native_decide
+example : (BenchmarkConfig.validate { outerTrials := 5 }).isOk = true := by native_decide
+
+/-! ## `ConfigOverride.outerTrials?` round-trips through `apply`. -/
+
+example :
+    (({ outerTrials? := some 7 } : ConfigOverride).apply
+      ({ outerTrials := 1 } : BenchmarkConfig)).outerTrials = 7 := rfl
+
+example :
+    (({} : ConfigOverride).apply
+      ({ outerTrials := 4 } : BenchmarkConfig)).outerTrials = 4 := rfl
+
+/-! ## `Stats.medianFloat` -/
+
+def testMedianFloatOdd : IO UInt32 := do
+  let xs : Array Float := #[3.0, 1.0, 2.0]
+  let m := Stats.medianFloat xs
+  unless m == 2.0 do
+    IO.eprintln s!"median odd: expected 2.0, got {m}"
+    return 1
+  return 0
+
+def testMedianFloatEvenUpperMiddle : IO UInt32 := do
+  -- Upper middle on even: index 2 of [1,2,3,4] is 3.0.
+  let xs : Array Float := #[4.0, 1.0, 3.0, 2.0]
+  let m := Stats.medianFloat xs
+  unless m == 3.0 do
+    IO.eprintln s!"median even: expected 3.0 (upper middle), got {m}"
+    return 1
+  return 0
+
+def testMedianFloatEmpty : IO UInt32 := do
+  let xs : Array Float := #[]
+  let m := Stats.medianFloat xs
+  unless m == 0.0 do
+    IO.eprintln s!"median empty: expected 0.0, got {m}"
+    return 1
+  return 0
+
+/-! ## `ratiosFromPoints` collapses trials per param via median. -/
+
+def testRatiosUseMedianAcrossTrials : IO UInt32 := do
+  -- Three trials at param=4, two trials at param=8. The middle (median)
+  -- of each cluster should drive the per-param ratio.
+  let pts : Array DataPoint := #[
+    mkOk 4 100.0 (trial := 0),
+    mkOk 4 200.0 (trial := 1),
+    mkOk 4 300.0 (trial := 2),
+    mkOk 8 350.0 (trial := 0),
+    mkOk 8 450.0 (trial := 1) ]
+  -- complexity = identity (n).
+  let comp : Nat → Nat := fun n => n
+  let rs := Stats.ratiosFromPoints comp pts
+  expectEq "ratios.size" rs.size 2
+  -- median(100,200,300) = 200; ratio at param=4 is 200/4 = 50.
+  expectEq "ratios.0.param" rs[0]!.1 4
+  unless rs[0]!.2 == 50.0 do
+    IO.eprintln s!"expected ratio at 4 to be 50.0, got {rs[0]!.2}"
+    return 1
+  -- Even-length cluster at 8: upper middle of (350, 450) = 450; ratio
+  -- 450/8 = 56.25.
+  expectEq "ratios.1.param" rs[1]!.1 8
+  unless rs[1]!.2 == 56.25 do
+    IO.eprintln s!"expected ratio at 8 to be 56.25 (upper-middle median), got {rs[1]!.2}"
+    return 1
+  return 0
+
+def testRatiosSkipNonOkTrials : IO UInt32 := do
+  -- A failed trial at param=4 must not count toward the median: median
+  -- of just (100, 300) — the two ok trials — is 300 (upper middle).
+  let pts : Array DataPoint := #[
+    mkOk 4 100.0 (trial := 0),
+    { param := 4, innerRepeats := 0, totalNanos := 0, perCallNanos := 0.0
+    , resultHash := none, status := .killedAtCap, trialIndex := 1 },
+    mkOk 4 300.0 (trial := 2) ]
+  let rs := Stats.ratiosFromPoints (fun n => n) pts
+  expectEq "ratios.size after skip" rs.size 1
+  -- 300 / 4 = 75.0
+  unless rs[0]!.2 == 75.0 do
+    IO.eprintln s!"expected ratio 75.0 (median of ok trials only), got {rs[0]!.2}"
+    return 1
+  return 0
+
+/-! ## `trialSummariesFromPoints` -/
+
+def testTrialSummariesShape : IO UInt32 := do
+  let pts : Array DataPoint := #[
+    mkOk 4 100.0 (trial := 0),
+    mkOk 4 200.0 (trial := 1),
+    mkOk 4 300.0 (trial := 2),
+    mkOk 8 500.0 (trial := 0) ]
+  let ss := Stats.trialSummariesFromPoints pts
+  expectEq "summaries.size" ss.size 2
+  expectEq "s0.param" ss[0]!.param 4
+  expectEq "s0.okCount" ss[0]!.okCount 3
+  unless ss[0]!.medianPerCallNanos == 200.0 do
+    IO.eprintln s!"s0.median: expected 200.0, got {ss[0]!.medianPerCallNanos}"
+    return 1
+  unless ss[0]!.minPerCallNanos == 100.0 do
+    IO.eprintln s!"s0.min: expected 100.0, got {ss[0]!.minPerCallNanos}"
+    return 1
+  unless ss[0]!.maxPerCallNanos == 300.0 do
+    IO.eprintln s!"s0.max: expected 300.0, got {ss[0]!.maxPerCallNanos}"
+    return 1
+  -- (max - min) / median = (300 - 100) / 200 = 1.0.
+  unless ss[0]!.relativeSpread == 1.0 do
+    IO.eprintln s!"s0.spread: expected 1.0, got {ss[0]!.relativeSpread}"
+    return 1
+  -- A single-trial cluster has spread = 0, min = max = median.
+  expectEq "s1.okCount" ss[1]!.okCount 1
+  unless ss[1]!.relativeSpread == 0.0 do
+    IO.eprintln s!"s1.spread: expected 0.0 on single trial, got {ss[1]!.relativeSpread}"
+    return 1
+  return 0
+
+/-! ## `Format.fmtResult` shows the trial-summary block iff outerTrials > 1. -/
+
+def testFmtResultHidesSummaryWhenOuterTrialsOne : IO UInt32 := do
+  let pts : Array DataPoint := #[mkOk 4 200.0]
+  let result : BenchmarkResult :=
+    { function := `Sample.fast
+    , complexityFormula := "n"
+    , hashable := true
+    , config := { outerTrials := 1 }
+    , points := pts
+    , ratios := #[(4, 50.0)]
+    , verdict := .inconclusive
+    , cMin? := some 50.0
+    , cMax? := some 50.0
+    , verdictDroppedLeading := 0
+    , slope? := none
+    , spawnFloorNanos? := some 100
+    , advisories := #[]
+    , trialSummaries := Stats.trialSummariesFromPoints pts }
+  let rendered := Format.fmtResult result
+  if containsSub rendered "trial summaries" then
+    IO.eprintln s!"expected NO trial-summary block when outerTrials=1, got:\n{rendered}"
+    return 1
+  -- Per-trial annotation must also be absent in the single-trial case.
+  if containsSub rendered "[trial 1/1]" then
+    IO.eprintln s!"expected NO [trial k/N] markers when outerTrials=1, got:\n{rendered}"
+    return 1
+  return 0
+
+def testFmtResultShowsSummaryWhenOuterTrialsGtOne : IO UInt32 := do
+  let pts : Array DataPoint := #[
+    mkOk 4 100.0 (trial := 0),
+    mkOk 4 200.0 (trial := 1),
+    mkOk 4 300.0 (trial := 2) ]
+  let summaries := Stats.trialSummariesFromPoints pts
+  let result : BenchmarkResult :=
+    { function := `Sample.trio
+    , complexityFormula := "n"
+    , hashable := true
+    , config := { outerTrials := 3 }
+    , points := pts
+    , ratios := #[(4, 50.0)]
+    , verdict := .inconclusive
+    , cMin? := some 50.0
+    , cMax? := some 50.0
+    , verdictDroppedLeading := 0
+    , slope? := none
+    , spawnFloorNanos? := some 100
+    , advisories := #[]
+    , trialSummaries := summaries }
+  let rendered := Format.fmtResult result
+  for needle in
+    ["trial summaries (3 trials per param", "spread", "[trial 1/3]",
+     "[trial 2/3]", "[trial 3/3]"] do
+    unless containsSub rendered needle do
+      IO.eprintln s!"missing '{needle}' in:\n{rendered}"
+      return 1
+  return 0
+
+/-! ## End-to-end: a real outerTrials=3 run produces the right shape. -/
+
+def testEndToEndOuterTrialsThree : IO UInt32 := do
+  let result ← runBenchmark trialsName
+  -- The benchmark is registered with outerTrials=3; every successful
+  -- rung should have its three measurements in `points`.
+  if result.points.isEmpty then
+    IO.eprintln "expected at least one measured point"
+    return 1
+  -- Group ok points by param, assert each group has 3 entries — every
+  -- rung that completed should run the full trial cluster (the harness
+  -- bails out only on the first failed trial).
+  let okPoints := result.points.filter (·.status == .ok)
+  if okPoints.isEmpty then
+    IO.eprintln s!"expected at least one ok point; got: {repr (result.points.map (·.status))}"
+    return 1
+  let okParams : Array Nat := okPoints.map (·.param)
+  let distinct : Array Nat := okParams.foldl (init := #[]) fun acc p =>
+    if acc.contains p then acc else acc.push p
+  for p in distinct do
+    let countAtP := okPoints.filter (·.param == p) |>.size
+    unless countAtP == 3 do
+      IO.eprintln s!"param={p} had {countAtP} ok trials; expected 3 (outerTrials=3)"
+      return 1
+  -- Trial indices must be 0,1,2 within each rung's ok cluster.
+  for p in distinct do
+    let indices : Array Nat := okPoints.filterMap fun dp =>
+      if dp.param == p then some dp.trialIndex else none
+    let sorted := indices.qsort (· < ·)
+    unless sorted == #[0, 1, 2] do
+      IO.eprintln s!"param={p} trial indices: expected #[0,1,2], got {sorted}"
+      return 1
+  -- Trial summaries: one entry per ok param.
+  unless result.trialSummaries.size == distinct.size do
+    IO.eprintln s!"expected {distinct.size} trial summaries, got {result.trialSummaries.size}"
+    return 1
+  for s in result.trialSummaries do
+    unless s.okCount == 3 do
+      IO.eprintln s!"trial-summary at param={s.param} okCount={s.okCount}, expected 3"
+      return 1
+    unless s.minPerCallNanos ≤ s.medianPerCallNanos
+        ∧ s.medianPerCallNanos ≤ s.maxPerCallNanos do
+      IO.eprintln s!"trial-summary at param={s.param}: min/median/max ordering broken"
+      return 1
+  return 0
+
+/-! ## CLI flag round-trip -/
+
+def testCliOuterTrialsFlag : IO UInt32 := do
+  match LeanBench.Cli.topCmd.process
+      ["run", "littleFnTrials", "--outer-trials", "5"] with
+  | .ok (_, parsed) =>
+    let ovr := LeanBench.Cli.configOverrideFromParsed parsed
+    expectEq "cli.outerTrials" ovr.outerTrials? (some 5)
+    return 0
+  | .error (_, msg) =>
+    IO.eprintln s!"unexpected parse failure: {msg}"
+    return 1
+
+/-! ## Driver -/
+
+def runTests : IO UInt32 := do
+  let mut anyFail : UInt32 := 0
+  for (label, t) in
+    [ ("median.odd", testMedianFloatOdd),
+      ("median.evenUpperMiddle", testMedianFloatEvenUpperMiddle),
+      ("median.empty", testMedianFloatEmpty),
+      ("ratios.medianAcrossTrials", testRatiosUseMedianAcrossTrials),
+      ("ratios.skipNonOk", testRatiosSkipNonOkTrials),
+      ("trialSummaries.shape", testTrialSummariesShape),
+      ("fmtResult.hidesSummaryWhenOne", testFmtResultHidesSummaryWhenOuterTrialsOne),
+      ("fmtResult.showsSummaryWhenMore", testFmtResultShowsSummaryWhenOuterTrialsGtOne),
+      ("cli.outerTrialsFlag", testCliOuterTrialsFlag),
+      ("e2e.outerTrialsThree", testEndToEndOuterTrialsThree) ]
+  do
+    let code ←
+      try t
+      catch e => do
+        IO.eprintln s!"FAIL: {label}: {e.toString}"
+        pure 1
+    if code != 0 then
+      IO.eprintln s!"FAIL: {label}"
+      anyFail := 1
+    else
+      IO.println s!"  ok  {label}"
+  if anyFail == 0 then
+    IO.println "outer-trials tests passed"
+  return anyFail
+
+/-- Same compiled binary is parent (driver) and child (single batch);
+    `_child` first arg distinguishes them. -/
+def main (args : List String) : IO UInt32 :=
+  match args with
+  | "_child" :: _ => LeanBench.Cli.dispatch args
+  | _ => runTests

--- a/test/LeanBenchTestOuterTrials.lean
+++ b/test/LeanBenchTestOuterTrials.lean
@@ -76,12 +76,12 @@ def testMedianFloatOdd : IO UInt32 := do
     return 1
   return 0
 
-def testMedianFloatEvenUpperMiddle : IO UInt32 := do
-  -- Upper middle on even: index 2 of [1,2,3,4] is 3.0.
+def testMedianFloatEvenMeanOfMiddles : IO UInt32 := do
+  -- Mean of two middles on even: (2 + 3) / 2 = 2.5.
   let xs : Array Float := #[4.0, 1.0, 3.0, 2.0]
   let m := Stats.medianFloat xs
-  unless m == 3.0 do
-    IO.eprintln s!"median even: expected 3.0 (upper middle), got {m}"
+  unless m == 2.5 do
+    IO.eprintln s!"median even: expected 2.5 (mean of two middles), got {m}"
     return 1
   return 0
 
@@ -113,17 +113,18 @@ def testRatiosUseMedianAcrossTrials : IO UInt32 := do
   unless rs[0]!.2 == 50.0 do
     IO.eprintln s!"expected ratio at 4 to be 50.0, got {rs[0]!.2}"
     return 1
-  -- Even-length cluster at 8: upper middle of (350, 450) = 450; ratio
-  -- 450/8 = 56.25.
+  -- Even-length cluster at 8: mean of (350, 450) = 400; ratio
+  -- 400/8 = 50.
   expectEq "ratios.1.param" rs[1]!.1 8
-  unless rs[1]!.2 == 56.25 do
-    IO.eprintln s!"expected ratio at 8 to be 56.25 (upper-middle median), got {rs[1]!.2}"
+  unless rs[1]!.2 == 50.0 do
+    IO.eprintln s!"expected ratio at 8 to be 50.0 (mean-of-middles median), got {rs[1]!.2}"
     return 1
   return 0
 
 def testRatiosSkipNonOkTrials : IO UInt32 := do
-  -- A failed trial at param=4 must not count toward the median: median
-  -- of just (100, 300) — the two ok trials — is 300 (upper middle).
+  -- A failed trial at param=4 must not count toward the median:
+  -- median of just (100, 300) — the two ok trials — is 200 (mean
+  -- of the two middles, since okCount drops to 2).
   let pts : Array DataPoint := #[
     mkOk 4 100.0 (trial := 0),
     { param := 4, innerRepeats := 0, totalNanos := 0, perCallNanos := 0.0
@@ -131,9 +132,9 @@ def testRatiosSkipNonOkTrials : IO UInt32 := do
     mkOk 4 300.0 (trial := 2) ]
   let rs := Stats.ratiosFromPoints (fun n => n) pts
   expectEq "ratios.size after skip" rs.size 1
-  -- 300 / 4 = 75.0
-  unless rs[0]!.2 == 75.0 do
-    IO.eprintln s!"expected ratio 75.0 (median of ok trials only), got {rs[0]!.2}"
+  -- 200 / 4 = 50.0
+  unless rs[0]!.2 == 50.0 do
+    IO.eprintln s!"expected ratio 50.0 (median of ok trials only), got {rs[0]!.2}"
     return 1
   return 0
 
@@ -293,7 +294,7 @@ def runTests : IO UInt32 := do
   let mut anyFail : UInt32 := 0
   for (label, t) in
     [ ("median.odd", testMedianFloatOdd),
-      ("median.evenUpperMiddle", testMedianFloatEvenUpperMiddle),
+      ("median.evenMeanOfMiddles", testMedianFloatEvenMeanOfMiddles),
       ("median.empty", testMedianFloatEmpty),
       ("ratios.medianAcrossTrials", testRatiosUseMedianAcrossTrials),
       ("ratios.skipNonOk", testRatiosSkipNonOkTrials),


### PR DESCRIPTION
## Summary

Closes #4. Adds an `outerTrials` knob and per-param trial summaries
(median / min / max / spread) without committing to a full
Criterion/JMH-style statistical framework.

- `BenchmarkConfig.outerTrials` (default `1`, declaration-time via
  `where { outerTrials := 3 }`) and the matching `--outer-trials N`
  CLI flag on `run`/`compare`. Default `1` is wire-identical to v0.1.
- With `outerTrials > 1` the harness runs `N` independent child
  spawns per ladder rung. `BenchmarkResult.points` keeps every
  per-trial row (raw data preserved per the issue's acceptance
  criterion); `BenchmarkResult.trialSummaries` reports one
  `TrialSummary` per verdict-eligible param with median, min, max,
  and `relativeSpread = (max - min) / median`.
- The verdict slope fit and `cMin`/`cMax` range check now consume
  one median per param rather than `N` co-located samples that
  would pseudo-replicate the rung.
- The doubling probe in `.linear` mode runs one trial per rung
  regardless of `outerTrials` (probe rows are
  `partOfVerdict := false` and never enter the verdict). The
  `.doubling` path tops up every successful probe rung to the
  full cluster after the probe completes.
- The sweep no longer terminates on a flaky single trial: a rung
  is treated as failed only when *every* configured trial at that
  rung errors / times out / hits the cap.
- Wire format unchanged: `trialIndex` is parent-side metadata and
  the child JSONL row stays at schema v1.

## What `--outer-trials 3` looks like in the report

The main table interleaves three rows per param tagged
`[trial 1/3]`, `[trial 2/3]`, `[trial 3/3]`. After the verdict
line a new block lists one summary line per verdict-eligible
param with `median`, `min`, `max`, and `spread`. The block is
hidden entirely when `outerTrials = 1` (every summary would
trivially have `min = median = max`, `spread = 0`).

Costs scale linearly with `N` — users who bump the knob are
opting into the runtime trade explicitly.

## Test plan

- [x] new `outer_trials_benchmark_test` covers `medianFloat`
  (odd/even/empty), per-param median aggregation,
  `trialSummariesFromPoints` shape, `Format.fmtResult` toggling
  the summary block by `outerTrials`, the `--outer-trials` CLI
  parse, and a real `outerTrials := 3` end-to-end run that
  asserts every successful rung has its three measurements
- [x] every existing test still passes (roundtrip, config,
  format, child-outcome, schema, cli-errors, advisory, fixed,
  verify, cache-mode, e2e)
- [x] `lake build` clean

## Review notes

Got a `/second-opinion` from Codex; addressed all four concerns
in commit 0f58752:

1. `medianFloat` switched from upper-middle to mean-of-two-middles
   on even counts (the upper-middle bias was material once
   failures left even `okCount`)
2. Doubling probe drops to one trial per rung in `.linear` mode;
   `.doubling` mode tops up after the probe so the verdict still
   sees the full cluster
3. `runRungTrials` no longer early-breaks on first failure;
   ladder progression keys off `rungAnyOk`
4. Docs clarified — `trialSummaries` is verdict-eligible only,
   not all `ok` rows; replaced "degrees of freedom" wording with
   pseudo-replication framing

🤖 Prepared with Claude Code