### PR TITLE
feat: profile subcommand for external profilers (issue #13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,10 @@ jobs:
         shell: bash
         run: ./.lake/build/bin/auto_fit_benchmark_test
 
+      - name: profile-mode test (issue #13: external profiler hooks)
+        shell: bash
+        run: ./.lake/build/bin/profile_benchmark_test
+
       # End-to-end smoke tests: `list` exercises the registry +
       # `initialize` blocks; `verify` spawns each registered benchmark's
       # child path against `f 0` / `f 1` and is bounded by the spec's

--- a/LeanBench.lean
+++ b/LeanBench.lean
@@ -11,6 +11,7 @@ import LeanBench.Compare
 import LeanBench.Verify
 import LeanBench.Format
 import LeanBench.Export
+import LeanBench.Profile
 import LeanBench.Cli
 
 /-!

--- a/LeanBench/Cli.lean
+++ b/LeanBench/Cli.lean
@@ -8,6 +8,7 @@ import LeanBench.Compare
 import LeanBench.Verify
 import LeanBench.Format
 import LeanBench.Export
+import LeanBench.Profile
 
 /-!
 # `LeanBench.Cli` — argv dispatcher
@@ -23,6 +24,7 @@ runner). Subcommand layout:
 | `./bench run NAME [override flags]`                             | parent: run one or more benchmarks, print report |
 | `./bench compare A B C [override flags]`                        | parent: comparison report |
 | `./bench verify [NAMES…]`                                        | parent: bounded `f 0` / `f 1` sanity check via children |
+| `./bench profile NAME --profiler "STR" [--param N]`              | parent: re-spawn child wrapped under user's profiler (issue #13) |
 | `./bench _child --bench NAME --param N --target-nanos T`        | child: one inner-tuned batch, print one JSONL row, exit |
 
 `run` and `compare` accept run-time `BenchmarkConfig` overrides via
@@ -380,6 +382,33 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
   IO.eprintln "compare: cannot mix parametric and fixed benchmarks; or one or more names are unregistered"
   return 1
 
+/-- Dispatch `profile NAME --profiler "perf stat --"`: re-invokes
+    this same binary in `_child` mode at a single param, but with the
+    user's profiler command in front. See `LeanBench.Profile.runProfile`
+    for the full contract. -/
+def runProfileCmd (p : Cli.Parsed) : IO UInt32 := do
+  let nameStr := (p.positionalArg! "name").as! String
+  let name := nameStr.toName
+  let profilerCmd := (p.flag! "profiler").as! String
+  let param : Nat := (parsedFlag? p "param" Nat).getD 0
+  if (LeanBench.profileTokens profilerCmd).isEmpty then
+    IO.eprintln "profile: --profiler must be a non-empty command (e.g. \"perf stat --\")"
+    return 1
+  match ← findRuntimeEntry name with
+  | none =>
+    -- Fixed benchmarks aren't profiled through this entry point yet —
+    -- the param-less single-shot case is the easier one to add later.
+    -- For now, point the user at the parametric registry explicitly.
+    match ← findFixedRuntimeEntry name with
+    | some _ =>
+      IO.eprintln s!"profile: {name} is a fixed benchmark; profiling for fixed benchmarks is not yet supported (issue #13)"
+      return 1
+    | none =>
+      IO.eprintln s!"profile: unregistered benchmark: {name}"
+      return 1
+  | some _ =>
+    LeanBench.runProfile name param profilerCmd (configOverrideFromParsed p)
+
 def runVerifyCmd (p : Cli.Parsed) : IO UInt32 := do
   let nameStrs := p.variableArgsAs! String |>.toList
   let (tagFilter, nameFilter) := parseFilters p
@@ -531,6 +560,40 @@ explicit names are used."
     ...names : String;     "Two or more benchmark names (variadic). Or use --tag/--filter to select."
 ]
 
