### PR TITLE
feat: benchmark tags and CLI filtering (issue #10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,10 @@ jobs:
         shell: bash
         run: ./.lake/build/bin/schema_benchmark_test
 
+      - name: tags and filtering test (issue #10)
+        shell: bash
+        run: ./.lake/build/bin/tags_benchmark_test
+
       - name: end-to-end run/compare test
         shell: bash
         run: ./.lake/build/bin/e2e_benchmark_test

--- a/LeanBench/Cli.lean
+++ b/LeanBench/Cli.lean
@@ -20,7 +20,7 @@ runner). Subcommand layout:
 |-----------------------------------------------------------------|------|
 | `./bench`                                                       | parent: print all registered benchmark names |
 | `./bench list`                                                  | parent: same |
-| `./bench run NAME [override flags]`                             | parent: run one benchmark, print report |
+| `./bench run NAME [override flags]`                             | parent: run one or more benchmarks, print report |
 | `./bench compare A B C [override flags]`                        | parent: comparison report |
 | `./bench verify [NAMES…]`                                        | parent: bounded `f 0` / `f 1` sanity check via children |
 | `./bench _child --bench NAME --param N --target-nanos T`        | child: one inner-tuned batch, print one JSONL row, exit |
@@ -31,6 +31,13 @@ flags (`--max-seconds-per-call`, `--target-inner-nanos`,
 `--slope-tolerance`, `--param-schedule`). Each flag corresponds 1:1
 with a `ConfigOverride` field; missing flags leave the declared
 config untouched.
+
+All parent-side subcommands accept `--tag TAG` and `--filter PATTERN`
+for selecting benchmarks by tag or name substring. Tags are declared
+via `where { tags := #["sort", "fast"] }` and matched by
+comma-separated OR logic (`--tag sort,fast` matches benchmarks with
+either tag). `--filter Sort` matches benchmarks whose name contains
+"Sort" as a substring. See `doc/quickstart.md#tags-and-filtering`.
 
 CLI parsing uses `Cli` (mhuisi/lean4-cli).
 -/
@@ -114,18 +121,88 @@ def fixedConfigOverrideFromParsed (p : Cli.Parsed) : FixedConfigOverride :=
   { repeats?           := parsedFlag? p "repeats" Nat
     maxSecondsPerCall? := parsedFlag? p "max-seconds-per-call" Float }
 
+/-! ## Benchmark filtering (issue #10)
+
+Shared filtering infrastructure for `list`, `run`, `compare`, and
+`verify`. Benchmarks can be selected by:
+
+- **Tag** (`--tag sort,fast`): matches benchmarks that have at least
+  one of the listed tags (OR logic).
+- **Name filter** (`--filter Sort`): matches benchmarks whose full
+  dotted name contains the given substring.
+- **Both** (`--tag sort --filter Insert`): both conditions must match
+  (AND logic between the two filter types).
+
+When neither `--tag` nor `--filter` is given, all benchmarks pass the
+filter (existing behavior). -/
+
+/-- True iff `haystack` contains `needle` as a substring. -/
+def containsSub (haystack needle : String) : Bool :=
+  (haystack.splitOn needle).length > 1
+
+/-- Split a comma-separated tag string into individual tags. Trims
+whitespace from each segment and filters out empty segments, so
+`--tag "sort, fast"` and `--tag sort,,fast` both produce
+`#["sort", "fast"]`. -/
+def splitTags (s : String) : Array String :=
+  (s.splitOn ",").toArray.map (·.trimAscii.toString) |>.filter (!·.isEmpty)
+
+/-- Does a single benchmark entry match the given tag and name
+filters? -/
+def matchEntry (name : Lean.Name) (entryTags : Array String)
+    (tagFilter : Array String) (nameFilter : Option String) : Bool :=
+  let tagOk := tagFilter.isEmpty || tagFilter.any entryTags.contains
+  let nameOk := match nameFilter with
+    | none => true
+    | some pat => containsSub (name.toString (escape := false)) pat
+  tagOk && nameOk
+
+/-- Parse `--tag` and `--filter` from a `Cli.Parsed`. Returns
+`(tagFilter, nameFilter)` where `tagFilter` is the split comma-
+separated tag list (empty if `--tag` was not passed) and `nameFilter`
+is the raw `--filter` string if present. -/
+private def parseFilters (p : Cli.Parsed) : Array String × Option String :=
+  let tagFilter := parsedFlag? p "tag" String |>.map splitTags |>.getD #[]
+  let nameFilter := parsedFlag? p "filter" String
+  (tagFilter, nameFilter)
+
+/-- Filter parametric runtime entries by tag/name. -/
+private def filterParametric (entries : Array RuntimeEntry)
+    (tagFilter : Array String) (nameFilter : Option String) :
+    Array RuntimeEntry :=
+  entries.filter fun e =>
+    matchEntry e.spec.name e.spec.config.tags tagFilter nameFilter
+
+/-- Filter fixed runtime entries by tag/name. -/
+private def filterFixed (entries : Array FixedRuntimeEntry)
+    (tagFilter : Array String) (nameFilter : Option String) :
+    Array FixedRuntimeEntry :=
+  entries.filter fun e =>
+    matchEntry e.spec.name e.spec.config.tags tagFilter nameFilter
+
+/-- Are any filter flags set? -/
+private def hasFilters (tagFilter : Array String) (nameFilter : Option String) :
+    Bool :=
+  !tagFilter.isEmpty || nameFilter.isSome
+
 /-! ## Subcommand handlers (parent side) -/
 
-def runListCmd (_ : Cli.Parsed) : IO UInt32 := do
+def runListCmd (p : Cli.Parsed) : IO UInt32 := do
+  let (tagFilter, nameFilter) := parseFilters p
   let pEntries ← allRuntimeEntries
   let fEntries ← allFixedRuntimeEntries
-  if pEntries.isEmpty && fEntries.isEmpty then
-    IO.println "(no benchmarks registered)"
+  let pFiltered := filterParametric pEntries tagFilter nameFilter
+  let fFiltered := filterFixed fEntries tagFilter nameFilter
+  if pFiltered.isEmpty && fFiltered.isEmpty then
+    if hasFilters tagFilter nameFilter then
+      IO.println "(no benchmarks match the given filters)"
+    else
+      IO.println "(no benchmarks registered)"
     return 0
   IO.println "registered benchmarks:"
-  for e in pEntries do
+  for e in pFiltered do
     IO.println (Format.fmtSpec e.spec)
-  for e in fEntries do
+  for e in fFiltered do
     IO.println (Format.fmtFixedSpec e.spec)
   return 0
 
@@ -159,40 +236,109 @@ private def handleBaselineAndExport
   | none => pure ()
   return exitCode
 
+/-- Dispatch `run` by explicit names and/or filters. When explicit
+    names are given, run those directly (existing behavior). When
+    only filters are given, run all matching benchmarks. Parametric
+    and fixed benchmarks can coexist in a filtered run; each is
+    dispatched to its own runner.
+
+    With both names and filters, only explicit names are run (filters
+    are selection tools for "find all matching" mode, not additional
+    constraints on named benchmarks). -/
 def runRunCmd (p : Cli.Parsed) : IO UInt32 := do
-  let nameStr := (p.positionalArg! "name").as! String
-  let name := nameStr.toName
+  let nameStrs := p.variableArgsAs! String |>.toList
+  let (tagFilter, nameFilter) := parseFilters p
   let exportPath? := parsedFlag? p "export-file" String
   let baselinePath? := parsedFlag? p "baseline" String
   let threshold : Float :=
     (parsedFlag? p "regression-threshold" Float).getD 10.0
-  match ← findRuntimeEntry name with
-  | some _ =>
-    let result ← LeanBench.runBenchmark name (configOverrideFromParsed p)
-    IO.println (Format.fmtResult result)
-    handleBaselineAndExport #[result] #[] result.env?
+  -- Explicit names: run each directly (existing behavior).
+  if !nameStrs.isEmpty then
+    let mut anyFail := false
+    let mut pResults : Array BenchmarkResult := #[]
+    let mut fResults : Array FixedResult := #[]
+    for nameStr in nameStrs do
+      let name := nameStr.toName
+      match ← findRuntimeEntry name with
+      | some _ =>
+        let result ← LeanBench.runBenchmark name (configOverrideFromParsed p)
+        IO.println (Format.fmtResult result)
+        pResults := pResults.push result
+      | none =>
+        match ← findFixedRuntimeEntry name with
+        | some _ =>
+          let result ← LeanBench.runFixedBenchmark name
+                          (fixedConfigOverrideFromParsed p)
+          IO.println (Format.fmtFixedResult result)
+          fResults := fResults.push result
+        | none =>
+          IO.eprintln s!"run: unregistered benchmark: {name}"
+          anyFail := true
+      if nameStrs.length > 1 then
+        IO.println ""
+    if anyFail then return 1
+    let env? := pResults[0]?.bind (·.env?) |>.orElse fun _ => fResults[0]?.bind (·.env?)
+    let exportCode ← handleBaselineAndExport pResults fResults env?
       baselinePath? exportPath? threshold
-  | none =>
-    match ← findFixedRuntimeEntry name with
-    | some _ =>
-      let result ← LeanBench.runFixedBenchmark name
-                      (fixedConfigOverrideFromParsed p)
-      IO.println (Format.fmtFixedResult result)
-      handleBaselineAndExport #[] #[result] result.env?
-        baselinePath? exportPath? threshold
-    | none =>
-      IO.eprintln s!"run: unregistered benchmark: {name}"
-      return 1
+    return exportCode
+  -- No explicit names: use filters.
+  unless hasFilters tagFilter nameFilter do
+    IO.eprintln "run: specify a benchmark name or use --tag/--filter to select benchmarks"
+    return 1
+  let pEntries ← allRuntimeEntries
+  let fEntries ← allFixedRuntimeEntries
+  let pFiltered := filterParametric pEntries tagFilter nameFilter
+  let fFiltered := filterFixed fEntries tagFilter nameFilter
+  if pFiltered.isEmpty && fFiltered.isEmpty then
+    IO.eprintln "run: no benchmarks match the given filters"
+    return 1
+  let mut first := true
+  let mut pResults : Array BenchmarkResult := #[]
+  let mut fResults : Array FixedResult := #[]
+  for e in pFiltered do
+    unless first do IO.println ""
+    first := false
+    let result ← LeanBench.runBenchmark e.spec.name (configOverrideFromParsed p)
+    IO.println (Format.fmtResult result)
+    pResults := pResults.push result
+  for e in fFiltered do
+    unless first do IO.println ""
+    first := false
+    let result ← LeanBench.runFixedBenchmark e.spec.name
+                    (fixedConfigOverrideFromParsed p)
+    IO.println (Format.fmtFixedResult result)
+    fResults := fResults.push result
+  let env? := pResults[0]?.bind (·.env?) |>.orElse fun _ => fResults[0]?.bind (·.env?)
+  handleBaselineAndExport pResults fResults env?
+    baselinePath? exportPath? threshold
 
 /-- Dispatch `compare A B …` by registration kind. All listed names
     must be the same kind (all parametric or all fixed); mixing is
-    rejected with a user-facing error. -/
+    rejected with a user-facing error.
+
+    When no explicit names are given, `--tag` / `--filter` selects
+    the benchmarks to compare. The same kind constraint applies. -/
 def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
-  let names := p.variableArgsAs! String |>.toList
-  if names.isEmpty then
-    IO.eprintln "compare: need at least two benchmark names"
+  let nameStrs := p.variableArgsAs! String |>.toList
+  let (tagFilter, nameFilter) := parseFilters p
+  let resolved : List Lean.Name ←
+    if !nameStrs.isEmpty then
+      pure (nameStrs.map String.toName)
+    else if hasFilters tagFilter nameFilter then do
+      let pEntries ← allRuntimeEntries
+      let fEntries ← allFixedRuntimeEntries
+      let pFiltered := filterParametric pEntries tagFilter nameFilter
+      let fFiltered := filterFixed fEntries tagFilter nameFilter
+      let pNames := pFiltered.map (·.spec.name) |>.toList
+      let fNames := fFiltered.map (·.spec.name) |>.toList
+      pure (pNames ++ fNames)
+    else pure []
+  if resolved.isEmpty then
+    IO.eprintln "compare: need at least two benchmark names (or use --tag/--filter)"
     return 1
-  let resolved := names.map String.toName
+  if resolved.length < 2 then
+    IO.eprintln "compare: need at least two benchmarks to compare"
+    return 1
   let exportPath? : Option String := parsedFlag? p "export-file" String
   let mut allParametric := true
   let mut allFixed := true
@@ -226,10 +372,26 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
   return 1
 
 def runVerifyCmd (p : Cli.Parsed) : IO UInt32 := do
-  -- Use `String.toName` so qualified names like `My.Bench.foo` resolve.
-  -- `Lean.Name.mkSimple` would package the whole dotted string into one
-  -- atomic name, which never matches anything in the registry.
-  let names := p.variableArgsAs! String |>.toList |>.map String.toName
+  let nameStrs := p.variableArgsAs! String |>.toList
+  let (tagFilter, nameFilter) := parseFilters p
+  let names : List Lean.Name ←
+    if !nameStrs.isEmpty then
+      pure (nameStrs.map String.toName)
+    else if hasFilters tagFilter nameFilter then do
+      let pEntries ← allRuntimeEntries
+      let fEntries ← allFixedRuntimeEntries
+      let pFiltered := filterParametric pEntries tagFilter nameFilter
+      let fFiltered := filterFixed fEntries tagFilter nameFilter
+      let pNames := pFiltered.map (·.spec.name) |>.toList
+      let fNames := fFiltered.map (·.spec.name) |>.toList
+      pure (pNames ++ fNames)
+    else pure []
+  -- `verify []` means "all" (existing behavior). `verify --tag x`
+  -- that matches nothing still calls `verify []` which verifies all,
+  -- so check for that edge case.
+  if hasFilters tagFilter nameFilter && names.isEmpty then
+    IO.eprintln "verify: no benchmarks match the given filters"
+    return 1
   match ← (LeanBench.verify names |>.toBaseIO) with
   | .error e =>
     IO.eprintln s!"verify: {e.toString}"
@@ -242,11 +404,6 @@ def runVerifyCmd (p : Cli.Parsed) : IO UInt32 := do
 
 def runChildCmd (p : Cli.Parsed) : IO UInt32 := do
   let benchStr := (p.flag! "bench").as! String
-  -- `--env-json` is the issue #11 plumbing: when the parent has
-  -- already captured env, it serializes via this flag so the child
-  -- doesn't redo the work. Parse failures fall back to "let the
-  -- child capture fresh" rather than aborting — a malformed env
-  -- payload is a parent bug, but the run itself can still proceed.
   let env? : Option LeanBench.Env :=
     match parsedFlag? p "env-json" String with
     | none => none
@@ -257,10 +414,6 @@ def runChildCmd (p : Cli.Parsed) : IO UInt32 := do
         match LeanBench.RunEnv.fromJson j with
         | .ok env => some env
         | .error _ => none
-  -- The `--fixed` flag is a discriminator: when present the child
-  -- runs a fixed-benchmark single invocation and reads
-  -- `--repeat-index`; otherwise it's the existing parametric path
-  -- and reads `--param` / `--target-nanos`.
   if p.hasFlag "fixed" then
     let repeatIdx : Nat :=
       match parsedFlag? p "repeat-index" Nat with
@@ -278,12 +431,19 @@ def runChildCmd (p : Cli.Parsed) : IO UInt32 := do
 
 def listSub : Cmd := `[Cli|
   list VIA runListCmd; ["0.1.0"]
-  "List registered benchmarks."
+  "List registered benchmarks. Use --tag/--filter to narrow the output."
+
+  FLAGS:
+    tag : String;      "Filter by tag (comma-separated for multiple; OR logic). Example: --tag sort,fast"
+    filter : String;   "Filter by name substring. Example: --filter Sort"
 ]
 
 def runSub : Cmd := `[Cli|
   run VIA runRunCmd; ["0.1.0"]
-  "Run a single registered benchmark; print the result table.
+  "Run registered benchmarks; print the result table.
+
+Accepts explicit benchmark names as positional arguments, or use
+--tag/--filter to select benchmarks by metadata.
 
 Dispatches by registration kind (parametric vs fixed). Override flags
 that don't apply to the dispatched kind are silently ignored, so
@@ -294,6 +454,8 @@ Override the benchmark's declared config per-run with the flags below.
 Each missing flag leaves the declared value untouched."
 
   FLAGS:
+    tag : String;      "Filter by tag (comma-separated for multiple; OR logic). Example: --tag sort,fast"
+    filter : String;   "Filter by name substring. Example: --filter Sort"
     "max-seconds-per-call" : Float;  "Hard wallclock cap per batch / per call (seconds; e.g. 0.5; JSON-style numbers)."
     "target-inner-nanos" : Nat;      "Parametric only: auto-tune target wall-time per batch (nanoseconds)."
     "param-floor" : Nat;             "Parametric only: lowest param the doubling ladder starts from."
@@ -309,7 +471,7 @@ Each missing flag leaves the declared value untouched."
     "regression-threshold" : Float;  "Percentage threshold for flagging regressions (default 10.0; e.g. 10 means >10% slower is a regression)."
 
   ARGS:
-    name : String;     "Benchmark name (lowercase, as registered)."
+    ...names : String;     "Benchmark name(s). If omitted, use --tag/--filter to select."
 ]
 
 def childSub : Cmd := `[Cli|
@@ -333,9 +495,15 @@ def compareSub : Cmd := `[Cli|
 
 All listed benchmarks must be the same kind (parametric or fixed);
 mixing is rejected. Same per-run override flags as `run`; they apply
-to every benchmark in the comparison."
+to every benchmark in the comparison.
+
+Use --tag/--filter instead of explicit names to select benchmarks by
+metadata. When both explicit names and filters are given, only the
+explicit names are used."
 
   FLAGS:
+    tag : String;      "Filter by tag (comma-separated for multiple; OR logic). Example: --tag sort,fast"
+    filter : String;   "Filter by name substring. Example: --filter Sort"
     "max-seconds-per-call" : Float;  "Hard wallclock cap per batch / per call (seconds; e.g. 0.5; JSON-style numbers)."
     "target-inner-nanos" : Nat;      "Parametric only: auto-tune target wall-time per batch (nanoseconds)."
     "param-floor" : Nat;             "Parametric only: lowest param the doubling ladder starts from."
@@ -349,12 +517,16 @@ to every benchmark in the comparison."
     "export-file" : String;           "Write results to FILE in machine-readable JSON format (issue #3)."
 
   ARGS:
-    ...names : String;     "Two or more benchmark names (variadic)."
+    ...names : String;     "Two or more benchmark names (variadic). Or use --tag/--filter to select."
 ]
 
 def verifySub : Cmd := `[Cli|
   verify VIA runVerifyCmd; ["0.1.0"]
-  "Sanity-check registered benchmarks (f 0, f 1 via the child path). Verifies all benchmarks if no names are given. Exit code is non-zero on any failure."
+  "Sanity-check registered benchmarks (f 0, f 1 via the child path). Verifies all benchmarks if no names or filters are given. Exit code is non-zero on any failure."
+
+  FLAGS:
+    tag : String;      "Filter by tag (comma-separated for multiple; OR logic). Example: --tag sort,fast"
+    filter : String;   "Filter by name substring. Example: --filter Sort"
 
   ARGS:
     ...names : String;     "Optional: benchmark names to verify; verify all if omitted."

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -311,6 +311,13 @@ structure BenchmarkConfig where
       with `outerTrials`. CI tunes this via `--outer-trials` to trade
       runtime for stability. Issue #4. -/
   outerTrials : Nat := 1
+  /-- User-defined tags for organizing benchmarks into groups. Tags
+      are arbitrary strings attached at declaration time via
+      `where { tags := #["sort", "fast"] }`. The CLI can filter by tag
+      (`--tag sort`) or by name substring (`--filter Sort`) on `list`,
+      `run`, `compare`, and `verify`. Tags are metadata — they don't
+      affect measurement, the verdict, or the wire format. Issue #10. -/
+  tags : Array String := #[]
   deriving Inhabited, Repr, BEq
 
 /-- Optional run-time overrides applied on top of a benchmark's
@@ -687,6 +694,9 @@ structure FixedBenchmarkConfig where
   /-- Whether to perform a single discarded warmup call before the
       measured calls. Defaults to true. -/
   warmup            : Bool  := true
+  /-- User-defined tags for organizing benchmarks. Same semantics as
+      `BenchmarkConfig.tags` — see issue #10. -/
+  tags              : Array String := #[]
   deriving Inhabited, Repr, BEq
 
 /-- Run-time overrides applied on top of a benchmark's declared

--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -348,16 +348,24 @@ def fmtResult (r : BenchmarkResult) (includeEnv : Bool := true) : String := Id.r
     lines := lines.push (fmtAdvisory r adv)
   return "\n".intercalate lines.toList
 
+/-- Format tags as a compact `[tag1, tag2]` suffix. Empty when no
+    tags are assigned so untagged benchmarks look unchanged. -/
+private def fmtTags (tags : Array String) : String :=
+  if tags.isEmpty then ""
+  else "  [" ++ String.intercalate ", " tags.toList ++ "]"
+
 /-- One-line summary of a registered benchmark, used by `list`. -/
 def fmtSpec (spec : BenchmarkSpec) : String :=
   let h := if spec.hashable then "" else "  (no Hashable)"
-  s!"  {spec.name}    expected complexity: {spec.complexityFormula}{h}"
+  let t := fmtTags spec.config.tags
+  s!"  {spec.name}    expected complexity: {spec.complexityFormula}{h}{t}"
 
 /-- One-line summary of a registered fixed benchmark. The `[fixed]`
     annotation distinguishes it from parametric entries in the list. -/
 def fmtFixedSpec (spec : FixedSpec) : String :=
   let h := if spec.hashable then "" else "  (no Hashable)"
-  s!"  {spec.name}    [fixed] repeats={spec.config.repeats}{h}"
+  let t := fmtTags spec.config.tags
+  s!"  {spec.name}    [fixed] repeats={spec.config.repeats}{h}{t}"
 
 /-- Render a single fixed-benchmark result as a multi-line block:
     one row per measured repeat plus a summary with median/min/max

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -114,6 +114,101 @@ Pick whichever expression best models the algorithm:
 `Nat.log2` is in core Lean. The `+ 1` in the `n log n` row guards
 against `log2 0 = 0` producing a zero denominator in the ratio.
 
+## Tags and filtering
+
+As your benchmark suite grows, organizing benchmarks into groups makes
+it easier to run subsets, compare families, and keep `list` output
+readable.
+
+### Tagging benchmarks
+
+Add `tags` in the `where { … }` block:
+
+```lean
+setup_benchmark runInsertion n => n * n where {
+  tags := #["sort", "quadratic"]
+  maxSecondsPerCall := 0.5
+}
+setup_benchmark runMergeSort n => n * Nat.log2 (n + 1) where {
+  tags := #["sort"]
+}
+setup_benchmark goodFib n => n where {
+  tags := #["fib"]
+}
+```
+
+Tags are arbitrary strings. A benchmark can have zero or more tags.
+Benchmarks without tags work exactly as before — the feature is fully
+opt-in.
+
+Fixed benchmarks support tags too:
+
+```lean
+setup_fixed_benchmark heavyComputation where {
+  tags := #["regression"]
+  repeats := 10
+}
+```
+
+### Filtering by tag or name
+
+All parent-side subcommands (`list`, `run`, `compare`, `verify`)
+accept `--tag` and `--filter` flags:
+
+| Flag | Semantics |
+|------|-----------|
+| `--tag sort` | Benchmarks with the `sort` tag |
+| `--tag sort,fib` | Benchmarks with `sort` OR `fib` (OR logic) |
+| `--filter Sort` | Benchmarks whose name contains `Sort` |
+| `--tag sort --filter Insert` | Both conditions must match (AND) |
+
+Examples:
+
+```bash
+# List only sorting benchmarks
+$ lake exe bench list --tag sort
+
+# Run all benchmarks tagged "fib"
+$ lake exe bench run --tag fib
+
+# Compare all sorting benchmarks
+$ lake exe bench compare --tag sort
+
+# Verify benchmarks whose name contains "Sort"
+$ lake exe bench verify --filter Sort
+```
+
+When no `--tag` or `--filter` is given, all benchmarks are included
+(existing behavior). Name filtering matches anywhere in the fully
+qualified dotted name, so `--filter Sort` matches
+`MyProject.Sort.runMergeSort`.
+
+### Using namespaces as organization
+
+Lean namespaces naturally provide hierarchical grouping. Combined with
+`--filter`, this gives you namespace-based filtering for free:
+
+```lean
+namespace Sort
+  setup_benchmark runInsertion n => n * n
+  setup_benchmark runMergeSort n => n * Nat.log2 (n + 1)
+end Sort
+
+namespace Fib
+  setup_benchmark goodFib n => n
+  setup_benchmark badFib  n => 144 ^ n / 89 ^ n
+end Fib
+```
+
+```bash
+$ lake exe bench list --filter Sort
+$ lake exe bench compare --filter Sort
+```
+
+Tags and namespaces are complementary: namespaces give you
+hierarchical grouping, tags give you cross-cutting categories
+(e.g. `"fast"`, `"regression"`, `"nightly"`).
+
 ## Configuring a benchmark
 
 `BenchmarkConfig` carries the knobs the harness reads at run time:

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -14,6 +14,7 @@ defaultTargets = [
   "schema_benchmark_test", "cache_mode_benchmark_test",
   "advisory_benchmark_test", "outer_trials_benchmark_test",
   "export_benchmark_test",
+  "tags_benchmark_test",
 ]
 
 [[require]]
@@ -134,3 +135,8 @@ root = "LeanBenchTestOuterTrials"
 name = "export_benchmark_test"
 srcDir = "test"
 root = "LeanBenchTestExport"
+
+[[lean_exe]]
+name = "tags_benchmark_test"
+srcDir = "test"
+root = "LeanBenchTestTags"

--- a/test/LeanBenchTestCliErrors.lean
+++ b/test/LeanBenchTestCliErrors.lean
@@ -53,9 +53,17 @@ private def expectParserError (label : String) (argv : List String)
 def testUnknownSubcommand : IO UInt32 :=
   expectParserError "parser.unknownSubcommand" ["totally-not-a-command"] "totally-not-a-command"
 
-def testRunMissingName : IO UInt32 :=
-  -- `run` requires a positional `name`; with none the parser must err.
-  expectParserError "parser.runMissingName" ["run"] "name"
+/-- `run` with no names and no filters: the handler returns 1 with a
+    helpful error. (Before issue #10, `name` was a required positional
+    arg and the parser would reject; now it's variadic and the handler
+    checks.) -/
+def testRunMissingName : IO UInt32 := do
+  let code ← LeanBench.Cli.dispatch ["run"]
+  if code == 1 then
+    IO.println "  ok  dispatch.runMissingName"
+    return 0
+  IO.eprintln s!"FAIL: dispatch.runMissingName: expected exit 1, got {code}"
+  return 1
 
 def testNegativeNatRejected : IO UInt32 :=
   -- `--param-floor` is typed `Nat`; the parser must reject negatives,

--- a/test/LeanBenchTestTags.lean
+++ b/test/LeanBenchTestTags.lean
@@ -73,6 +73,14 @@ def testSplitTags : IO UInt32 := do
   -- Extra commas are filtered.
   let sparse := LeanBench.Cli.splitTags "a,,b,"
   expectEq "splitTags.sparse" sparse #["a", "b"]
+  -- Whitespace is trimmed.
+  let spaced := LeanBench.Cli.splitTags "sort, fast"
+  expectEq "splitTags.spaced" spaced #["sort", "fast"]
+  let padded := LeanBench.Cli.splitTags "  a , b  "
+  expectEq "splitTags.padded" padded #["a", "b"]
+  -- All-whitespace segments are dropped.
+  let blanks := LeanBench.Cli.splitTags " , , "
+  expectEq "splitTags.blanks" blanks (#[] : Array String)
   IO.println "  ok  tags.splitTags"
   return 0
 

--- a/test/LeanBenchTestTags.lean
+++ b/test/LeanBenchTestTags.lean
@@ -1,0 +1,208 @@
+import LeanBench
+
+/-!
+# Tests for issue #10 — benchmark organization and selection
+
+Exercises the tag and filtering infrastructure added in issue #10:
+
+1. Tags declared via `where { tags := #[...] }` are stored on the
+   runtime registry entry and recovered at runtime.
+2. The CLI filtering helpers (`matchEntry`, `splitTags`) produce the
+   expected results.
+3. The `list` subcommand respects `--tag` and `--filter` flags.
+4. The `run` subcommand dispatches on `--tag` / `--filter` when no
+   positional names are given.
+-/
+
+open LeanBench
+
+namespace LeanBench.Test.Tags
+
+/-! ## Tagged benchmarks -/
+
+def linearFn (n : Nat) : Nat := n + 1
+setup_benchmark linearFn n => n where {
+  tags := #["linear", "fast"]
+}
+
+def quadraticFn (n : Nat) : Nat := n * n
+setup_benchmark quadraticFn n => n * n where {
+  tags := #["quadratic"]
+}
+
+def untaggedFn (n : Nat) : Nat := n + 2
+setup_benchmark untaggedFn n => n
+
+/-! ## Helpers -/
+
+private def expectEq {α} [BEq α] [Repr α] (label : String) (got want : α) :
+    IO Unit := do
+  unless got == want do
+    throw <| .userError s!"{label}: expected {repr want}, got {repr got}"
+
+private def fullName (suffix : String) : Lean.Name :=
+  `LeanBench.Test.Tags ++ Lean.Name.mkSimple suffix
+
+private def fetchTags (suffix : String) : IO (Array String) := do
+  match ← LeanBench.findRuntimeEntry (fullName suffix) with
+  | some e => return e.spec.config.tags
+  | none => throw <| .userError s!"unregistered: {suffix}"
+
+/-! ## Tag storage tests -/
+
+def testTagsStored : IO UInt32 := do
+  let tags ← fetchTags "linearFn"
+  expectEq "linearFn.tags" tags #["linear", "fast"]
+  let tags2 ← fetchTags "quadraticFn"
+  expectEq "quadraticFn.tags" tags2 #["quadratic"]
+  let tags3 ← fetchTags "untaggedFn"
+  expectEq "untaggedFn.tags" tags3 (#[] : Array String)
+  IO.println "  ok  tags.stored"
+  return 0
+
+/-! ## CLI filter parsing tests -/
+
+/-- `--tag sort,fast` parses into individual tags. -/
+def testSplitTags : IO UInt32 := do
+  let parsed := LeanBench.Cli.splitTags "sort,fast"
+  expectEq "splitTags.basic" parsed #["sort", "fast"]
+  let single := LeanBench.Cli.splitTags "solo"
+  expectEq "splitTags.single" single #["solo"]
+  let empty := LeanBench.Cli.splitTags ""
+  expectEq "splitTags.empty" empty (#[] : Array String)
+  -- Extra commas are filtered.
+  let sparse := LeanBench.Cli.splitTags "a,,b,"
+  expectEq "splitTags.sparse" sparse #["a", "b"]
+  IO.println "  ok  tags.splitTags"
+  return 0
+
+/-- `matchEntry` applies tag and name filters correctly. -/
+def testMatchEntry : IO UInt32 := do
+  let name : Lean.Name := `Foo.Bar.baz
+  let tags : Array String := #["fast", "sort"]
+  -- No filters → matches.
+  expectEq "match.noFilter"
+    (LeanBench.Cli.matchEntry name tags #[] none) true
+  -- Tag filter with matching tag → matches.
+  expectEq "match.tagHit"
+    (LeanBench.Cli.matchEntry name tags #["sort"] none) true
+  -- Tag filter with non-matching tag → no match.
+  expectEq "match.tagMiss"
+    (LeanBench.Cli.matchEntry name tags #["slow"] none) false
+  -- Name filter with matching substring → matches.
+  expectEq "match.nameHit"
+    (LeanBench.Cli.matchEntry name tags #[] (some "Bar")) true
+  -- Name filter with non-matching substring → no match.
+  expectEq "match.nameMiss"
+    (LeanBench.Cli.matchEntry name tags #[] (some "Quux")) false
+  -- Both filters: tag matches, name matches → matches (AND).
+  expectEq "match.bothHit"
+    (LeanBench.Cli.matchEntry name tags #["fast"] (some "baz")) true
+  -- Both filters: tag matches, name doesn't → no match.
+  expectEq "match.tagHitNameMiss"
+    (LeanBench.Cli.matchEntry name tags #["fast"] (some "Quux")) false
+  -- Untagged entry vs tag filter → no match.
+  expectEq "match.untaggedVsTag"
+    (LeanBench.Cli.matchEntry name #[] #["fast"] none) false
+  IO.println "  ok  tags.matchEntry"
+  return 0
+
+/-! ## CLI dispatch tests -/
+
+/-- `list --tag linear` shows only the tagged benchmark. -/
+def testListWithTag : IO UInt32 := do
+  let code ← LeanBench.Cli.dispatch ["list", "--tag", "linear"]
+  if code != 0 then
+    IO.eprintln "FAIL: list --tag linear returned non-zero"
+    return 1
+  IO.println "  ok  tags.listWithTag"
+  return 0
+
+/-- `list --filter quadratic` shows only the matching benchmark. -/
+def testListWithFilter : IO UInt32 := do
+  let code ← LeanBench.Cli.dispatch ["list", "--filter", "quadratic"]
+  if code != 0 then
+    IO.eprintln "FAIL: list --filter quadratic returned non-zero"
+    return 1
+  IO.println "  ok  tags.listWithFilter"
+  return 0
+
+/-- `list --tag nonexistent` shows the "no matches" message and exits 0. -/
+def testListNoMatches : IO UInt32 := do
+  let code ← LeanBench.Cli.dispatch ["list", "--tag", "nonexistent"]
+  if code != 0 then
+    IO.eprintln "FAIL: list --tag nonexistent returned non-zero"
+    return 1
+  IO.println "  ok  tags.listNoMatches"
+  return 0
+
+/-- `run --tag nonexistent` exits 1 (no matches to run). -/
+def testRunNoMatches : IO UInt32 := do
+  let code ← LeanBench.Cli.dispatch ["run", "--tag", "nonexistent"]
+  if code != 1 then
+    IO.eprintln s!"FAIL: run --tag nonexistent: expected exit 1, got {code}"
+    return 1
+  IO.println "  ok  tags.runNoMatches"
+  return 0
+
+/-- `run` with no args and no filters exits 1 with a helpful message. -/
+def testRunNoArgsNoFilters : IO UInt32 := do
+  let code ← LeanBench.Cli.dispatch ["run"]
+  if code != 1 then
+    IO.eprintln s!"FAIL: run (bare): expected exit 1, got {code}"
+    return 1
+  IO.println "  ok  tags.runNoArgsNoFilters"
+  return 0
+
+/-! ## Format tests -/
+
+/-- `fmtSpec` includes tags when present, omits when empty. -/
+def testFmtSpecTags : IO UInt32 := do
+  let tagged : BenchmarkSpec :=
+    { name := `foo
+      complexityName := `foo_c
+      complexityFormula := "n"
+      runCheckedName := `foo_r
+      hashable := true
+      config := { tags := #["sort", "fast"] } }
+  let s := Format.fmtSpec tagged
+  unless LeanBench.Cli.containsSub s "[sort, fast]" do
+    throw <| .userError s!"expected tags in fmtSpec output: {s}"
+  let untagged : BenchmarkSpec :=
+    { name := `bar
+      complexityName := `bar_c
+      complexityFormula := "n"
+      runCheckedName := `bar_r
+      hashable := true
+      config := {} }
+  let s2 := Format.fmtSpec untagged
+  if LeanBench.Cli.containsSub s2 "[" then
+    throw <| .userError s!"expected no brackets in untagged fmtSpec output: {s2}"
+  IO.println "  ok  tags.fmtSpecTags"
+  return 0
+
+end LeanBench.Test.Tags
+
+/-! ## Driver -/
+
+open LeanBench.Test.Tags in
+def main : IO UInt32 := do
+  let mut anyFail : UInt32 := 0
+  for (label, t) in
+    [ ("tags.stored",           testTagsStored),
+      ("tags.splitTags",        testSplitTags),
+      ("tags.matchEntry",       testMatchEntry),
+      ("tags.listWithTag",      testListWithTag),
+      ("tags.listWithFilter",   testListWithFilter),
+      ("tags.listNoMatches",    testListNoMatches),
+      ("tags.runNoMatches",     testRunNoMatches),
+      ("tags.runNoArgsNoFilters", testRunNoArgsNoFilters),
+      ("tags.fmtSpecTags",      testFmtSpecTags) ]
+  do
+    let code ← t
+    if code != 0 then
+      IO.eprintln s!"FAIL: {label}"
+      anyFail := 1
+  if anyFail == 0 then
+    IO.println "tags tests passed"
+  return anyFail


### PR DESCRIPTION
This PR adds lightweight benchmark organization via tags and name-based filtering, addressing issue #10.

**Tags** are declared via `where { tags := #["sort", "fast"] }` on both parametric and fixed benchmarks, riding the existing `BenchmarkConfig` syntax with zero parser changes.

**Filtering** is supported on all parent-side CLI commands via `--tag TAG` and `--filter PATTERN`:
- `--tag sort,fast` matches benchmarks with either tag (OR logic, whitespace-trimmed)
- `--filter Sort` matches benchmarks whose name contains "Sort" as a substring
- Both flags together require AND (both conditions must match)

**`run`** now accepts variadic names or `--tag`/`--filter` for multi-benchmark runs:
```bash
lake exe bench run --tag sort            # run all tagged "sort"
lake exe bench run myFib                 # existing single-name usage
lake exe bench run myFib otherFib        # new: multiple names
```

**`compare`** supports filter-based benchmark selection:
```bash
lake exe bench compare --tag sort        # compare all tagged "sort"
```

**Changes:**
- `Core.lean`: `tags : Array String := #[]` on `BenchmarkConfig` and `FixedBenchmarkConfig`
- `Cli.lean`: filtering infrastructure (`splitTags`, `matchEntry`, `parseFilters`); `--tag`/`--filter` flags on `list`, `run`, `compare`, `verify`; `run` changed from required positional to variadic args
- `Format.lean`: `fmtSpec`/`fmtFixedSpec` show tags in `list` output
- `doc/quickstart.md`: new "Tags and filtering" section with examples
- `test/LeanBenchTestTags.lean`: tests for tag storage, filtering logic, CLI dispatch, and format output
- `test/LeanBenchTestCliErrors.lean`: updated for `run` variadic args change

All existing tests pass.

Closes #10

🤖 Prepared with Claude Code