### PR TITLE
feat: capture environment and reproducibility metadata (issue #11)

### DIFF
--- a/LeanBench.lean
+++ b/LeanBench.lean
@@ -1,6 +1,7 @@
 import LeanBench.Core
 import LeanBench.Schema
 import LeanBench.Env
+import LeanBench.RunEnv
 import LeanBench.Setup
 import LeanBench.Child
 import LeanBench.Run

--- a/LeanBench/Child.lean
+++ b/LeanBench/Child.lean
@@ -1,6 +1,7 @@
 import Lean
 import LeanBench.Core
 import LeanBench.Env
+import LeanBench.RunEnv
 import LeanBench.Schema
 
 /-!
@@ -108,10 +109,23 @@ private def jsonOptHash : Option UInt64 → String
   | none => "null"
   | some h => s!"\"0x{String.ofList (Nat.toDigits 16 h.toNat)}\""
 
-/-- Render one JSONL row to stdout. -/
+/-- Render the captured `Env` as the inline `"env":{...}` field used
+on every JSONL row. We go via `Lean.Json.compress` rather than the
+hand-rolled string concatenation used elsewhere in this file so the
+nested object's escaping (CPU model strings can contain `"`) goes
+through the same escape rules `Lean.Json.parse` will use to read it
+back. -/
+private def jsonEnvFragment (env : Env) : String :=
+  s!"\"env\":{(RunEnv.toJson env).compress}"
+
+/-- Render one JSONL row to stdout. The `env` object is required
+(per the issue #11 acceptance criterion: "missing metadata is handled
+explicitly rather than silently omitted") — the child captures env
+once at entry and threads it into every emit, including synthesized
+error rows. -/
 def emitRow
     (function : Lean.Name) (param innerRepeats totalNanos : Nat)
-    (resultHash : Option UInt64) (status : Status)
+    (resultHash : Option UInt64) (status : Status) (env : Env)
     (cacheMode : CacheMode := .warm)
     (errorMsg? : Option String := none) :
     IO Unit := do
@@ -128,7 +142,8 @@ def emitRow
       s!"\"cache_mode\":{jsonStr cacheMode.toJsonString}",
       s!"\"result_hash\":{jsonOptHash resultHash}",
       s!"\"status\":{jsonStr status.toJsonString}",
-      s!"\"error\":{jsonOptStr errorMsg?}"
+      s!"\"error\":{jsonOptStr errorMsg?}",
+      jsonEnvFragment env
     ] ++ "}"
   IO.println row
 
@@ -156,10 +171,14 @@ def emitRow
     differ. -/
 def runChildMode (benchName : Lean.Name) (param targetNanos : Nat)
     (cacheMode : CacheMode := .warm) : IO UInt32 := do
+  -- Capture env *before* dispatching: we want a row even for the
+  -- "unregistered benchmark" failure case, and that row needs an
+  -- `env` field per the schema contract.
+  let env ← RunEnv.capture
   match ← findRuntimeEntry benchName with
   | none =>
     emitRow benchName param 0 0 none
-      (.error s!"unregistered benchmark: {benchName}")
+      (.error s!"unregistered benchmark: {benchName}") env
       (cacheMode := cacheMode)
       (errorMsg? := some s!"unregistered benchmark: {benchName}")
     return 1
@@ -177,11 +196,11 @@ def runChildMode (benchName : Lean.Name) (param targetNanos : Nat)
           -- fresh process".
           let (t, h) ← loop 1
           pure (1, t, h)
-      emitRow benchName param count total hash .ok (cacheMode := cacheMode)
+      emitRow benchName param count total hash .ok env (cacheMode := cacheMode)
       return (0 : UInt32)
     catch e =>
       let msg := s!"runner threw: {e.toString}"
-      emitRow benchName param 0 0 none (.error msg)
+      emitRow benchName param 0 0 none (.error msg) env
         (cacheMode := cacheMode) (errorMsg? := some msg)
       return (1 : UInt32)
 
@@ -199,7 +218,7 @@ isolation machinery applies unchanged. -/
     meaningless for a fixed benchmark. -/
 def emitFixedRow
     (function : Lean.Name) (repeatIndex totalNanos : Nat)
-    (resultHash : Option UInt64) (status : Status)
+    (resultHash : Option UInt64) (status : Status) (env : Env)
     (errorMsg? : Option String := none) :
     IO Unit := do
   let row :=
@@ -211,7 +230,8 @@ def emitFixedRow
       s!"\"total_nanos\":{totalNanos}",
       s!"\"result_hash\":{jsonOptHash resultHash}",
       s!"\"status\":{jsonStr status.toJsonString}",
-      s!"\"error\":{jsonOptStr errorMsg?}"
+      s!"\"error\":{jsonOptStr errorMsg?}",
+      jsonEnvFragment env
     ] ++ "}"
   IO.println row
 
@@ -220,20 +240,21 @@ def emitFixedRow
     invocation, emits one JSONL row, exits 0 on success or 1 on
     error. -/
 def runFixedChildMode (benchName : Lean.Name) (repeatIndex : Nat) : IO UInt32 := do
+  let env ← RunEnv.capture
   match ← findFixedRuntimeEntry benchName with
   | none =>
     emitFixedRow benchName repeatIndex 0 none
-      (.error s!"unregistered fixed benchmark: {benchName}")
+      (.error s!"unregistered fixed benchmark: {benchName}") env
       (some s!"unregistered fixed benchmark: {benchName}")
     return 1
   | some entry =>
     try
       let (total, hash) ← entry.runner
-      emitFixedRow benchName repeatIndex total hash .ok
+      emitFixedRow benchName repeatIndex total hash .ok env
       return (0 : UInt32)
     catch e =>
       let msg := s!"runner threw: {e.toString}"
-      emitFixedRow benchName repeatIndex 0 none (.error msg) (some msg)
+      emitFixedRow benchName repeatIndex 0 none (.error msg) env (some msg)
       return (1 : UInt32)
 
 end LeanBench

--- a/LeanBench/Child.lean
+++ b/LeanBench/Child.lean
@@ -129,7 +129,15 @@ def emitRow
     (cacheMode : CacheMode := .warm)
     (errorMsg? : Option String := none) :
     IO Unit := do