+def profileSub : Cmd := `[Cli|
+  profile VIA runProfileCmd; ["0.1.0"]
+  "Run a single benchmark invocation under an external profiler.
+
+The harness re-spawns itself in child mode at one param, but with the
+user-supplied --profiler command prefixed in front. The profiler's
+output (perf record's perf.data, perf stat's summary, samply's
+server URL, time -v's resource usage, …) lands directly on the user's
+terminal alongside the child's JSONL row.
+
+Single-shot by design: profile one param at a time. No ladder, no
+verdict, no kill-on-cap (profilers can be slow to flush their own
+output). The benchmark's declared cacheMode is honoured — pin
+`--cache-mode cold` for one-shot first-touch profiling, leave it at
+`warm` (default) so the autotuner exercises the function many times
+inside one profiler invocation. See doc/profiling.md for end-to-end
+workflows with perf, samply, heaptrack, and time -v.
+
+Linux-first: --profiler is opaque, so any tool the user has on PATH
+works, but the canned workflows in doc/profiling.md focus on perf
+and samply on Linux. macOS users have Instruments and dtrace; Windows
+users have ETW. The harness side is platform-neutral."
+
+  FLAGS:
+    profiler : String;               "Required. Profiler command prefix to wrap the child invocation (e.g. \"perf stat --\", \"perf record -F 99 -g --\", \"samply record --\", \"/usr/bin/time -v\"). Whitespace-split into argv tokens; no shell quoting."
+    param : Nat;                     "Param value to invoke the function with. Default 0."
+    "max-seconds-per-call" : Float;  "Override the declared per-batch cap (seconds). Note: there is no kill-on-cap in profile mode; this only flows through to the child's reporting."
+    "target-inner-nanos" : Nat;      "Override the auto-tuner target wall-time per batch (ns). In warm mode (default) this controls how many iterations run inside one profiler invocation."
+    "cache-mode" : LeanBench.CacheMode;  "warm (default — autotuned, many calls per profiler invocation) or cold (one untuned call per spawn)."
+
+  ARGS:
+    name : String;     "Benchmark name (as registered)."
+]
+
 def verifySub : Cmd := `[Cli|
   verify VIA runVerifyCmd; ["0.1.0"]
   "Sanity-check registered benchmarks (f 0, f 1 via the child path). Verifies all benchmarks if no names or filters are given. Exit code is non-zero on any failure."
@@ -553,6 +616,7 @@ def topCmd : Cmd := `[Cli|
     runSub;
     compareSub;
     verifySub;
+    profileSub;
     childSub
 ]
 

--- a/LeanBench/Profile.lean
+++ b/LeanBench/Profile.lean
@@ -1,0 +1,152 @@
+import Lean
+import LeanBench.Core
+import LeanBench.Run
+
+/-!
+# `LeanBench.Profile` — wrap a single child invocation under an external profiler
+
+The benchmark harness measures *that* something is slow. Profiling
+tells you *why*. This module is the minimum plumbing that lets a user
+run one ladder rung under any external profiler (`perf`, `samply`,
+`heaptrack`, `time -v`, `valgrind`, `dtrace`, …) without writing shell
+glue: the parent re-invokes itself in child mode, but with a
+user-supplied profiler-command prefix in front of the executable.
+
+Design choices, all driven by the issue #13 acceptance criteria:
+
+- **Profiler command is opaque.** We don't try to abstract perf vs
+  samply vs valgrind behind one interface — each tool's CLI is its
+  own dialect (`-o`, `-F`, `--call-graph`, `--`). The user passes the
+  full prefix as a single string; we whitespace-split it and exec.
+  This deliberately punts on shell quoting (paths with spaces won't
+  round-trip) — see the `profileTokens` docstring for the contract.
+
+- **No killer task.** Profilers can be slow to flush their own output
+  files (`perf record` writes `perf.data`, can take seconds on a big
+  recording). The wallclock cap that's right for benchmark mode
+  would mis-fire here.
+
+- **Single param, single child.** A full ladder produces N profile
+  artifacts that almost certainly collide on the same output filename
+  unless the user threaded `$param` through their command. Doing one
+  rung per `profile` invocation keeps the contract simple and matches
+  every profiler workflow the author has seen.
+
+- **stdout / stderr inherit.** The child still emits its single JSONL
+  row to stdout; the profiler writes its own report to stdout / stderr
+  / a side file. The user sees both. We don't try to capture and
+  parse — that's what `run` is for.
+
+- **No effect on `run` / `compare` / `verify`.** This module adds a
+  fresh entry point; nothing in the existing measurement path
+  changes. That's the third acceptance criterion ("does not distort
+  ordinary benchmark mode behavior") — by construction, since the
+  ordinary paths don't import this module's functions.
+-/
+
+namespace LeanBench
+
+/-- Whitespace-split the profiler command into argv tokens.
+
+    Contract: we split on ASCII spaces / tabs / newlines and drop
+    empty tokens. There is no shell-quoting layer — a path containing
+    a space won't round-trip. Users who need quoting can wrap their
+    profiler in a tiny script and pass the script's path here, or use
+    a profiler that takes a single positional path argument and put
+    that argument in a known location.
+
+    Examples:
+    - `"perf stat --"`           → `#["perf", "stat", "--"]`
+    - `"perf record -F 99 -g --"` → `#["perf", "record", "-F", "99", "-g", "--"]`
+    - `"  samply  record  --"`   → `#["samply", "record", "--"]`
+    - `""`                       → `#[]` (caller treats as "no profiler") -/
+def profileTokens (cmd : String) : Array String :=
+  cmd.splitOn " " |>.foldl (init := (#[] : Array String)) fun acc raw =>
+    -- Inner trim handles the tab / newline case (`cmd.split` only
+    -- splits on space; an embedded tab from a here-doc would survive
+    -- as part of a token and confuse the spawned profiler).
+    let tok := raw.trimAscii.toString
+    if tok.isEmpty then acc else acc.push tok
+
+/-- Build the argv that wraps the child invocation under the profiler.
+
+    Returns `(cmd, args)` ready for `IO.Process.spawn`. The first
+    token of the user-supplied profiler command becomes `cmd`; every
+    remaining token plus the harness's own `_child` argv becomes
+    `args`. When the profiler command is empty the function returns
+    `none` and the caller emits a user-facing error. -/
+def buildProfileArgv (profilerCmd : String) (exe : String)
+    (childArgs : Array String) : Option (String × Array String) :=
+  let toks := profileTokens profilerCmd
+  if h : 0 < toks.size then
+    let head := toks[0]
+    let rest := toks.extract 1 toks.size
+    some (head, rest ++ #[exe] ++ childArgs)
+  else
+    none
+
+/-- Construct the `_child` argv the profile path would invoke. Pulled
+    out of `runProfile` so the argv assembly is unit-testable without
+    actually spawning anything. Mirrors `Run.runOneBatch`'s argv with
+    one omission: no `--env-json`, because we don't want to thread a
+    huge JSON blob through `perf record`'s argv when the child can
+    capture it itself in ~3ms. The profile path is the one place
+    where re-capturing env in the child is cheaper than serializing
+    it through. -/
+def profileChildArgs (spec : BenchmarkSpec) (param : Nat) : Array String :=
+  #[ "_child"
+   , "--bench", spec.name.toString (escape := false)
+   , "--param", toString param
+   , "--target-nanos", toString spec.config.targetInnerNanos
+   , "--cache-mode", spec.config.cacheMode.toJsonString ]
+
+/-- Run a single child invocation wrapped in the user's profiler
+    command. Inherits stdout / stderr so the profiler's output and
+    the child's JSONL row both land on the user's terminal.
+
+    Returns the wrapped process's exit code. A non-zero exit may come
+    from either the profiler (`perf` returns the wrapped command's
+    code in most modes, but exits non-zero on its own permission /
+    setup failures) or the child; we don't try to disambiguate. The
+    caller surfaces the code as the parent process's exit code. -/
+def runProfile (name : Lean.Name) (param : Nat) (profilerCmd : String)
+    (override : ConfigOverride := {}) : IO UInt32 := do
+  let some entry ← findRuntimeEntry name
+    | throw (.userError s!"unregistered benchmark: {name}")
+  let cfg := override.apply entry.spec.config
+  match cfg.validate with
+  | .error msg => throw (.userError s!"{name}: {msg}")
+  | .ok () => pure ()
+  let spec := { entry.spec with config := cfg }
+  let exe ← ownExe
+  let childArgs := profileChildArgs spec param
+  match buildProfileArgv profilerCmd exe childArgs with
+  | none =>
+    -- The CLI handler guards against empty profilerCmd before reaching
+    -- here, so this branch is defensive only. Kept so direct callers
+    -- of `runProfile` (test fixtures, downstream tooling) get a clean
+    -- error instead of an empty-argv `IO.Process.spawn` panic.
+    throw (.userError "profile: --profiler must be a non-empty command (e.g. \"perf stat --\")")
+  | some (cmd, args) =>
+    -- Echo the wrapped command to stderr so the user sees exactly what
+    -- gets exec'd. Useful when the profiler is misconfigured ("perf:
+    -- not found") or when debugging what argv the harness actually
+    -- assembled.
+    let argLine := String.intercalate " " args.toList
+    IO.eprintln s!"lean-bench profile: {cmd} {argLine}"
+    let child ← IO.Process.spawn {
+      cmd := cmd
+      args := args
+      -- Inherit so the JSONL row lands on stdout next to whatever the
+      -- profiler prints. Some profilers (`perf record`) write to
+      -- stderr; some (`perf stat`) write a summary to stderr; some
+      -- (`samply`) write a server URL. Treating all of them as
+      -- opaque text streams means we don't need a per-tool adapter.
+      stdout := .inherit
+      stderr := .inherit
+      stdin  := .null
+    }
+    let exit ← child.wait
+    return exit
+
+end LeanBench

--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ name = "my_benchmarks"
 root = "MyBenchmarks"
 ```
 
-Then `lake exe my_benchmarks list / run NAME / compare A B / verify …`.
-See [doc/quickstart.md](doc/quickstart.md).
+Then `lake exe my_benchmarks list / run NAME / compare A B / verify /
+profile NAME --profiler "perf record -g --"`.
+See [doc/quickstart.md](doc/quickstart.md) and
+[doc/profiling.md](doc/profiling.md).
 
 ## Fixed-problem benchmarks
 
@@ -120,8 +122,10 @@ supports (Linux, macOS, Windows). See [PLAN.md](PLAN.md) for the
 v0.2+ roadmap, [doc/quickstart.md](doc/quickstart.md) for the
 user guide, [doc/pitfalls.md](doc/pitfalls.md) for Lean-specific
 benchmarking pitfalls (bignum `Nat`, forcing evaluation, sharing,
-warm vs. cold), and [doc/schema.md](doc/schema.md) for the JSONL
-result-row schema and its evolution rules.
+warm vs. cold), [doc/profiling.md](doc/profiling.md) for the
+external-profiler integration (`perf`, `samply`, `heaptrack`,
+`/usr/bin/time -v`), and [doc/schema.md](doc/schema.md) for the
+JSONL result-row schema and its evolution rules.
 
 ## Design
 

--- a/doc/profiling.md
+++ b/doc/profiling.md
@@ -1,0 +1,232 @@
+# Profiling
+
+Issue #13. Once `lake exe bench run` flags a regression, the next
+question is *why*. lean-bench gives you a way to run a single
+benchmark invocation under any external profiler — `perf`, `samply`,
+`heaptrack`, `/usr/bin/time -v`, `valgrind --tool=callgrind`, … —
+without writing shell glue.
+
+The mechanism is intentionally minimal: the `profile` subcommand
+re-invokes the benchmark binary in child mode at one parameter, but
+with your profiler command prefixed in front. The profiler sees a
+single short-lived child process that runs the registered function
+many times (under the default `cacheMode := .warm` autotuner) and
+then exits. Whatever output the profiler produces — flamegraphs,
+counters, allocation traces — lands directly on your terminal or in
+files at the location it chose.
+
+This page documents four end-to-end workflows. None of them require
+modifying your `setup_benchmark` declarations. All of them assume
+you already have a populated benchmark binary; if not, see
+[`quickstart.md`](quickstart.md) first.
+
+## How `profile` works
+
+```
+$ lake exe bench profile NAME --profiler "PROFILER ARGS --" [--param N]
+```
+
+The harness assembles the argv:
+
+```
+PROFILER ARGS -- /path/to/bench _child --bench NAME --param N
+                 --target-nanos T --cache-mode warm
+```
+
+…and `IO.Process.spawn`s the result with stdout / stderr inherited.
+Differences from `run`:
+
+- **Single param, no ladder.** The full doubling/linear sweep would
+  produce N profile artifacts that collide on the same output
+  filename. Pick the param you want to investigate (`--param 1024`)
+  and re-run for each one.
+- **No kill-on-cap.** Profilers can take seconds to flush their own
+  output (`perf record` writes `perf.data`; `samply` boots a server).
+  The wallclock cap that's right for benchmark mode would mis-fire.
+- **No verdict reduction.** The child still emits its single JSONL
+  row with the timing — useful for correlating profile artefacts
+  against an absolute wall time — but no aggregation happens.
+- **Profiler command is opaque.** The string you pass is
+  whitespace-split into argv tokens; there is no shell-quoting layer.
+  If your profiler invocation needs paths with spaces, wrap it in a
+  one-liner script and pass the script's path.
+
+The harness echoes the assembled command line to stderr before
+exec'ing so you can see exactly what was run.
+
+## Workflow 1 — `perf stat` (counters at a glance)
+
+`perf stat` is the right tool when you want to know "is this a CPU
+problem, a memory-bandwidth problem, or a branch-misprediction
+problem?" before reaching for a profile. It has no output file —
+results print to stderr at the end of the run.
+
+```bash
+$ lake exe bench profile myFib --param 4096 \
+    --profiler "perf stat -e cycles,instructions,cache-misses,branch-misses --"
+```
+
+Expected output:
+
+```
+lean-bench profile: perf stat -e cycles,instructions,... -- /path/to/bench _child ...
+{"schema_version":1,"kind":"parametric","function":"myFib","param":4096,...}
+
+ Performance counter stats for ' /path/to/bench _child ... ':
+
+   12,345,678,901      cycles
+   18,234,567,890      instructions             #    1.48  insn per cycle
+       12,345,678      cache-misses
+        2,345,678      branch-misses
+
+       0.512345678 seconds time elapsed
+```
+
+The benchmark's own JSONL row stays interleaved on stdout — the
+`per_call_nanos` field gives you the per-iteration wall time, and
+`inner_repeats` tells you how many calls the autotuner ran inside
+this single profiler invocation.
+
+## Workflow 2 — `perf record` + `perf report` / flamegraph
+
+For "where is the hot code?" use `perf record`. It writes a
+`perf.data` file in the current directory which `perf report` reads
+back interactively, or which Brendan Gregg's
+[FlameGraph](https://github.com/brendangregg/FlameGraph) tools
+convert to SVG.
+
+```bash
+$ lake exe bench profile myFib --param 4096 \
+    --profiler "perf record -F 999 -g --call-graph dwarf --"
+
+# inspect interactively:
+$ perf report
+
+# or render a flamegraph (assumes FlameGraph/ on PATH):
+$ perf script | stackcollapse-perf.pl | flamegraph.pl > myFib.svg
+```
+
+Notes:
+
+- `-F 999` samples at 999 Hz, slightly off the kernel's default 1000
+  Hz so samples don't lock-step with timer interrupts.
+- `--call-graph dwarf` is more reliable than the default `fp` for
+  Lean binaries because the Lean compiler doesn't always preserve
+  frame pointers at `-O3`.
+- `cacheMode := .warm` (the default) is what you want here: the
+  autotuner runs the function ~thousands of times inside one `perf
+  record` invocation, so the profile is dense.
+
+## Workflow 3 — `samply` (perf-equivalent, cross-platform)
+
+[`samply`](https://github.com/mstange/samply) is a perf-style
+sampling profiler that works on Linux and macOS, with a built-in
+Firefox-Profiler-compatible viewer. Useful when you don't want to
+deal with `perf`'s output file or you're on macOS.
+
+```bash
+$ cargo install samply  # one-time
+$ lake exe bench profile myFib --param 4096 \
+    --profiler "samply record --"
+```
+
+`samply record` boots a local server and prints a URL; open it in a
+browser for the interactive flamegraph view.
+
+On macOS, `samply` is the path of least resistance — Apple's
+Instruments works too, but its CLI integration is heavier.
+
+## Workflow 4 — `/usr/bin/time -v` (resource usage / RSS)
+
+Issue #13 mentions allocation profilers; the lightest-weight
+proxy on Linux is the GNU `time -v` flag, which reports peak
+resident-set size, page faults, voluntary / involuntary context
+switches, and several other kernel resource counters.
+
+```bash
+$ lake exe bench profile myFib --param 1048576 \
+    --profiler "/usr/bin/time -v"
+```
+
+Expected output (abridged):
+
+```
+        Maximum resident set size (kbytes): 184320
+        Major (requiring I/O) page faults: 0
+        Minor (reclaiming a frame) page faults: 12345
+        Voluntary context switches: 7
+        Involuntary context switches: 23
+```
+
+For deeper allocation inspection, `heaptrack` is the natural next
+step on Linux:
+
+```bash
+$ lake exe bench profile myFib --param 1024 \
+    --profiler "heaptrack --"
+$ heaptrack_gui heaptrack.bench.NNNN.gz
+```
+
+`heaptrack` produces one trace per spawn, named with the child PID,
+so multi-param sweeps don't collide.
+
+## Picking the right cache mode
+
+The benchmark's declared `cacheMode` flows through to the child:
+
+- **`cacheMode := .warm` (default)** — the autotuner picks an inner
+  repeat count and runs the function many times in one process.
+  This is what you want for `perf record` / `samply` (dense profile)
+  and for `perf stat` (steady-state counters).
+- **`cacheMode := .cold`** — the child runs the function exactly
+  once. This is what you want when you specifically care about
+  first-call costs: cache-cold paths, lazy initialization, JIT-style
+  patterns. The downside is that the profile is very thin —
+  consider `--cache-mode cold` plus a longer `perf record` run, or
+  use a different profiler altogether (e.g., `bpftrace` watching a
+  uprobe).
+
+Pin from the CLI per run:
+
+```bash
+$ lake exe bench profile myFib --param 1024 \
+    --cache-mode cold --profiler "perf record -F 999 -g --"
+```
+
+## What `profile` does not do
+
+- It does not run the verdict / advisory pipeline. If you want a
+  verdict-eligible measurement, use `run` and `compare`.
+- It does not parse the profiler's output. Whatever the tool prints
+  is what you see. This is the point: the harness gets out of the
+  way once it has spawned the wrapped child.
+- It does not aggregate across runs. A profile of one param at a
+  time is the contract; loop in your shell if you need many.
+- It is not a replacement for `verify`, `run`, or `compare`. It is
+  an *additional* entry point for the case where you've already
+  identified something worth investigating.
+
+## Platform notes
+
+- Linux is the canonical target. `perf` requires
+  `/proc/sys/kernel/perf_event_paranoid` ≤ 2 (the kernel default on
+  most distros) and is most useful with kernel symbols available.
+- macOS users should reach for `samply` first; Apple's Instruments
+  works (the CLI is `xcrun xctrace record`) but the UX is heavier
+  and the results aren't as portable.
+- Windows users have ETW via `xperf` / Windows Performance Recorder.
+  The `--profiler` flag is opaque, so any of these tools work — the
+  harness side does not care.
+
+## Acceptance criteria status
+
+- ✓ Users can invoke benchmarks in profiler-friendly mode without
+  custom shell glue: `lake exe bench profile NAME --profiler "..."`.
+- ✓ Documentation includes at least one end-to-end profiling
+  workflow: this page documents four (`perf stat`, `perf record`,
+  `samply`, `/usr/bin/time -v` + `heaptrack`).
+- ✓ The feature does not distort ordinary benchmark mode behavior:
+  `profile` is a separate subcommand that imports `LeanBench.Profile`;
+  nothing in `LeanBench.Run` / `LeanBench.Stats` / `LeanBench.Compare`
+  changed. `run` / `compare` / `verify` measurement paths are
+  byte-for-byte unchanged.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -16,6 +16,7 @@ defaultTargets = [
   "export_benchmark_test",
   "tags_benchmark_test",
   "auto_fit_benchmark_test",
+  "profile_benchmark_test",
 ]
 
 [[require]]
@@ -146,3 +147,8 @@ root = "LeanBenchTestTags"
 name = "auto_fit_benchmark_test"
 srcDir = "test"
 root = "LeanBenchTestAutoFit"
+
+[[lean_exe]]
+name = "profile_benchmark_test"
+srcDir = "test"
+root = "LeanBenchTestProfile"

--- a/test/LeanBenchTestProfile.lean
+++ b/test/LeanBenchTestProfile.lean
@@ -1,0 +1,196 @@
+import LeanBench
+
+/-!
+# Profile-mode tests (issue #13)
+
+The `profile` subcommand wraps a single child invocation under a
+user-supplied profiler command. Real profilers (`perf`, `samply`)
+aren't available cross-platform in CI, so we exercise the wrapper
+two ways:
+
+1. **Pure unit tests** on `profileTokens` and `buildProfileArgv` —
+   the argv assembly logic is the most regression-prone piece of the
+   feature and has no IO.
+2. **End-to-end smoke** via `/usr/bin/env`, which is present on every
+   POSIX host the CI matrix exercises (Linux, macOS) and acts as a
+   transparent stub: it just exec's its tail. Skipped on Windows,
+   where the CI runs the smoke suite from a different launcher and
+   `/usr/bin/env` doesn't exist anyway.
+
+The test deliberately doesn't touch `--cache-mode cold` or any
+flag that would change child timing semantics — that's not what
+this test is asserting on. The point is "the wrapper command line
+gets assembled, exec'd, and the child still emits its JSONL row,"
+nothing more.
+-/
+
+open LeanBench
+
+namespace LeanBench.Test.Profile
+
+/-- Same trivial benchmark shape as `LeanBenchTestE2E` so we don't
+    need a heavyweight registration to test the smoke path. -/
+def tinyFn (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 1
+  for _ in [0:n] do x := x ^^^ n.toUInt64
+  return x
+
+setup_benchmark tinyFn n => n where {
+  maxSecondsPerCall := 0.5, paramCeiling := 8, targetInnerNanos := 50_000_000
+  signalFloorMultiplier := 1.0
+}
+
+end LeanBench.Test.Profile
+
+private def tinyName : Lean.Name := `LeanBench.Test.Profile.tinyFn
+
+/-! ## Unit tests on the argv-assembly helpers -/
+
+/-- `profileTokens` whitespace-splits and drops empty tokens. -/
+def testTokensSplits : IO UInt32 := do
+  let cases : List (String × Array String) :=
+    [ ("perf stat --",            #["perf", "stat", "--"])
+    , ("perf record -F 99 -g --", #["perf", "record", "-F", "99", "-g", "--"])
+    , ("  samply  record  --  ",  #["samply", "record", "--"])
+    , ("",                        #[])
+    , ("   ",                     #[])
+    , ("env",                     #["env"]) ]
+  for (input, expected) in cases do
+    let got := LeanBench.profileTokens input
+    unless got == expected do
+      IO.eprintln s!"FAIL profileTokens({input.quote}): expected {expected}, got {got}"
+      return 1
+  IO.println "  ok  profileTokens.splits"
+  return 0
+
+/-- `buildProfileArgv` returns `none` on empty profiler, otherwise
+    `(head, restProfilerArgs ++ exe ++ childArgs)`. -/
+def testBuildArgv : IO UInt32 := do
+  let exe := "/path/to/exe"
+  let childArgs : Array String := #["_child", "--bench", "X"]
+  -- Empty profiler → none.
+  match LeanBench.buildProfileArgv "" exe childArgs with
+  | none => pure ()
+  | some (cmd, args) =>
+    IO.eprintln s!"FAIL: empty profiler should yield none; got cmd={cmd}, args={args}"
+    return 1
+  -- Single-token profiler → that token is cmd, exe + childArgs is args.
+  match LeanBench.buildProfileArgv "perf" exe childArgs with
+  | some (cmd, args) =>
+    unless cmd == "perf" do
+      IO.eprintln s!"FAIL: cmd should be 'perf'; got {cmd}"
+      return 1
+    unless args == #[exe] ++ childArgs do
+      IO.eprintln s!"FAIL: single-token args wrong; got {args}"
+      return 1
+  | none =>
+    IO.eprintln "FAIL: 'perf' should produce some argv"
+    return 1
+  -- Multi-token: profiler tokens past the first land before the exe.
+  match LeanBench.buildProfileArgv "perf record -F 99 --" exe childArgs with
+  | some (cmd, args) =>
+    let expected : Array String :=
+      #["record", "-F", "99", "--", exe] ++ childArgs
+    unless cmd == "perf" do
+      IO.eprintln s!"FAIL: cmd should be 'perf'; got {cmd}"
+      return 1
+    unless args == expected do
+      IO.eprintln s!"FAIL: multi-token args wrong; got {args}, expected {expected}"
+      return 1
+  | none =>
+    IO.eprintln "FAIL: multi-token should produce some argv"
+    return 1
+  IO.println "  ok  buildProfileArgv"
+  return 0
+
+/-- `profileChildArgs` produces the same `_child` argv shape that
+    `Run.runOneBatch` does (sans `--env-json`). Pin enough of it that
+    a regression in the shape — wrong flag name, wrong order — fails
+    here rather than at runtime when the child's CLI parser rejects. -/
+def testChildArgs : IO UInt32 := do
+  match ← findRuntimeEntry tinyName with
+  | none =>
+    IO.eprintln s!"FAIL: tiny benchmark not registered: {tinyName}"
+    return 1
+  | some entry =>
+    let argv := LeanBench.profileChildArgs entry.spec 5
+    -- Must start with `_child` so the parent's dispatcher routes to
+    -- child mode, then carry --bench / --param / --target-nanos /
+    -- --cache-mode.
+    unless argv[0]? == some "_child" do
+      IO.eprintln s!"FAIL: argv[0] should be '_child'; got {argv}"
+      return 1
+    unless argv.contains "--bench" ∧ argv.contains tinyName.toString do
+      IO.eprintln s!"FAIL: argv missing --bench {tinyName}; got {argv}"
+      return 1
+    unless argv.contains "--param" ∧ argv.contains "5" do
+      IO.eprintln s!"FAIL: argv missing --param 5; got {argv}"
+      return 1
+    unless argv.contains "--cache-mode" do
+      IO.eprintln s!"FAIL: argv missing --cache-mode; got {argv}"
+      return 1
+    IO.println "  ok  profileChildArgs"
+    return 0
+
+/-! ## End-to-end smoke via `/usr/bin/env` -/
+
+/-- Spawn this binary in `profile` mode wrapped under `/usr/bin/env`
+    (a transparent exec stub). Capture stdout, assert it contains the
+    child's JSONL row — that's the user-visible "the profiler
+    workflow worked" signal. Skipped on Windows; documented in the
+    file header.
+
+    Why `/usr/bin/env` and not `env`: hard-code the absolute path so
+    PATH peculiarities on `nix`-y CI hosts don't cause the spawn to
+    fail with "command not found." Both Ubuntu and macOS images
+    ship `/usr/bin/env`. -/
+def testProfileSmokeViaEnv : IO UInt32 := do
+  if System.Platform.isWindows then
+    IO.println "  skip profile.smoke (windows: no /usr/bin/env)"
+    return 0
+  let exe ← LeanBench.ownExe
+  let proc ← IO.Process.output {
+    cmd := exe
+    args := #[ "profile"
+             , tinyName.toString (escape := false)
+             , "--profiler", "/usr/bin/env"
+             , "--param", "4" ]
+    stdin := .null
+  }
+  -- The child writes one JSONL row to stdout — search for the
+  -- distinguishing field. Don't assert exact equality on the row
+  -- because timestamps / per-call values vary across hosts.
+  let needle := s!"\"function\":\"{tinyName.toString (escape := false)}\""
+  if (proc.stdout.splitOn needle).length > 1 then
+    IO.println "  ok  profile.smokeViaEnv"
+    return 0
+  IO.eprintln s!"FAIL: profile smoke: expected stdout to contain {needle}"
+  IO.eprintln s!"  exit code: {proc.exitCode}"
+  IO.eprintln s!"  stdout: {proc.stdout}"
+  IO.eprintln s!"  stderr: {proc.stderr}"
+  return 1
+
+/-! ## Driver -/
+
+def runTests : IO UInt32 := do
+  let mut anyFail : UInt32 := 0
+  for t in
+    [ testTokensSplits,
+      testBuildArgv,
+      testChildArgs,
+      testProfileSmokeViaEnv ]
+  do
+    let code ← t
+    if code != 0 then anyFail := 1
+  if anyFail == 0 then
+    IO.println "profile tests passed"
+  return anyFail
+
+/-- Mirror of `LeanBenchTestE2E.main`: same compiled binary acts as
+    parent (test driver) and child (single-batch runner spawned by
+    the profile path). The `_child` first arg distinguishes them. -/
+def main (args : List String) : IO UInt32 :=
+  match args with
+  | "_child" :: _ => LeanBench.Cli.dispatch args
+  | "profile" :: _ => LeanBench.Cli.dispatch args
+  | _ => runTests


### PR DESCRIPTION
Closes #13.

Adds `profile NAME --profiler "STR"` — a single-shot subcommand that
re-spawns the benchmark binary in `_child` mode at one parameter,
with the user's profiler command prefixed in front. The harness gets
out of the way once it has spawned the wrapped child: stdout/stderr
inherit so both the child's JSONL row and the profiler's output
land directly on the terminal.

## Design highlights

- **Single param, no ladder.** Profiling a full ladder produces N
  output files that collide on the same filename; pick a param and
  re-run for each.
- **No kill-on-cap.** Profilers can take seconds to flush their own
  data (`perf record` → `perf.data`); the wallclock cap that's right
  for benchmark mode would mis-fire.
- **Profiler command is opaque.** Whitespace-split into argv tokens,
  no shell quoting layer. Punts on paths-with-spaces in the same way
  every Unix CLI does — wrap in a script if needed.
- **Untouched measurement paths.** `LeanBench.Run`, `Stats`,
  `Compare`, `Verify` are byte-for-byte unchanged. The feature is
  purely additive.

## Files

- `LeanBench/Profile.lean` — `profileTokens`, `buildProfileArgv`,
  `profileChildArgs`, `runProfile`. argv assembly extracted into
  pure helpers so it can be unit-tested without spawning anything.
- `LeanBench/Cli.lean` — `runProfileCmd` handler, `profileSub`
  command tree node wired into `topCmd`.
- `doc/profiling.md` — four end-to-end workflows: `perf stat`,
  `perf record` + flamegraph, `samply record`, `/usr/bin/time -v`
  + `heaptrack`.
- `test/LeanBenchTestProfile.lean` — pure unit tests on the argv
  helpers + an end-to-end smoke test using `/usr/bin/env` as a
  transparent exec stub. Skipped on Windows.
- `lakefile.toml` — registers `profile_benchmark_test`.
- `.github/workflows/ci.yml` — runs the new test on every push.

## Acceptance criteria status

- ✓ Users can invoke benchmarks in profiler-friendly mode without
  custom shell glue.
- ✓ Documentation includes at least one end-to-end profiling
  workflow (four are documented).
- ✓ The feature does not distort ordinary benchmark mode behavior.

## Test plan

- [x] `lake build` clean across all 99 targets
- [x] `profile_benchmark_test` passes (4/4 cases on macOS)
- [x] All 13 existing tests pass unchanged
- [x] Manual smoke: `./fib_benchmark_example profile … --profiler "/usr/bin/env"` round-trips to a JSONL row
- [ ] CI green on Linux / macOS / Windows

🤖 Prepared with Claude Code