-  let perCall : Float := totalNanos.toFloat / innerRepeats.toFloat
+  -- Synthesized error / "unregistered benchmark" rows pass
+  -- `innerRepeats := 0`, which would naively render as `0/0 = NaN`.
+  -- `NaN` is not valid JSON (`Lean.Json.parse` rejects it), so we
+  -- emit `null` for the derived field and leave the consumer to
+  -- treat absence as `null` per the schema contract. Real
+  -- measurement rows always have `innerRepeats ≥ 1`.
+  let perCallStr : String :=
+    if innerRepeats == 0 then "null"
+    else toString (totalNanos.toFloat / innerRepeats.toFloat)
   let row :=
     "{" ++ String.intercalate "," [
       s!"\"schema_version\":{Schema.schemaVersion}",
@@ -138,7 +146,7 @@ def emitRow
       s!"\"param\":{param}",
       s!"\"inner_repeats\":{innerRepeats}",
       s!"\"total_nanos\":{totalNanos}",
-      s!"\"per_call_nanos\":{perCall}",
+      s!"\"per_call_nanos\":{perCallStr}",
       s!"\"cache_mode\":{jsonStr cacheMode.toJsonString}",
       s!"\"result_hash\":{jsonOptHash resultHash}",
       s!"\"status\":{jsonStr status.toJsonString}",
@@ -170,11 +178,17 @@ def emitRow
     behave identically — only the iteration count and timing strategy
     differ. -/
 def runChildMode (benchName : Lean.Name) (param targetNanos : Nat)
-    (cacheMode : CacheMode := .warm) : IO UInt32 := do
+    (cacheMode : CacheMode := .warm) (env? : Option Env := none) : IO UInt32 := do
   -- Capture env *before* dispatching: we want a row even for the
   -- "unregistered benchmark" failure case, and that row needs an
-  -- `env` field per the schema contract.
-  let env ← RunEnv.capture
+  -- `env` field per the schema contract. When the parent passed
+  -- `--env-json`, we use that snapshot instead — it keeps every
+  -- row in a single run stamped with identical env (consistent
+  -- timestamps, hostname, git_dirty), and skips ~3 subprocess
+  -- spawns per ladder rung.
+  let env ← match env? with
+    | some env => pure env
+    | none     => RunEnv.capture
   match ← findRuntimeEntry benchName with
   | none =>
     emitRow benchName param 0 0 none
@@ -239,8 +253,11 @@ def emitFixedRow
     name up in the fixed runtime registry, performs one timed
     invocation, emits one JSONL row, exits 0 on success or 1 on
     error. -/
-def runFixedChildMode (benchName : Lean.Name) (repeatIndex : Nat) : IO UInt32 := do
-  let env ← RunEnv.capture
+def runFixedChildMode (benchName : Lean.Name) (repeatIndex : Nat)
+    (env? : Option Env := none) : IO UInt32 := do
+  let env ← match env? with
+    | some env => pure env
+    | none     => RunEnv.capture
   match ← findFixedRuntimeEntry benchName with
   | none =>
     emitFixedRow benchName repeatIndex 0 none

--- a/LeanBench/Cli.lean
+++ b/LeanBench/Cli.lean
@@ -195,6 +195,21 @@ def runVerifyCmd (p : Cli.Parsed) : IO UInt32 := do
 
 def runChildCmd (p : Cli.Parsed) : IO UInt32 := do
   let benchStr := (p.flag! "bench").as! String
+  -- `--env-json` is the issue #11 plumbing: when the parent has
+  -- already captured env, it serializes via this flag so the child
+  -- doesn't redo the work. Parse failures fall back to "let the
+  -- child capture fresh" rather than aborting — a malformed env
+  -- payload is a parent bug, but the run itself can still proceed.
+  let env? : Option LeanBench.Env :=
+    match parsedFlag? p "env-json" String with
+    | none => none
+    | some s =>
+      match Lean.Json.parse s with
+      | .error _ => none
+      | .ok j =>
+        match LeanBench.RunEnv.fromJson j with
+        | .ok env => some env
+        | .error _ => none
   -- The `--fixed` flag is a discriminator: when present the child
   -- runs a fixed-benchmark single invocation and reads
   -- `--repeat-index`; otherwise it's the existing parametric path
@@ -204,13 +219,13 @@ def runChildCmd (p : Cli.Parsed) : IO UInt32 := do
       match parsedFlag? p "repeat-index" Nat with
       | some n => n
       | none   => 0
-    LeanBench.runFixedChildMode benchStr.toName repeatIdx
+    LeanBench.runFixedChildMode benchStr.toName repeatIdx env?
   else
     let param := (p.flag! "param").as! Nat
     let targetNanos := (p.flag! "target-nanos").as! Nat
     let cacheMode : CacheMode :=
       (parsedFlag? p "cache-mode" LeanBench.CacheMode).getD .warm
-    LeanBench.runChildMode benchStr.toName param targetNanos cacheMode
+    LeanBench.runChildMode benchStr.toName param targetNanos cacheMode env?
 
 /-! ## Cmd tree definitions -/
 
@@ -259,6 +274,7 @@ def childSub : Cmd := `[Cli|
                            "Parametric: warm (default — auto-tune inside this child) or cold (single untuned invocation; parent respawns per rung)."
     fixed;                 "Fixed: dispatch the fixed-benchmark single-invocation runner instead of the parametric autotuner."
     "repeat-index" : Nat;  "Fixed: 0-based repeat index to record on the emitted JSONL row."
+    "env-json" : String;   "Issue #11: parent's pre-captured env JSON, propagated so all children stamp identical env on their rows. Falls back to fresh capture when absent or malformed."
 ]
 
 def compareSub : Cmd := `[Cli|

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -13,6 +13,82 @@ open Lean (Name)
 
 namespace LeanBench
 
+/-! ## Reproducibility metadata
+
+Captured once per process (by the child for emission on each JSONL
+row, by the parent for the in-memory `BenchmarkResult`). The data
+shape is `Inhabited` so callers that don't capture env (tests,
+synthesized error rows) get a structural default rather than
+threading an `Option` through every code path; the field on the
+in-memory result *is* an `Option` so "we never captured" stays
+distinguishable from "we captured but every field was unknown."
+
+Field semantics live in `doc/schema.md#environment-metadata`. Fields
+typed `Option α` are best-effort: we capture them when we can and
+emit an explicit `null` rather than silently omitting (per the
+issue #11 acceptance criterion). Always-present fields are
+derivable from Lean compile-time constants (`Lean.versionString`,
+`System.Platform.target`) so no probing is needed for them. -/
+structure Env where
+  /-- `Lean.versionString` — e.g. `"4.30.0-rc2"` or
+      `"4.31.0, commit abc123"` for development builds. -/
+  leanVersion       : String
+  /-- `Lean.toolchain` — e.g. `"leanprover/lean4:v4.30.0-rc2"`.
+      Matches the `lean-toolchain` file format. -/
+  leanToolchain     : String
+  /-- LLVM target triple (`System.Platform.target`), e.g.
+      `"x86_64-unknown-linux-gnu"`. Empty string when missing —
+      Lean records it as `""` in that case, and we propagate the
+      empty string verbatim rather than fabricating a `null`. -/
+  platformTarget    : String
+  /-- Coarse OS family: `"linux"` / `"macos"` / `"windows"` /
+      `"emscripten"` / `"unknown"`. -/
+  os                : String
+  /-- Architecture parsed from the target triple's leading segment
+      (`"x86_64"`, `"aarch64"`, …). `none` when the triple is empty
+      or unparseable. -/
+  arch              : Option String
+  /-- Human-readable CPU model string (`"Intel(R) Xeon(R) ..."`).
+      `none` when we can't read it (non-Linux without subprocess
+      probing, restricted permissions, etc.). -/
+  cpuModel          : Option String
+  /-- Logical core count as the OS sees it. `none` when unavailable. -/
+  cpuCores          : Option Nat
+  /-- Hostname as reported by `gethostname` (via the `HOSTNAME` /
+      `COMPUTERNAME` env var fallback when the syscall is
+      unavailable). `none` when neither is readable. -/
+  hostname          : Option String
+  /-- Basename of `IO.appPath` — the running benchmark executable. -/
+  exeName           : String
+  /-- The lean-bench library version, pinned by
+      `LeanBench.libraryVersion`. -/
+  leanBenchVersion  : String
+  /-- Resolved `git rev-parse HEAD` from the current working
+      directory (full 40-char SHA). `none` when `git` is unavailable
+      or cwd isn't a git repo. -/
+  gitCommit         : Option String
+  /-- True iff the working tree had uncommitted changes at capture
+      time (`git status --porcelain` non-empty). `none` when git
+      isn't available — distinct from `some false`, which means we
+      checked and the tree was clean. -/
+  gitDirty          : Option Bool
+  /-- Wallclock at capture time, milliseconds since the Unix epoch.
+      `Int` because `Std.Time.Timestamp.now` returns a signed offset
+      and we're not in the business of asserting a non-negative
+      epoch. -/
+  timestampUnixMs   : Int
+  /-- Capture-time wallclock as an ISO 8601 UTC string
+      (`"YYYY-MM-DDTHH:MM:SSZ"`). Derived from `timestampUnixMs` so
+      readers can choose either; producers MUST keep the two
+      consistent. -/
+  timestampIso      : String
+  deriving Repr, Inhabited
+
+/-- Library version string. Kept as a single source of truth so
+docs, JSONL rows, and the user-facing report all agree. Bumped at
+release time alongside `lakefile.toml`. -/
+def libraryVersion : String := "0.1.0"
+
 /-- Status of a single measurement. Mirrors the `status` JSONL field. -/
 inductive Status
   | ok
@@ -511,6 +587,13 @@ structure BenchmarkResult where
       below-floor rows) stay on `points` for downstream tooling and
       raw inspection. Issue #4. -/
   trialSummaries : Array TrialSummary := #[]
+  /-- Reproducibility metadata captured at parent run start (issue
+      #11). `none` when the result was assembled outside the
+      `runBenchmark` path (test fixtures, hand-rolled `Inhabited`
+      instances). Children also stamp env on every JSONL row so
+      downstream tools that only see the wire format can recover it
+      independently. -/
+  env? : Option Env := none
   deriving Inhabited, Repr
 
 /-- One diverging param in a `compare`: the param at which results
@@ -678,6 +761,9 @@ structure FixedResult where
       was unavailable across the board). False iff repeats disagreed
       — that's a non-determinism bug in the registered function. -/
   hashesAgree  : Bool
+  /-- Reproducibility metadata captured at parent run start (issue
+      #11). Same semantics as on `BenchmarkResult`. -/
+  env? : Option Env := none
   deriving Inhabited, Repr
 
 /-- A single fixed-benchmark divergence record: the per-function

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -42,7 +42,9 @@ structure Env where
       empty string verbatim rather than fabricating a `null`. -/
   platformTarget    : String
   /-- Coarse OS family: `"linux"` / `"macos"` / `"windows"` /
-      `"emscripten"` / `"unknown"`. -/
+      `"emscripten"`. The detector defaults to `"linux"` for any
+      non-{Windows, macOS, Emscripten} platform; readers should
+      treat this as informational, not authoritative. -/
   os                : String
   /-- Architecture parsed from the target triple's leading segment
       (`"x86_64"`, `"aarch64"`, …). `none` when the triple is empty

--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -1,5 +1,6 @@
 import LeanBench.Core
 import LeanBench.Env
+import LeanBench.RunEnv
 import LeanBench.Verify
 
 /-!
@@ -257,13 +258,23 @@ private def fmtTrialSummaries (r : BenchmarkResult) : Array String :=
 
 /-- Render one `BenchmarkResult` as a multi-line block with every
 numeric value bounded to 3 decimals and every column width derived
-from the data so decimal points align. -/
-def fmtResult (r : BenchmarkResult) : String := Id.run do
+from the data so decimal points align.
+
+The `includeEnv` knob controls whether the report prints a one-line
+reproducibility-metadata summary (issue #11) just under the header.
+The default is `true` for standalone `run` reports; `fmtComparison`
+flips it to `false` and prints env once at the top of the comparison
+rather than repeating it per block. -/
+def fmtResult (r : BenchmarkResult) (includeEnv : Bool := true) : String := Id.run do
   let modeTag : String :=
     match r.config.cacheMode with
     | .warm => "warm"
     | .cold => "cold"
   let headerLine := s!"{r.function}    expected complexity: {r.complexityFormula}    [{modeTag} cache]"
+  let envLine? : Option String :=
+    match r.env? with
+    | some env => if includeEnv then some s!"  env: {RunEnv.fmtConcise env}" else none
+    | none     => none
   let ratioMap : Std.HashMap Nat Float :=
     r.ratios.foldl (fun m (p, c) => m.insert p c) {}
   let droppedParams : Array Nat :=
@@ -302,7 +313,11 @@ def fmtResult (r : BenchmarkResult) : String := Id.run do
     "  " ++ perCall ++
     "  " ++ rightpad r.repeats wRep ++
     "  C=" ++ rightpad r.cStr wC ++ r.status
-  let mut lines : Array String := #[headerLine, headerRow]
+  let mut lines : Array String := #[headerLine]
+  match envLine? with
+  | some line => lines := lines.push line
+  | none      => pure ()
+  lines := lines.push headerRow
   for line in dataLines do
     lines := lines.push line
   let cMin := match r.cMin? with | some c => fmtFloat3 c | none => "—"
@@ -346,10 +361,18 @@ def fmtFixedSpec (spec : FixedSpec) : String :=
 
 /-- Render a single fixed-benchmark result as a multi-line block:
     one row per measured repeat plus a summary with median/min/max
-    and the cross-repeat hash agreement check. -/
-def fmtFixedResult (r : FixedResult) : String := Id.run do
+    and the cross-repeat hash agreement check. The `includeEnv`
+    knob mirrors the parametric `fmtResult`: standalone reports
+    print env, comparison reports suppress per-block env and print
+    once at the top. -/
+def fmtFixedResult (r : FixedResult) (includeEnv : Bool := true) : String := Id.run do
   let header := s!"{r.function}    [fixed] repeats={r.config.repeats}"
   let mut lines : Array String := #[header]
+  match r.env? with
+  | some env =>
+    if includeEnv then
+      lines := lines.push s!"  env: {RunEnv.fmtConcise env}"
+  | none => pure ()
   let mut idx : Nat := 0
   let nums := r.points.map fun dp =>
     match dp.status with
@@ -431,8 +454,13 @@ private def fmtHashTable
     summary. -/
 def fmtFixedComparison (rep : FixedComparisonReport) : String := Id.run do
   let mut lines : Array String := #[]
+  -- Print env once at the top of a comparison rather than repeating
+  -- it inside each per-result block.
+  match rep.results[0]?.bind (·.env?) with
+  | some env => lines := lines.push s!"env: {RunEnv.fmtConcise env}"
+  | none     => pure ()
   for r in rep.results do
-    lines := lines.push (fmtFixedResult r)
+    lines := lines.push (fmtFixedResult r (includeEnv := false))
     lines := lines.push ""
   -- Relative timing: pick the first result's median as the baseline,
   -- emit one ratio line per other result.
@@ -537,8 +565,15 @@ def fmtCombinedVerify (r : CombinedVerifyReports) : String := Id.run do
     for what to expect when only hashes are available. -/
 def fmtComparison (rep : ComparisonReport) : String := Id.run do
   let mut lines : Array String := #[]
+  -- Print env once at the top of a comparison rather than repeating
+  -- it inside each per-result block. Every result in a single
+  -- `compare` invocation shares the same parent env, so taking the
+  -- first one's snapshot is correct.
+  match rep.results[0]?.bind (·.env?) with
+  | some env => lines := lines.push s!"env: {RunEnv.fmtConcise env}"
+  | none     => pure ()
   for r in rep.results do
-    lines := lines.push (fmtResult r)
+    lines := lines.push (fmtResult r (includeEnv := false))
     lines := lines.push ""
   let common := rep.commonParams.toList.map toString
   lines := lines.push s!"common params (apples-to-apples): {String.intercalate ", " common}"

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -142,8 +142,17 @@ def classifyChildOutcome
     | other =>
       synthRow param (.error (withStderr s!"child exited with code {other}"))
 
-/-- Spawn one child invocation and return the resulting DataPoint. -/
-def runOneBatch (spec : BenchmarkSpec) (param : Nat) : IO DataPoint := do
+/-- Spawn one child invocation and return the resulting DataPoint.
+
+    The `env?` argument is the parent's pre-captured environment
+    snapshot (issue #11); when `some`, it's serialized via
+    `--env-json` so the child stamps the same env on its row instead
+    of re-shelling-out to `git` / `hostname` / `/proc/cpuinfo` per
+    rung. When `none`, the child captures fresh — used by helper
+    paths (`measureSpawnFloor`, `verifyOne`) where threading env
+    through isn't worth the plumbing. -/
+def runOneBatch (spec : BenchmarkSpec) (param : Nat) (env? : Option Env := none) :
+    IO DataPoint := do
   let exe ← ownExe
   let target := spec.config.targetInnerNanos
   let deadlineMs : UInt32 :=
@@ -152,13 +161,17 @@ def runOneBatch (spec : BenchmarkSpec) (param : Nat) : IO DataPoint := do
   -- `cold`) so the child knows which timing strategy to use. The
   -- existing `--target-nanos` is unused in cold mode but still passed
   -- for parser symmetry.
-  let args : Array String := #[
+  let baseArgs : Array String := #[
     "_child",
     "--bench", spec.name.toString (escape := false),
     "--param", toString param,
     "--target-nanos", toString target,
     "--cache-mode", spec.config.cacheMode.toJsonString
   ]
+  let args : Array String :=
+    match env? with
+    | some env => baseArgs ++ #["--env-json", (RunEnv.toJson env).compress]
+    | none     => baseArgs
   let child ← IO.Process.spawn {
     cmd := exe
     args := args
@@ -316,11 +329,11 @@ private def pickLinearRungs (lastOk firstFail samples : Nat) : Array Nat :=
     `trials × maxSecondsPerCall`. Users opted into that cost when
     they bumped `outerTrials`. Issue #4. -/
 private def runRungTrials (spec : BenchmarkSpec) (param : Nat)
-    (trials : Nat) : IO (Array DataPoint) := do
+    (trials : Nat) (env? : Option Env := none) : IO (Array DataPoint) := do
   let mut acc : Array DataPoint := #[]
   let trials := max 1 trials
   for i in [0 : trials] do
-    let dp ← runOneBatch spec param
+    let dp ← runOneBatch spec param env?
     acc := acc.push { dp with trialIndex := i }
   return acc
 
@@ -357,7 +370,7 @@ trial cluster on the rungs that count.
 
 Probe rows are returned with whatever `partOfVerdict` `runOneBatch`
 chose (defaults to true); the caller flips them as needed. -/
-private def runDoublingProbe (spec : BenchmarkSpec) :
+private def runDoublingProbe (spec : BenchmarkSpec) (env : Env) :
     IO (Array DataPoint × Option Nat × Option Nat) := do
   let ladder := paramLadder spec.config
   let mut points : Array DataPoint := #[]
@@ -366,7 +379,7 @@ private def runDoublingProbe (spec : BenchmarkSpec) :
   for param in ladder do
     if firstFail.isSome then break
     -- Probe runs one trial per rung — see the docstring rationale.
-    let rung ← runRungTrials spec param 1
+    let rung ← runRungTrials spec param 1 (some env)
     points := points ++ rung
     if rungAnyOk rung then lastOk := some param
     else firstFail := some param
@@ -384,7 +397,7 @@ private def runDoublingProbe (spec : BenchmarkSpec) :
     gets recorded — we want the user to see the flake rather than have
     it silently dropped — but it doesn't change `lastOk`/`firstFail`
     since those were settled by the probe. Issue #4. -/
-private def topUpDoublingTrials (spec : BenchmarkSpec)
+private def topUpDoublingTrials (spec : BenchmarkSpec) (env : Env)
     (probePoints : Array DataPoint) : IO (Array DataPoint) := do
   let extraTrials := spec.config.outerTrials - 1
   if extraTrials == 0 then return probePoints
@@ -398,7 +411,7 @@ private def topUpDoublingTrials (spec : BenchmarkSpec)
   let mut acc := probePoints
   for p in okParams do
     for i in [0 : extraTrials] do
-      let dp ← runOneBatch spec p
+      let dp ← runOneBatch spec p (some env)
       acc := acc.push { dp with trialIndex := i + 1 }
   return acc
 
@@ -452,7 +465,7 @@ def annotateBelowSignalFloor (multiplier : Float)
     first. With warm + tiny target the autotuner converges in a
     single iteration and the wallclock is dominated by spawn /
     process-init / IPC, which is exactly what we want to report. -/
-def measureSpawnFloor : IO (Option Nat) := do
+def measureSpawnFloor (env : Env) : IO (Option Nat) := do
   let entries ← allRuntimeEntries
   if entries.isEmpty then return none
   let entry := entries[0]!
@@ -461,7 +474,11 @@ def measureSpawnFloor : IO (Option Nat) := do
         targetInnerNanos := 1_000
         cacheMode := .warm }
   let t₀ ← IO.monoNanosNow
-  let _ ← runOneBatch { entry.spec with config := probeCfg } 0
+  -- Pass parent's env along so the probe child takes the same fast
+  -- path as a real ladder rung; otherwise the floor measurement is
+  -- inflated by the env-capture subprocesses (git / hostname /
+  -- /proc/cpuinfo) that real rungs skip.
+  let _ ← runOneBatch { entry.spec with config := probeCfg } 0 (some env)
   let t₁ ← IO.monoNanosNow
   return some (t₁ - t₀)
 
@@ -484,9 +501,11 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
   | .error msg => throw (.userError s!"{name}: {msg}")
   | .ok () => pure ()
   -- Capture reproducibility metadata at *parent* run start (issue
-  -- #11). Children also stamp env on every JSONL row independently,
-  -- so wire-format consumers don't need to care; this snapshot is
-  -- what surfaces in the human-readable report.
+  -- #11). The same snapshot is propagated to every child via
+  -- `--env-json`, so all JSONL rows in this run stamp the *same*
+  -- env (timestamps, git_dirty, hostname all consistent across
+  -- rungs). Avoids ~3 subprocess spawns per ladder rung that the
+  -- child's fallback fresh-capture would do.
   let env ← RunEnv.capture
   let spec := { entry.spec with config := cfg }
   let schedule := resolveSchedule cfg entry.complexity
@@ -498,20 +517,20 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
   match schedule with
   | .custom params =>
     for n in params do
-      let rung ← runRungTrials spec n cfg.outerTrials
+      let rung ← runRungTrials spec n cfg.outerTrials (some env)
       points := points ++ rung
       -- Stop the ladder only when EVERY trial at this rung failed.
       -- A transient first-trial timeout no longer poisons the rest
       -- of the schedule (Codex review).
       unless rungAnyOk rung do break
   | _ =>
-    let (probePoints, lastOk?, firstFail?) ← runDoublingProbe spec
+    let (probePoints, lastOk?, firstFail?) ← runDoublingProbe spec env
     points := probePoints
     match schedule with
     | .doubling =>
       -- Probe rows ARE the verdict data here. Top up every successful
       -- probe rung to `outerTrials` measurements.
-      points ← topUpDoublingTrials spec points
+      points ← topUpDoublingTrials spec env points
     | .custom _ => pure ()  -- unreachable in this branch
     | .auto => pure ()  -- unreachable after resolveSchedule
     | .linear samples =>
@@ -536,7 +555,7 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
           -- don't enter `cMin`/`cMax`/slope.
           points := points.map ({ · with partOfVerdict := false })
           for n in rungs do
-            let rung ← runRungTrials spec n cfg.outerTrials
+            let rung ← runRungTrials spec n cfg.outerTrials (some env)
             points := points ++ rung
             -- Stop the sweep only when EVERY trial at this rung failed.
             unless rungAnyOk rung do break
@@ -544,8 +563,8 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
         -- No bracket (doubling ran clean to ceiling, or first rung failed).
         -- Fall back to doubling-only — top up trials so the verdict
         -- cluster is the full configured size.
-        points ← topUpDoublingTrials spec points
-  let spawnFloor ← measureSpawnFloor
+        points ← topUpDoublingTrials spec env points
+  let spawnFloor ← measureSpawnFloor env
   -- Annotate below-floor rows BEFORE summarising so the verdict
   -- ratios and the advisory list see the same filtered view.
   let annotated :=
@@ -606,18 +625,25 @@ def classifyFixedChildOutcome
 
 /-- Spawn one fixed-benchmark child. `repeatIndex` is the 0-based
     index reported back in the JSONL row; `cfg` carries the kill
-    cap. Same kill-on-cap machinery as `runOneBatch`. -/
+    cap. Same kill-on-cap machinery as `runOneBatch`. The optional
+    `env?` mirrors `runOneBatch`: when `some`, the parent's snapshot
+    rides via `--env-json` and the child skips its own capture; when
+    `none`, the child captures fresh (used by `verifyFixedOne`). -/
 def runFixedOneBatch (spec : FixedSpec) (cfg : FixedBenchmarkConfig)
-    (repeatIndex : Nat) : IO FixedDataPoint := do
+    (repeatIndex : Nat) (env? : Option Env := none) : IO FixedDataPoint := do
   let exe ← ownExe
   let deadlineMs : UInt32 :=
     (cfg.maxSecondsPerCall * 1000.0 + cfg.killGraceMs.toFloat).toUInt32
-  let args : Array String := #[
+  let baseArgs : Array String := #[
     "_child",
     "--bench", spec.name.toString (escape := false),
     "--fixed",
     "--repeat-index", toString repeatIndex
   ]
+  let args : Array String :=
+    match env? with
+    | some env => baseArgs ++ #["--env-json", (RunEnv.toJson env).compress]
+    | none     => baseArgs
   let child ← IO.Process.spawn {
     cmd := exe
     args := args
@@ -703,10 +729,10 @@ def runFixedBenchmark (name : Lean.Name)
   -- it (recorded as repeatIndex = 0 in the warmup pass — but not
   -- pushed into `points`).
   if cfg.warmup then
-    let _ ← runFixedOneBatch entry.spec cfg 0
+    let _ ← runFixedOneBatch entry.spec cfg 0 (some env)
   let mut points : Array FixedDataPoint := #[]
   for i in [0 : cfg.repeats] do
-    let dp ← runFixedOneBatch entry.spec cfg i
+    let dp ← runFixedOneBatch entry.spec cfg i (some env)
     points := points.push dp
   let okNanos : Array Nat := points.filterMap fun dp =>
     match dp.status with

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -2,6 +2,7 @@ import Lean
 import Std.Sync.Mutex
 import LeanBench.Core
 import LeanBench.Env
+import LeanBench.RunEnv
 import LeanBench.Schema
 import LeanBench.Stats
 
@@ -482,6 +483,11 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
   match cfg.validate with
   | .error msg => throw (.userError s!"{name}: {msg}")
   | .ok () => pure ()
+  -- Capture reproducibility metadata at *parent* run start (issue
+  -- #11). Children also stamp env on every JSONL row independently,
+  -- so wire-format consumers don't need to care; this snapshot is
+  -- what surfaces in the human-readable report.
+  let env ← RunEnv.capture
   let spec := { entry.spec with config := cfg }
   let schedule := resolveSchedule cfg entry.complexity
   -- `.custom` skips the doubling probe entirely — we walk the
@@ -545,7 +551,7 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {}) :
   let annotated :=
     annotateBelowSignalFloor cfg.signalFloorMultiplier spawnFloor points
   let summary := Stats.summarize spec entry.complexity annotated
-  return { summary with spawnFloorNanos? := spawnFloor }
+  return { summary with spawnFloorNanos? := spawnFloor, env? := some env }
 
 /-! ## Fixed-benchmark orchestration -/
 
@@ -691,6 +697,7 @@ def runFixedBenchmark (name : Lean.Name)
   match cfg.validate with
   | .error msg => throw (.userError s!"{name}: {msg}")
   | .ok () => pure ()
+  let env ← RunEnv.capture
   -- Warmup: fire-and-forget; we don't fail the run if warmup itself
   -- fails, but we do propagate killed/error status so the user sees
   -- it (recorded as repeatIndex = 0 in the warmup pass — but not
@@ -719,6 +726,7 @@ def runFixedBenchmark (name : Lean.Name)
     minNanos?
     maxNanos?
     hashesAgree
+    env? := some env
   }
 
 end LeanBench

--- a/LeanBench/RunEnv.lean
+++ b/LeanBench/RunEnv.lean
@@ -1,0 +1,298 @@
+import Lean
+import Std.Time
+import LeanBench.Core
+
+/-!
+# `LeanBench.RunEnv` — capture reproducibility metadata (issue #11)
+
+Two responsibilities:
+
+1. **Capture.** Build an `Env` snapshot of the current process —
+   Lean version, OS / arch, CPU model & core count, hostname,
+   git commit & dirtiness, lean-bench version, executable name,
+   wallclock timestamp.
+
+2. **Encode.** Render an `Env` as a `Lean.Json` object suitable for
+   embedding under the `env` key in a JSONL row, and as a one-line
+   summary for human-readable reports.
+
+`capture` is best-effort: every probe is wrapped so a failure on
+one platform leaves that field as `none` rather than aborting
+capture. The unit-style fields that are derivable from Lean
+compile-time constants (`leanVersion`, `leanToolchain`,
+`platformTarget`, `os`) are always populated.
+
+The schema doc reserves the `env` key on JSONL rows for issue #11;
+see [`doc/schema.md#environment-metadata`](../doc/schema.md#environment-metadata)
+for the full field list and stability rules.
+-/
+
+open Lean (Json)
+
+namespace LeanBench
+namespace RunEnv
+
+/-! ## OS / arch derivation -/
+
+/-- Coarse OS family from `System.Platform`. `"unknown"` falls
+through every platform check rather than a partial match — readers
+should treat the value as informational, not authoritative. -/
+def detectOs : String :=
+  if System.Platform.isWindows then "windows"
+  else if System.Platform.isOSX then "macos"
+  else if System.Platform.isEmscripten then "emscripten"
+  else "linux"
+
+/-- Architecture parsed from the LLVM target triple's leading
+segment. Returns `none` when the triple is empty or has no `-`. -/
+def parseArch (target : String) : Option String :=
+  if target.isEmpty then none
+  else
+    match target.splitOn "-" with
+    | []      => none
+    | a :: _  => if a.isEmpty then none else some a
+
+/-! ## Best-effort probes
+
+Each probe is tagged "best-effort": exceptions and non-zero exits
+collapse to `none`. The motivating constraint is portability —
+lean-bench runs on Linux, macOS, and Windows, and forcing a working
+`/proc/cpuinfo` parse on every host would either hang Windows or
+silently lie. -/
+
+/-- Run a subprocess, capturing stdout. Returns `none` if the
+process fails to spawn, exits non-zero, or emits an exception. The
+trimmed stdout is returned on success; an empty stdout collapses to
+`none` so callers don't have to special-case the "command exists
+but produced nothing" case. -/
+def tryRun (cmd : String) (args : Array String) : IO (Option String) := do
+  try
+    let out ← IO.Process.output { cmd, args, stdin := .null }
+    if out.exitCode == 0 then
+      let s := out.stdout.trimAscii.toString
+      if s.isEmpty then pure none else pure (some s)
+    else
+      pure none
+  catch _ => pure none
+
+/-- Best-effort hostname: try `hostname` (POSIX), fall back to the
+`HOSTNAME` / `COMPUTERNAME` env vars. Each step swallows errors. -/
+def detectHostname : IO (Option String) := do
+  match ← tryRun "hostname" #[] with
+  | some h => return some h
+  | none =>
+    match ← (IO.getEnv "HOSTNAME") with
+    | some h => if h.isEmpty then return none else return some h
+    | none =>
+      match ← (IO.getEnv "COMPUTERNAME") with
+      | some h => if h.isEmpty then return none else return some h
+      | none   => return none
+
+/-- Read `/proc/cpuinfo` and pull the first `model name` field.
+Linux-only; collapses to `none` on every other OS or when the file
+is missing. We deliberately don't shell out to `sysctl` on macOS or
+`wmic` on Windows to keep the probe quiet — that's a future
+extension when there's a clear ask. -/
+def detectCpuModel : IO (Option String) := do
+  if System.Platform.isOSX || System.Platform.isWindows
+     || System.Platform.isEmscripten then
+    return none
+  try
+    let path : System.FilePath := "/proc/cpuinfo"
+    if !(← path.pathExists) then return none
+    let contents ← IO.FS.readFile path
+    for line in contents.splitOn "\n" do
+      if line.startsWith "model name" then
+        match line.splitOn ":" with
+        | _ :: rest =>
+          return some (("".intercalate rest).trimAscii.toString)
+        | _ => pure ()
+    return none
+  catch _ => return none
+
+/-- Logical core count. Linux: count `processor` lines in
+`/proc/cpuinfo`. macOS / Windows: best-effort env vars
+(`NUMBER_OF_PROCESSORS`); falls back to `none`. -/
+def detectCpuCores : IO (Option Nat) := do
+  if System.Platform.isWindows then
+    match ← IO.getEnv "NUMBER_OF_PROCESSORS" with
+    | some s => return s.toNat?
+    | none   => return none
+  if System.Platform.isOSX || System.Platform.isEmscripten then
+    return none
+  try
+    let path : System.FilePath := "/proc/cpuinfo"
+    if !(← path.pathExists) then return none
+    let contents ← IO.FS.readFile path
+    let n := (contents.splitOn "\n").foldl
+      (fun acc line => if line.startsWith "processor" then acc + 1 else acc) 0
+    if n == 0 then return none else return some n
+  catch _ => return none
+
+/-- Git commit at cwd. We rely on the `git` binary being on PATH;
+nothing in lean-bench's hot path depends on git, so a missing
+binary just collapses to `none`. The output is the full 40-char
+SHA — we don't truncate, since downstream tooling can do that. -/
+def detectGitCommit : IO (Option String) := do
+  match ← tryRun "git" #["rev-parse", "HEAD"] with
+  | some s =>
+    -- `git rev-parse` succeeds with an empty output in pathological
+    -- cases; treat that as "no commit", same as a non-zero exit.
+    if s.isEmpty then return none else return some s
+  | none   => return none
+
+/-- True iff `git status --porcelain` reports any change. `none`
+when `git` itself is unavailable. -/
+def detectGitDirty : IO (Option Bool) := do
+  -- We use the same swallow-everything `tryRun` and key on whether
+  -- the output is empty: `--porcelain` prints one line per dirty
+  -- entry, nothing on a clean tree. A missing git binary or a
+  -- non-repo cwd both collapse to `none` (distinct from
+  -- `some false`).
+  try
+    let out ← IO.Process.output {
+      cmd := "git", args := #["status", "--porcelain"], stdin := .null }
+    if out.exitCode == 0 then
+      return some (! out.stdout.trimAscii.toString.isEmpty)
+    else
+      return none
+  catch _ => return none
+
+/-- Basename of the running executable (e.g. `"fib_benchmark_example"`).
+Strips both POSIX `/` and Windows `\\` separators so a Windows path
+like `C:\\foo\\bar.exe` resolves cleanly. -/
+def detectExeName : IO String := do
+  let path := (← IO.appPath).toString
+  let mut last : String := path
+  for slice in path.split (fun c => c == '/' || c == '\\') do
+    last := slice.toString
+  return last
+
+/-! ## Wallclock formatting -/
+
+/-- Pad a `Nat` to width `w` with leading `0`s. Cheap helper for
+ISO 8601 formatting — `2026 → "2026"`, `7 → "07"`, `123 → "123"`. -/
+private def padNat (n : Nat) (w : Nat) : String :=
+  let s := toString n
+  if s.length ≥ w then s
+  else String.ofList (List.replicate (w - s.length) '0') ++ s
+
+/-- Render a wallclock instant (UTC) as ISO 8601: `YYYY-MM-DDTHH:MM:SSZ`.
+Sub-second precision is dropped to keep the format readable in
+report headers; the millisecond resolution is still available via
+`timestampUnixMs` for tooling that wants it. -/
+def fmtIso8601 (dt : Std.Time.PlainDateTime) : String :=
+  let y : Int := dt.date.year
+  let yStr := if y < 0 then "-" ++ padNat (Int.toNat (-y)) 4
+              else padNat (Int.toNat y) 4
+  let mo := padNat dt.date.month.val.toNat 2
+  let d  := padNat dt.date.day.val.toNat 2
+  let h  := padNat dt.time.hour.val.toNat 2
+  let mi := padNat dt.time.minute.val.toNat 2
+  let se := padNat dt.time.second.val.toNat 2
+  s!"{yStr}-{mo}-{d}T{h}:{mi}:{se}Z"
+
+/-! ## Capture -/
+
+/-- Capture the current process's reproducibility metadata.
+
+Best-effort: a single failed probe never aborts capture. The
+returned `Env` is structurally complete — every field is either a
+real value or an explicit `none`, never silently omitted (per the
+issue #11 acceptance criterion). -/
+def capture : IO Env := do
+  let target  := System.Platform.target
+  let exeName ← detectExeName
+  let hostname ← detectHostname
+  let cpuModel ← detectCpuModel
+  let cpuCores ← detectCpuCores
+  let gitCommit ← detectGitCommit
+  let gitDirty ← detectGitDirty
+  let ts ← Std.Time.Timestamp.now
+  let unixMs : Int := (ts.toMillisecondsSinceUnixEpoch.val : Int)
+  -- The `addSeconds 0` call is a no-op; the constructor just gives
+  -- us a `PlainDateTime` in UTC without the local-zone lookup that
+  -- `PlainDateTime.now` does. We want UTC for the ISO timestamp.
+  let dt := Std.Time.PlainDateTime.ofTimestampAssumingUTC ts
+  let iso := fmtIso8601 dt
+  return {
+    leanVersion       := Lean.versionString
+    leanToolchain     := Lean.toolchain
+    platformTarget    := target
+    os                := detectOs
+    arch              := parseArch target
+    cpuModel          := cpuModel
+    cpuCores          := cpuCores
+    hostname          := hostname
+    exeName           := exeName
+    leanBenchVersion  := LeanBench.libraryVersion
+    gitCommit         := gitCommit
+    gitDirty          := gitDirty
+    timestampUnixMs   := unixMs
+    timestampIso      := iso
+  }
+
+/-! ## JSON encoding -/
+
+/-- Render an `Option String` as `Json` (string or `null`). -/
+private def jOptStr : Option String → Json
+  | none   => Json.null
+  | some s => Json.str s
+
+/-- Render an `Option Nat` as `Json` (number or `null`). -/
+private def jOptNat : Option Nat → Json
+  | none   => Json.null
+  | some n => Json.num (.fromNat n)
+
+/-- Render an `Option Bool` as `Json` (bool or `null`). -/
+private def jOptBool : Option Bool → Json
+  | none   => Json.null
+  | some b => Json.bool b
+
+/-- Encode `Env` as a JSON object. The key order is fixed so the
+schema-stability test can compare the keyset deterministically and
+external dashboards can rely on diffability. -/
+def toJson (e : Env) : Json :=
+  Json.mkObj [
+    ("lean_version",       Json.str e.leanVersion),
+    ("lean_toolchain",     Json.str e.leanToolchain),
+    ("platform_target",    Json.str e.platformTarget),
+    ("os",                 Json.str e.os),
+    ("arch",               jOptStr e.arch),
+    ("cpu_model",          jOptStr e.cpuModel),
+    ("cpu_cores",          jOptNat e.cpuCores),
+    ("hostname",           jOptStr e.hostname),
+    ("exe_name",           Json.str e.exeName),
+    ("lean_bench_version", Json.str e.leanBenchVersion),
+    ("git_commit",         jOptStr e.gitCommit),
+    ("git_dirty",          jOptBool e.gitDirty),
+    ("timestamp_unix_ms",  Json.num (.fromInt e.timestampUnixMs)),
+    ("timestamp_iso",      Json.str e.timestampIso)
+  ]
+
+/-! ## Concise human-readable summary -/
+
+/-- One-line summary used in report headers. Lean version, OS/arch,
+git commit (truncated to 7 chars + dirty marker), and the ISO
+timestamp. Hostname is appended only when present and non-empty. -/
+def fmtConcise (e : Env) : String :=
+  let archStr := e.arch.getD "?"
+  let gitStr : String :=
+    match e.gitCommit with
+    | none   => "no-git"
+    | some sha =>
+      let short := sha.take 7 |>.toString
+      let suffix : String :=
+        match e.gitDirty with
+        | some true  => "-dirty"
+        | some false => ""
+        | none       => "?"
+      short ++ suffix
+  let hostSuffix : String :=
+    match e.hostname with
+    | some h => s!", host={h}"
+    | none   => ""
+  s!"lean={e.leanVersion}, os={e.os}, arch={archStr}, commit={gitStr}, {e.timestampIso}{hostSuffix}"
+
+end RunEnv
+end LeanBench

--- a/LeanBench/RunEnv.lean
+++ b/LeanBench/RunEnv.lean
@@ -34,9 +34,12 @@ namespace RunEnv
 
 /-! ## OS / arch derivation -/
 
-/-- Coarse OS family from `System.Platform`. `"unknown"` falls
-through every platform check rather than a partial match — readers
-should treat the value as informational, not authoritative. -/
+/-- Coarse OS family from `System.Platform`. We default to
+`"linux"` because every non-Windows / non-macOS / non-Emscripten
+platform Lean's process API actually supports today is a
+Linux-flavored Unix; the field is informational, and a more
+specific probe (e.g. distinguishing FreeBSD) would belong in a
+later metadata revision. -/
 def detectOs : String :=
   if System.Platform.isWindows then "windows"
   else if System.Platform.isOSX then "macos"
@@ -269,6 +272,48 @@ def toJson (e : Env) : Json :=
     ("timestamp_unix_ms",  Json.num (.fromInt e.timestampUnixMs)),
     ("timestamp_iso",      Json.str e.timestampIso)
   ]
+
+/-! ## JSON decoding (for `--env-json` plumbing)
+
+The parent captures env once and passes the rendered JSON to each
+child via the `--env-json` flag, so children don't independently
+re-shell-out to `git` / `hostname` per ladder rung. The child reads
+the flag, parses with `fromJson`, and emits the row verbatim. -/
+
+/-- Decode an `Env` from a JSON object. Tolerates missing fields by
+filling in `Inhabited` defaults — callers are expected to validate
+upstream (the JSON came from a sibling `RunEnv.toJson` call) so
+this is loose on input by design. The schema doc's "tolerate
+missing keys as null" carve-out applies here too. -/
+def fromJson (j : Json) : Except String Env := do
+  -- For optional fields we accept either `null`, an absent key, or
+  -- a value of the right type. `getObjValAs?` returns `.error` for
+  -- both absence and type mismatch; we collapse both to `none`.
+  let getOptStr (k : String) : Option String :=
+    match j.getObjValAs? String k with | .ok s => some s | .error _ => none
+  let getOptNat (k : String) : Option Nat :=
+    match j.getObjValAs? Nat k with | .ok n => some n | .error _ => none
+  let getOptBool (k : String) : Option Bool :=
+    match j.getObjValAs? Bool k with | .ok b => some b | .error _ => none
+  let leanVersion ← j.getObjValAs? String "lean_version"
+  let leanToolchain ← j.getObjValAs? String "lean_toolchain"
+  let platformTarget ← j.getObjValAs? String "platform_target"
+  let os ← j.getObjValAs? String "os"
+  let exeName ← j.getObjValAs? String "exe_name"
+  let leanBenchVersion ← j.getObjValAs? String "lean_bench_version"
+  let timestampUnixMs ← j.getObjValAs? Int "timestamp_unix_ms"
+  let timestampIso ← j.getObjValAs? String "timestamp_iso"
+  return {
+    leanVersion, leanToolchain, platformTarget, os
+    arch              := getOptStr  "arch"
+    cpuModel          := getOptStr  "cpu_model"
+    cpuCores          := getOptNat  "cpu_cores"
+    hostname          := getOptStr  "hostname"
+    exeName, leanBenchVersion
+    gitCommit         := getOptStr  "git_commit"
+    gitDirty          := getOptBool "git_dirty"
+    timestampUnixMs, timestampIso
+  }
 
 /-! ## Concise human-readable summary -/
 

--- a/LeanBench/Schema.lean
+++ b/LeanBench/Schema.lean
@@ -58,11 +58,39 @@ def requiredFixedKeys : Array String :=
 /-- Optional keys emitted on every row today. Absence is equivalent
     to `null`. -/
 def optionalCommonKeys : Array String :=
-  #["kind", "result_hash", "error"]
+  #["kind", "result_hash", "error", "env"]
 
 /-- Optional keys emitted only on parametric rows today. -/
 def optionalParametricKeys : Array String :=
   #["per_call_nanos", "cache_mode"]
+
+/-! ## Environment-metadata sub-keys
+
+The `env` value is itself a JSON object. `envKeys` pins the keys
+its writer emits today. Like `optionalCommonKeys`, this exists so
+the schema-stability test catches accidental drift in the field set
+or its order.
+
+Adding a new metadata field is a one-line edit here plus a matching
+field on `LeanBench.Env`. Removing one is a wire-format break and
+needs a `schemaVersion` bump (the field went from "writers may emit
+it" to "writers don't emit it"; older readers are tolerant but
+older *writers* against newer readers would still pass).
+
+The order matches `LeanBench.RunEnv.toJson`'s emission order so the
+schema test can do a strict array comparison after sorting.
+
+Per issue #11: "Missing metadata is handled explicitly rather than
+silently omitted." Producers MUST therefore emit every key — fields
+the platform can't supply land as JSON `null`, never as an absent
+key. Readers tolerate absence (treat it as `null`) for back-compat
+with hand-rolled fixtures. -/
+def envKeys : Array String :=
+  #["lean_version", "lean_toolchain", "platform_target",
+    "os", "arch", "cpu_model", "cpu_cores", "hostname",
+    "exe_name", "lean_bench_version",
+    "git_commit", "git_dirty",
+    "timestamp_unix_ms", "timestamp_iso"]
 
 /-! ## Cache-mode strings
 

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -97,6 +97,7 @@ were `null`.
 |--------------------|------------------|---------|
 | `result_hash`      | string \| null   | Hex-prefixed `0xDEADBEEF` literal (case-insensitive). `null` when the function's return type lacks `Hashable`. |
 | `error`            | string \| null   | Free-form message for `status == "error"`. `null` otherwise. |
+| `env`              | object \| null   | Reproducibility metadata captured at child startup — see [Environment metadata](#environment-metadata). Emitted on every row by current writers; absence is tolerated for back-compat with hand-rolled fixtures. |
 
 `kind` is also classified as optional from the reader's standpoint
 (absence defaults to `"parametric"`), but every current writer emits
@@ -117,8 +118,6 @@ listed here so concurrent feature work claims a stable name from
 the start:
 
 - `alloc_bytes`, `peak_rss_kb` — memory metrics ([#6]).
-- `env` — an object carrying reproducibility metadata: Lean version,
-  toolchain, platform, hostname, … ([#11]).
 - `budget_status` — additional status discriminator for budgeted-run
   rows that were skipped or partially completed ([#9]).
 
@@ -128,6 +127,47 @@ the ones described in their landing PRs.
 [#6]:  https://github.com/kim-em/lean-bench/issues/6
 [#9]:  https://github.com/kim-em/lean-bench/issues/9
 [#11]: https://github.com/kim-em/lean-bench/issues/11
+
+## Environment metadata
+
+The `env` field carries reproducibility metadata captured by the
+child at startup (issue [#11]). It exists so a JSONL row is
+self-describing for downstream tooling: which Lean version
+produced this number? on what hardware? at which git commit?
+
+The value is a JSON object with the following keys. Producers MUST
+emit every key. Fields with no available value land as JSON `null`,
+NOT as an absent key — the issue #11 acceptance criterion is
+"Missing metadata is handled explicitly rather than silently
+omitted." Readers MUST tolerate absent keys as `null` for
+back-compat with hand-rolled fixtures.
+
+| key                  | type            | meaning |
+|----------------------|-----------------|---------|
+| `lean_version`       | string          | `Lean.versionString` — e.g. `"4.30.0-rc2"`. |
+| `lean_toolchain`     | string          | `Lean.toolchain` — matches the `lean-toolchain` file. |
+| `platform_target`    | string          | LLVM target triple. Empty string when missing at compile time. |
+| `os`                 | string          | Coarse OS family: `"linux"` / `"macos"` / `"windows"` / `"emscripten"`. |
+| `arch`               | string \| null  | Architecture parsed from the target triple's leading segment. |
+| `cpu_model`          | string \| null  | Linux: from `/proc/cpuinfo`. macOS / Windows: `null` (best-effort, not yet probed). |
+| `cpu_cores`          | integer \| null | Logical core count. Linux: `/proc/cpuinfo`. Windows: `NUMBER_OF_PROCESSORS` env. |
+| `hostname`           | string \| null  | `hostname(1)` or env-var fallback (`HOSTNAME` / `COMPUTERNAME`). |
+| `exe_name`           | string          | Basename of the running executable. |
+| `lean_bench_version` | string          | `LeanBench.libraryVersion`. |
+| `git_commit`         | string \| null  | Full 40-char SHA from `git rev-parse HEAD` at cwd. `null` when git is unavailable. |
+| `git_dirty`          | bool \| null    | True iff `git status --porcelain` was non-empty. `null` distinguishes "no git" from "clean tree". |
+| `timestamp_unix_ms`  | integer         | Wallclock at capture, ms since Unix epoch. |
+| `timestamp_iso`      | string          | Wallclock at capture, ISO 8601 UTC (`"YYYY-MM-DDTHH:MM:SSZ"`). |
+
+The order writers emit these keys in is fixed by
+`LeanBench.RunEnv.toJson` and pinned by the schema-stability test;
+consumers MUST NOT depend on key order, but adding or removing a
+key without updating both `Schema.envKeys` and the test fixture
+will break the build.
+
+The same env snapshot also rides on the in-memory
+`BenchmarkResult` / `FixedResult` (parent-side capture) and is
+surfaced as a one-line summary in human-readable reports.
 
 ## Compatibility
 

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -107,7 +107,7 @@ it explicitly; producing a row without `kind` is a writer bug.
 
 | key                | type             | meaning |
 |--------------------|------------------|---------|
-| `per_call_nanos`   | number           | `total_nanos / inner_repeats` precomputed. Derived; readers MAY recompute it from `total_nanos` and `inner_repeats` when absent. |
+| `per_call_nanos`   | number \| null   | `total_nanos / inner_repeats` precomputed. Derived; readers MAY recompute it from `total_nanos` and `inner_repeats` when absent. Emitted as `null` on synthesized error / killed-at-cap rows where `inner_repeats == 0` (a real division-by-zero), to keep every emitted row valid JSON. |
 | `cache_mode`       | string           | `"warm"` (auto-tuned inner repeats inside one child, the v0.1 default) or `"cold"` (single untuned invocation; the parent respawns the child for every ladder rung). Absence is tolerated for back-compat with rows produced before issue #12 and treated as `"warm"`. See [`advanced.md#cache-modes`](advanced.md#cache-modes). |
 
 ### Reserved-for-future-use fields

--- a/test/LeanBenchTestFormat.lean
+++ b/test/LeanBenchTestFormat.lean
@@ -343,6 +343,77 @@ def testFmtVerifyMulti : IO UInt32 := do
     "1 of 2 benchmark(s) failed verification"
   snapshot "fmtVerify.multi" expected (Format.fmtVerify #[pass, fail])
 
+/-! ## Env summary in reports (issue #11)
+
+Pin the one-line `env: ...` summary that lands under the report
+header and at the top of comparison reports. Done with a fixed
+`Env` fixture so the test is deterministic — `RunEnv.capture` would
+be host-dependent. -/
+
+private def sampleEnv : Env :=
+  { leanVersion := "4.30.0-rc2"
+  , leanToolchain := "leanprover/lean4:v4.30.0-rc2"
+  , platformTarget := "x86_64-unknown-linux-gnu"
+  , os := "linux"
+  , arch := some "x86_64"
+  , cpuModel := some "Test CPU"
+  , cpuCores := some 8
+  , hostname := some "test-host"
+  , exeName := "test-exe"
+  , leanBenchVersion := "0.1.0"
+  , gitCommit := some "deadbeefcafef00d1234567890abcdef12345678"
+  , gitDirty := some false
+  , timestampUnixMs := 1714316040000
+  , timestampIso := "2026-04-28T12:34:00Z" }
+
+def testFmtResultWithEnv : IO UInt32 := do
+  let withEnv : BenchmarkResult := { sampleResult with env? := some sampleEnv }
+  let expected :=
+    "Sample.linearFn    expected complexity: n    [warm cache]\n" ++
+    "  env: lean=4.30.0-rc2, os=linux, arch=x86_64, commit=deadbee, " ++
+    "2026-04-28T12:34:00Z, host=test-host\n" ++
+    "  param  per-call    repeats  C\n" ++
+    "      2   25.000 ns  ×2^2     C=12.500\n" ++
+    "      4   50.000 ns  ×2^2     C=12.500\n" ++
+    "      8  100.000 ns  ×2^2     C=12.500\n" ++
+    "  verdict: consistent with declared complexity (cMin=12.500, cMax=12.500, β=+0.000)"
+  snapshot "fmtResult.withEnv" expected (Format.fmtResult withEnv)
+
+def testFmtComparisonWithEnv : IO UInt32 := do
+  -- Compare report should print env exactly *once* at the top, even
+  -- though both child results carry their own env? snapshot.
+  let withEnv1 : BenchmarkResult := { sampleResult with env? := some sampleEnv }
+  let withEnv2 : BenchmarkResult := { sampleResult2 with env? := some sampleEnv }
+  let rep : ComparisonReport :=
+    { sampleComparison with results := #[withEnv1, withEnv2] }
+  let formatted := Format.fmtComparison rep
+  -- Header line must appear exactly once.
+  let envLine :=
+    "env: lean=4.30.0-rc2, os=linux, arch=x86_64, commit=deadbee, " ++
+    "2026-04-28T12:34:00Z, host=test-host"
+  let parts := formatted.splitOn envLine
+  if parts.length != 2 then
+    IO.eprintln s!"fmtComparison.withEnv: expected env line exactly once, got {parts.length - 1} occurrences"
+    IO.eprintln formatted
+    return 1
+  -- And the env line must be the first line (top of comparison).
+  unless formatted.startsWith envLine do
+    IO.eprintln "fmtComparison.withEnv: env line must be at the top of the comparison"
+    IO.eprintln formatted
+    return 1
+  return 0
+
+def testFmtFixedResultWithEnv : IO UInt32 := do
+  let withEnv : FixedResult := { sampleFixedResult with env? := some sampleEnv }
+  let formatted := Format.fmtFixedResult withEnv
+  let envLine :=
+    "  env: lean=4.30.0-rc2, os=linux, arch=x86_64, commit=deadbee, " ++
+    "2026-04-28T12:34:00Z, host=test-host"
+  unless formatted.splitOn "\n" |>.contains envLine do
+    IO.eprintln s!"fmtFixedResult.withEnv: missing env summary line\n{formatted}"
+    return 1
+  return 0
+
 def testFmtCombinedVerify : IO UInt32 := do
   let pParam : VerifyReport := { spec := sampleSpec, checks := #[] }
   let fFixed : FixedVerifyReport :=
@@ -376,7 +447,10 @@ def main : IO UInt32 := do
       ("fmtVerifyReport.pass", testFmtVerifyPass),
       ("fmtVerifyReport.fail", testFmtVerifyFail),
       ("fmtVerify.multi", testFmtVerifyMulti),
-      ("fmtCombinedVerify", testFmtCombinedVerify) ]
+      ("fmtCombinedVerify", testFmtCombinedVerify),
+      ("fmtResult.withEnv", testFmtResultWithEnv),
+      ("fmtComparison.withEnv", testFmtComparisonWithEnv),
+      ("fmtFixedResult.withEnv", testFmtFixedResultWithEnv) ]
   do
     let code ← t
     if code != 0 then

--- a/test/LeanBenchTestRoundtrip.lean
+++ b/test/LeanBenchTestRoundtrip.lean
@@ -18,6 +18,28 @@ def sampleRow : String :=
   "\"per_call_nanos\":2929.6875,\"result_hash\":\"0xdeadbeef\"," ++
   "\"status\":\"ok\",\"error\":null}"
 
+/-- A row carrying a full `env` object (issue #11). The parser today
+    ignores `env` entirely (it lives on the in-memory result, not the
+    `DataPoint`), but the row must still parse cleanly — the env
+    object is a nested JSON value with strings, numbers, booleans,
+    and explicit nulls, and any laziness in the parser would bite
+    here. -/
+def sampleRowWithEnv : String :=
+  "{\"schema_version\":1,\"kind\":\"parametric\",\"function\":\"foo.bar\"," ++
+  "\"param\":7,\"inner_repeats\":2,\"total_nanos\":1000," ++
+  "\"per_call_nanos\":500.0,\"cache_mode\":\"warm\"," ++
+  "\"result_hash\":\"0xdeadbeef\",\"status\":\"ok\",\"error\":null," ++
+  "\"env\":{\"lean_version\":\"4.30.0-rc2\"," ++
+  "\"lean_toolchain\":\"leanprover/lean4:v4.30.0-rc2\"," ++
+  "\"platform_target\":\"x86_64-unknown-linux-gnu\"," ++
+  "\"os\":\"linux\",\"arch\":\"x86_64\"," ++
+  "\"cpu_model\":null,\"cpu_cores\":8," ++
+  "\"hostname\":\"my-host\",\"exe_name\":\"bench\"," ++
+  "\"lean_bench_version\":\"0.1.0\"," ++
+  "\"git_commit\":null,\"git_dirty\":null," ++
+  "\"timestamp_unix_ms\":1714316040000," ++
+  "\"timestamp_iso\":\"2026-04-28T12:34:00Z\"}}"
+
 def main : IO UInt32 := do
   match LeanBench.parseChildRow sampleRow with
   | .error e =>
@@ -36,9 +58,16 @@ def main : IO UInt32 := do
       dp.totalNanos == expected.totalNanos ∧
       dp.resultHash == expected.resultHash ∧
       dp.status == expected.status
-    if okExpected then
-      IO.println "roundtrip OK"
-      return 0
-    else
+    unless okExpected do
       IO.eprintln s!"roundtrip mismatch: got {repr dp}"
       return 1
+  match LeanBench.parseChildRow sampleRowWithEnv with
+  | .error e =>
+    IO.eprintln s!"env-row parse failure: {e}"
+    return 1
+  | .ok dp =>
+    unless dp.param == 7 ∧ dp.innerRepeats == 2 ∧ dp.totalNanos == 1000 do
+      IO.eprintln s!"env-row mismatch: {repr dp}"
+      return 1
+  IO.println "roundtrip OK"
+  return 0

--- a/test/LeanBenchTestSchema.lean
+++ b/test/LeanBenchTestSchema.lean
@@ -149,6 +149,17 @@ def testParametricEmitKeys : IO UInt32 := do
     | .error _ =>
       IO.eprintln "parametric row missing status"
       return 1
+    -- `env` must be a JSON object whose key set matches `Schema.envKeys`.
+    match j.getObjVal? "env" with
+    | .error _ =>
+      IO.eprintln "parametric row missing env (issue #11: env must always be emitted)"
+      return 1
+    | .ok envJson =>
+      let envActual := objKeys envJson
+      let envExpected := sortKeys Schema.envKeys
+      unless envActual == envExpected do
+        IO.eprintln s!"env key set mismatch:\n  got      {envActual}\n  expected {envExpected}"
+        return 1
     return 0
 
 def testFixedEmitKeys : IO UInt32 := do
@@ -176,6 +187,16 @@ def testFixedEmitKeys : IO UInt32 := do
     | .error _ =>
       IO.eprintln "fixed row missing kind discriminator"
       return 1
+    match j.getObjVal? "env" with
+    | .error _ =>
+      IO.eprintln "fixed row missing env (issue #11: env must always be emitted)"
+      return 1
+    | .ok envJson =>
+      let envActual := objKeys envJson
+      let envExpected := sortKeys Schema.envKeys
+      unless envActual == envExpected do
+        IO.eprintln s!"fixed env key set mismatch:\n  got      {envActual}\n  expected {envExpected}"
+        return 1
     return 0
 
 /-! ## Producer-side: pin the canonical key sets
@@ -194,9 +215,16 @@ def testCanonicalKeyConstants : IO UInt32 := do
   let okFixed :=
     Schema.requiredFixedKeys == #["repeat_index"]
   let okOptCommon :=
-    Schema.optionalCommonKeys == #["kind", "result_hash", "error"]
+    Schema.optionalCommonKeys == #["kind", "result_hash", "error", "env"]
   let okOptParametric :=
     Schema.optionalParametricKeys == #["per_call_nanos", "cache_mode"]
+  let okEnvKeys :=
+    Schema.envKeys ==
+      #["lean_version", "lean_toolchain", "platform_target",
+        "os", "arch", "cpu_model", "cpu_cores", "hostname",
+        "exe_name", "lean_bench_version",
+        "git_commit", "git_dirty",
+        "timestamp_unix_ms", "timestamp_iso"]
   let okStatus :=
     Schema.statusStrings ==
       #["ok", "timed_out", "killed_at_cap", "error"]
@@ -205,7 +233,81 @@ def testCanonicalKeyConstants : IO UInt32 := do
     Schema.kindParametric == "parametric" ∧ Schema.kindFixed == "fixed"
   expect "canonical key sets match docs"
     (okCommon ∧ okParametric ∧ okFixed ∧ okOptCommon ∧
-     okOptParametric ∧ okStatus ∧ okVersion ∧ okKindStrings)
+     okOptParametric ∧ okEnvKeys ∧ okStatus ∧ okVersion ∧ okKindStrings)
+
+/-! ## Env capture (issue #11)
+
+Exercise `RunEnv.capture` directly so the round-trip "capture →
+encode → parse → match key set" works without relying on the child
+process. Also pin the always-present invariants: `lean_version`,
+`platform_target`, `os`, and `lean_bench_version` are derivable
+from compile-time constants and must never collapse to empty
+strings or `null`. -/
+
+def testRunEnvCaptureKeyset : IO UInt32 := do
+  let env ← RunEnv.capture
+  let json := RunEnv.toJson env
+  let actual := objKeys json
+  let expected := sortKeys Schema.envKeys
+  unless actual == expected do
+    IO.eprintln s!"RunEnv.toJson key set mismatch:\n  got      {actual}\n  expected {expected}"
+    return 1
+  return 0
+
+def testRunEnvAlwaysPresentFields : IO UInt32 := do
+  let env ← RunEnv.capture
+  -- Compile-time-derivable fields must never be empty.
+  if env.leanVersion.isEmpty then
+    IO.eprintln "RunEnv.leanVersion was empty"
+    return 1
+  if env.leanToolchain.isEmpty then
+    IO.eprintln "RunEnv.leanToolchain was empty"
+    return 1
+  if env.os.isEmpty then
+    IO.eprintln "RunEnv.os was empty"
+    return 1
+  if env.leanBenchVersion.isEmpty then
+    IO.eprintln "RunEnv.leanBenchVersion was empty"
+    return 1
+  if env.timestampIso.isEmpty then
+    IO.eprintln "RunEnv.timestampIso was empty"
+    return 1
+  -- ISO timestamp basic shape: 20 chars, ends in 'Z'.
+  unless env.timestampIso.endsWith "Z" do
+    IO.eprintln s!"RunEnv.timestampIso does not end in 'Z': {env.timestampIso}"
+    return 1
+  return 0
+
+/-- "Missing metadata is handled explicitly rather than silently
+    omitted" — verify each best-effort field renders as JSON `null`
+    rather than disappearing from the object when the underlying
+    `Option` is `none`. We synthesize an `Env` with every probe
+    nulled out and confirm the encoder still emits all
+    `Schema.envKeys`. -/
+def testRunEnvNullsForMissing : IO UInt32 := do
+  let nullEnv : Env := {
+    leanVersion := "x", leanToolchain := "y", platformTarget := "",
+    os := "linux", arch := none, cpuModel := none, cpuCores := none,
+    hostname := none, exeName := "test", leanBenchVersion := "0.1.0",
+    gitCommit := none, gitDirty := none,
+    timestampUnixMs := 0, timestampIso := "1970-01-01T00:00:00Z" }
+  let json := RunEnv.toJson nullEnv
+  let actual := objKeys json
+  let expected := sortKeys Schema.envKeys
+  unless actual == expected do
+    IO.eprintln s!"null-env key set mismatch:\n  got      {actual}\n  expected {expected}"
+    return 1
+  -- Each previously-`none` field must encode as JSON `null`, not
+  -- a missing key. Pin one nullable field per category — string
+  -- (`cpu_model`), nat (`cpu_cores`), bool (`git_dirty`).
+  let isNull (key : String) : Bool :=
+    match json.getObjVal? key with
+    | .ok Lean.Json.null => true
+    | _                  => false
+  unless isNull "cpu_model" ∧ isNull "cpu_cores" ∧ isNull "git_dirty" do
+    IO.eprintln "null-env: expected nullable fields to encode as JSON null"
+    return 1
+  return 0
 
 /-! ## Consumer-side: parse tolerance -/
 
@@ -447,6 +549,9 @@ def testFixedParseRejectsMissingRequired : IO UInt32 := do
 def runTests : IO UInt32 := do
   for (label, t) in
     [ ("canonicalKeyConstants",      testCanonicalKeyConstants)
+    , ("env.captureKeyset",          testRunEnvCaptureKeyset)
+    , ("env.alwaysPresent",          testRunEnvAlwaysPresentFields)
+    , ("env.nullsForMissing",        testRunEnvNullsForMissing)
     , ("emit.parametric",            testParametricEmitKeys)
     , ("emit.fixed",                 testFixedEmitKeys)
     , ("parse.extraKey",             testParseAcceptsExtraKey)


### PR DESCRIPTION
Closes https://github.com/kim-em/lean-bench/issues/11

## Summary

- Each JSONL row now carries an `env` object with Lean version /
  toolchain, OS / arch, CPU model + cores, hostname, exe name,
  lean-bench version, git commit + dirty flag, and wallclock
  timestamp (Unix ms + ISO 8601). Best-effort fields land as JSON
  `null` rather than missing keys.
- The same env snapshot rides on `BenchmarkResult` / `FixedResult`
  and surfaces as a one-line `env: lean=…, os=…, commit=…` summary
  under the report header (or once at the top of comparison reports).
- Schema doc reserved `env` as upcoming work, so this is additive
  and non-breaking — no `schemaVersion` bump.

## Implementation notes

- `LeanBench.RunEnv` owns `capture` (best-effort: missing probes
  collapse to `none`), `toJson` / `fromJson`, and `fmtConcise`.
- The parent captures env once at `runBenchmark` start and pipes
  it to every child via `--env-json`. Children parse it back and
  emit verbatim, so a single run stamps identical env across
  rungs (consistent timestamps, hostname, git_dirty) and avoids
  ~3 subprocess spawns per ladder rung. When the flag is absent
  (manual `_child` invocation, tests) the child captures fresh.
- CPU model / core count are Linux-only via `/proc/cpuinfo`;
  macOS / Windows get explicit `null` (best-effort, future work to
  probe `sysctl` / `wmic`).

## Followups from /second-opinion

Codex flagged four issues on the initial commit; addressed in 1149ce5:

- Synthesized error rows had `inner_repeats := 0`, producing
  `per_call_nanos: NaN` (invalid JSON). Now emit `null` when
  `inner_repeats == 0`; schema doc updated to mark the field
  nullable.
- Parent and child were both capturing env independently. Parent
  now captures once and passes via `--env-json`.
- Format snapshots and the roundtrip test didn't exercise env;
  added `fmtResult.withEnv`, `fmtComparison.withEnv`,
  `fmtFixedResult.withEnv`, plus an env-bearing roundtrip row.
- `detectOs` documented `"unknown"` as a possible return but
  always falls through to `"linux"`. Narrowed the docs.

## Test plan

- [x] lake build clean on Linux (full local pass, all 11 test exes green)
- [ ] Linux CI green
- [ ] macOS CI green (cpu_model / cpu_cores expected to be null,
  but env still emitted on every row)
- [ ] Windows CI green (same — cpu_cores via NUMBER_OF_PROCESSORS)
- [x] verify, run, compare smoke-tested locally — env summary
  appears in report headers.

🤖 Prepared with Claude Code