### PR TITLE
fix: schedule-aware advisory + warn on inert --param-floor/-ceiling for .custom (issue #46)

### DIFF
--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -157,29 +157,76 @@ private def rawRow (cMaybe : Option Float) (totalTrials : Nat) (dp : DataPoint) 
 private def customScheduleHint : String :=
   "use `where { paramSchedule := .custom #[...] }` to pin a tractable rung set"
 
+/-- Is the in-force schedule a declaration-pinned `.custom` array?
+The CLI cannot produce `.custom`, so seeing it in the merged config
+means the registration is dictating the rung set and `--param-floor` /
+`--param-ceiling` would be silently inert. The advisories below
+branch on this so suggestions point at the actual knob in force.
+Issue #46. -/
+private def isCustomSchedule (r : BenchmarkResult) : Bool :=
+  match r.config.paramSchedule with
+  | .custom _ => true
+  | _         => false
+
+/-- Suggestion phrasing for "the rungs need to reach larger params"
+under each schedule shape. `.custom` ignores `--param-ceiling`, so
+suggesting it would mislead — point at the declared array instead.
+Issue #46. -/
+private def raiseCeilingHint (r : BenchmarkResult) : String :=
+  if isCustomSchedule r then
+    "extend the declared `paramSchedule := .custom #[...]` array with larger params"
+  else
+    "raise `--param-ceiling`"
+
+/-- Suggestion phrasing for "the rungs need to stop short of large
+params". For `.custom` the user has to trim the declared array
+manually; `--param-ceiling` is inert. Issue #46. -/
+private def lowerCeilingHint (r : BenchmarkResult) : String :=
+  if isCustomSchedule r then
+    "trim the largest params from the declared `paramSchedule := .custom #[...]` array"
+  else
+    "lower `--param-ceiling`"
+
+/-- Suggestion phrasing for "skip the cold regime by starting from a
+larger param". Same `.custom` story — `--param-floor` is inert.
+Issue #46. -/
+private def raiseFloorHint (r : BenchmarkResult) : String :=
+  if isCustomSchedule r then
+    "drop the smallest params from the declared `paramSchedule := .custom #[...]` array"
+  else
+    "raise `--param-floor`"
+
+/-- The "or pin a custom array" tail only makes sense when the
+schedule isn't already `.custom`. Issue #46. -/
+private def orCustomScheduleTail (r : BenchmarkResult) : String :=
+  if isCustomSchedule r then "" else ", or " ++ customScheduleHint
+
 /-- Render one `Advisory` for a result as a single advisory line.
 Each message is structured as `‼ <symptom>; <suggestion>` so users
 see both why the harness is concerned and what knob to turn next.
-Issue #15. -/
+Issue #15. The suggestions are schedule-aware (issue #46): a `.custom`
+schedule pins the rungs at declaration time, so `--param-floor` /
+`--param-ceiling` are silently inert and the advisory points at the
+declared array instead. -/
 private def fmtAdvisory (r : BenchmarkResult) : Advisory → String
   | .belowSignalFloor =>
     let floorStr := match r.spawnFloorNanos? with
       | some n => s!" (per-spawn floor ≈ {fmtNanosStr n})"
       | none => ""
-    s!"  ‼ every measurement was below {fmtFloat3 r.config.signalFloorMultiplier}× the per-spawn floor{floorStr}; the function is too fast for child-process measurement at the configured params. Try `--param-ceiling` higher, wrap the function in a hot inner loop, or use `setup_fixed_benchmark` for a single-shot reading."
+    s!"  ‼ every measurement was below {fmtFloat3 r.config.signalFloorMultiplier}× the per-spawn floor{floorStr}; the function is too fast for child-process measurement at the configured params. Try the following: {raiseCeilingHint r}, wrap the function in a hot inner loop, or use `setup_fixed_benchmark` for a single-shot reading."
   | .partiallyBelowSignalFloor n total =>
-    s!"  ‼ {n}/{total} ok rows were below {fmtFloat3 r.config.signalFloorMultiplier}× the per-spawn floor; those rungs are excluded from the verdict. Raise `--param-floor` to skip the cold regime if the trimmed warmup isn't enough."
+    s!"  ‼ {n}/{total} ok rows were below {fmtFloat3 r.config.signalFloorMultiplier}× the per-spawn floor; those rungs are excluded from the verdict. {(raiseFloorHint r).capitalize} to skip the cold regime if the trimmed warmup isn't enough."
   | .allCapped =>
-    s!"  ‼ every measurement hit the wallclock cap (`maxSecondsPerCall = {fmtFloat3 r.config.maxSecondsPerCall}s`); no `ok` row landed. The benchmark is too slow at the configured params. Bump `--max-seconds-per-call`, lower `--param-ceiling`, or " ++ customScheduleHint ++ "."
+    s!"  ‼ every measurement hit the wallclock cap (`maxSecondsPerCall = {fmtFloat3 r.config.maxSecondsPerCall}s`); no `ok` row landed. The benchmark is too slow at the configured params. Bump `--max-seconds-per-call`, {lowerCeilingHint r}{orCustomScheduleTail r}."
   | .truncatedAtCap p =>
     -- Phrased order-agnostically: "later rungs were skipped" works
     -- for the doubling/linear ladders (ascending) and for `.custom`
     -- (whatever order the user listed). Codex flagged that
     -- "no rungs above this point" was misleading for sparse / non-
     -- monotone custom ladders.
-    s!"  ‼ ladder stopped at param={p} after hitting the wallclock cap (`maxSecondsPerCall = {fmtFloat3 r.config.maxSecondsPerCall}s`); subsequent rungs in the schedule were skipped. Raise the cap if you need to reach further, or " ++ customScheduleHint ++ "."
+    s!"  ‼ ladder stopped at param={p} after hitting the wallclock cap (`maxSecondsPerCall = {fmtFloat3 r.config.maxSecondsPerCall}s`); subsequent rungs in the schedule were skipped. Raise the cap if you need to reach further{orCustomScheduleTail r}."
   | .tooFewVerdictRows kept =>
-    s!"  ‼ only {kept} verdict-eligible row(s) survived warmup-trim + signal-floor filter; the verdict is below resolution. Lower `--warmup-fraction`, raise `--param-ceiling`, or " ++ customScheduleHint ++ "."
+    s!"  ‼ only {kept} verdict-eligible row(s) survived warmup-trim + signal-floor filter; the verdict is below resolution. Lower `--warmup-fraction`, {raiseCeilingHint r}{orCustomScheduleTail r}."
 
 /-- Render the per-param trial-summary block. One header line plus
 one data line per `TrialSummary`. Returns `#[]` when there is nothing

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -537,6 +537,26 @@ def measureSpawnFloor (env : Env) : IO (Option Nat) := do
   let t₁ ← IO.monoNanosNow
   return some (t₁ - t₀)
 
+/-- Issue #46: warn on stderr when CLI `--param-floor` /
+    `--param-ceiling` are passed but the merged schedule is still
+    `.custom`, in which case the override is silently inert. The
+    `.custom` arm of `runBenchmark` walks the declared array verbatim;
+    floor and ceiling only steer the doubling/linear ladder generators.
+    Stay quiet when the user also passed `--param-schedule
+    doubling|linear` (which switches the shape away from `.custom`,
+    making floor/ceiling actually apply). -/
+private def warnInertParamOverrides (name : Lean.Name)
+    (override : ConfigOverride) (cfg : BenchmarkConfig) : IO Unit := do
+  match cfg.paramSchedule with
+  | .custom _ =>
+    let mut inert : Array String := #[]
+    if override.paramFloor?.isSome   then inert := inert.push "--param-floor"
+    if override.paramCeiling?.isSome then inert := inert.push "--param-ceiling"
+    unless inert.isEmpty do
+      let flags := String.intercalate ", " inert.toList
+      IO.eprintln s!"note: {flags} ignored for {name}: effective `paramSchedule` is `.custom`, which walks the declared params verbatim; pass `--param-schedule doubling` (or `linear`) to switch the shape, or edit the `.custom` array."
+  | _ => pure ()
+
 /-- Run one benchmark end-to-end: resolve the schedule, run the
     doubling probe, optionally do a bracket-internal linear sweep,
     then summarise.
@@ -563,6 +583,7 @@ def runBenchmark (name : Lean.Name) (override : ConfigOverride := {})
   match cfg.validate with
   | .error msg => throw (.userError s!"{name}: {msg}")
   | .ok () => pure ()
+  warnInertParamOverrides name override cfg
   -- Capture reproducibility metadata at *parent* run start (issue
   -- #11). The same snapshot is propagated to every child via
   -- `--env-json`, so all JSONL rows in this run stamp the *same*

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -372,6 +372,15 @@ declared with `.linear 32` keeps the declared `32`, since the flag
 only carries the schedule kind. Switching from `.auto` / `.doubling`
 to `.linear` via the CLI uses the macro-default 16 samples.
 
+`--param-floor` / `--param-ceiling` only steer the doubling and
+linear ladder generators; a benchmark registered with
+`paramSchedule := .custom #[…]` walks the declared array verbatim,
+so those flags would be inert. The harness logs a `note:` to stderr
+when this happens so the override doesn't appear to have been
+honoured (issue #46). Either edit the declared `.custom` array, or
+pass `--param-schedule doubling` (or `linear`) to switch the shape —
+floor/ceiling apply once the schedule is no longer `.custom`.
+
 `--cache-mode warm|cold` selects what is being measured. The default
 `warm` is the v0.1 design: the child auto-tunes an inner-repeat count
 and runs the function many times in a single spawn, so caches and

--- a/test/LeanBenchTestAdvisory.lean
+++ b/test/LeanBenchTestAdvisory.lean
@@ -214,6 +214,47 @@ def testFmtResultAdvisoryLines : IO UInt32 := do
       return 1
   return 0
 
+/-- Issue #46: when the schedule is `.custom`, the advisory must NOT
+    suggest `--param-ceiling` / `--param-floor` (silently inert) and
+    SHOULD point at the declared array. -/
+def testFmtResultAdvisoryCustomSchedule : IO UInt32 := do
+  let customResult : BenchmarkResult :=
+    { function := `Sample.custom
+    , complexityFormula := "n"
+    , hashable := true
+    , config :=
+        { maxSecondsPerCall := 1.0
+          signalFloorMultiplier := 10.0
+          paramSchedule := .custom #[1024, 2048, 4096] }
+    , points := #[mkOk 2 1 1.0]
+    , ratios := #[]
+    , verdict := .inconclusive
+    , cMin? := none
+    , cMax? := none
+    , verdictDroppedLeading := 0
+    , slope? := none
+    , spawnFloorNanos? := some 100
+    , advisories := #[
+        .belowSignalFloor,
+        .partiallyBelowSignalFloor 1 4,
+        .allCapped,
+        .truncatedAtCap 16,
+        .tooFewVerdictRows 1 ] }
+  let rendered := Format.fmtResult customResult
+  -- The five advisory lines together must not mention the inert flags.
+  for forbidden in ["--param-ceiling", "--param-floor"] do
+    if containsSub rendered forbidden then
+      IO.eprintln s!"unexpected '{forbidden}' in `.custom` advisory:\n{rendered}"
+      return 1
+  -- Each schedule-aware suggestion lands.
+  for needle in ["extend the declared `paramSchedule := .custom",
+                 "trim the largest params from the declared",
+                 "Drop the smallest params from the declared"] do
+    unless containsSub rendered needle do
+      IO.eprintln s!"missing schedule-aware suggestion '{needle}' in:\n{rendered}"
+      return 1
+  return 0
+
 /-! ## `.custom` ladder semantics
 
 Pure config layer — drive `runBenchmark` with the `.custom` schedule
@@ -248,6 +289,46 @@ def testCustomLadder : IO UInt32 := do
   -- All-ok prefix — the params are tiny, nothing should hit the cap.
   -- The ladder is exactly the declared list.
   expectEq "custom.params" observed #[3, 5, 7, 11]
+  return 0
+
+/-- Capture stderr of `act` into a string, restoring the previous
+    stream afterward. -/
+private def captureStderr (act : IO α) : IO (String × α) := do
+  let bufRef ← IO.mkRef ({} : IO.FS.Stream.Buffer)
+  let prev ← IO.setStderr (IO.FS.Stream.ofBuffer bufRef)
+  try
+    let a ← act
+    let buf ← bufRef.get
+    let captured := String.fromUTF8! buf.data
+    return (captured, a)
+  finally
+    discard <| IO.setStderr prev
+
+/-- Issue #46: passing `--param-ceiling` (or `--param-floor`) when the
+    registration pins `paramSchedule := .custom` is silently inert,
+    so we surface a stderr `note:` so a CI run can't appear to have
+    honoured a knob it didn't. -/
+def testCustomInertOverrideWarning : IO UInt32 := do
+  let override : ConfigOverride :=
+    { paramCeiling? := some 1_000_000
+      paramFloor?   := some 1 }
+  let (stderrText, _) ← captureStderr (runBenchmark customName override)
+  for needle in ["--param-ceiling", "--param-floor", "`.custom`"] do
+    unless containsSub stderrText needle do
+      IO.eprintln s!"missing '{needle}' in stderr:\n{stderrText}"
+      return 1
+  return 0
+
+/-- Switching the schedule shape via `--param-schedule` makes the
+    floor/ceiling overrides effective, so no warning should fire. -/
+def testCustomShapeSwitchSilencesWarning : IO UInt32 := do
+  let override : ConfigOverride :=
+    { paramCeiling?   := some 16
+      paramSchedule?  := some .doubling }
+  let (stderrText, _) ← captureStderr (runBenchmark customName override)
+  if containsSub stderrText "ignored" then
+    IO.eprintln s!"unexpected inert-override note when shape switched:\n{stderrText}"
+    return 1
   return 0
 
 /-- An empty `.custom` ladder is rejected up front by config validation
@@ -305,7 +386,10 @@ def runTests : IO UInt32 := do
       ("advisory.ordinaryRunIsEmpty", testAdvisoryOrdinaryRunIsEmpty),
       ("fmtResult.belowFloorMark", testFmtResultBelowFloorMark),
       ("fmtResult.advisoryLines",  testFmtResultAdvisoryLines),
+      ("fmtResult.advisoryCustomSchedule", testFmtResultAdvisoryCustomSchedule),
       ("custom.ladder",            testCustomLadder),
+      ("custom.inertOverrideWarning", testCustomInertOverrideWarning),
+      ("custom.shapeSwitchSilencesWarning", testCustomShapeSwitchSilencesWarning),
       ("custom.emptyRejected",     testCustomEmptyRejected),
       ("custom.duplicateRejected", testCustomDuplicateRejected),
       ("signalFloorMultiplier.validated", testSignalFloorMultiplierValidated) ]


### PR DESCRIPTION
Fixes #46.

When a benchmark is registered with \`paramSchedule := .custom #[…]\`, the \`.custom\` arm of \`runBenchmark\` walks the declared array verbatim — only the doubling and linear ladder generators consult \`paramFloor\` / \`paramCeiling\`. Passing \`--param-floor\` / \`--param-ceiling\` on the CLI was silently inert, and the inconclusive-verdict advisory then suggested raising \`--param-ceiling\` (which doesn't move the rungs).

## Summary

- **\`Format.lean\`** — branch the advisory text on the merged \`paramSchedule\`. For \`.custom\` schedules, suggest editing the declared array (extend / trim / drop entries) instead of turning \`--param-ceiling\` / \`--param-floor\`. Doubling and linear schedules keep the existing wording.
- **\`Run.lean\`** — when \`runBenchmark\` sees an override carrying \`paramFloor?\` or \`paramCeiling?\` alongside an effective \`.custom\` schedule, log a one-line \`note:\` on stderr naming the inert flags and pointing at \`--param-schedule doubling|linear\` (which switches the shape) or the declared \`.custom\` array. Stays quiet when the user actually swapped the schedule shape.
- **Docs** — \`doc/quickstart.md\` mentions the \`.custom\` interaction with floor/ceiling.

## Test plan
- [x] \`advisory_benchmark_test\` covers the schedule-aware advisory text and the warning/no-warning split for \`.custom\` vs explicit shape switch
- [x] All 18 test exes still pass locally
- [x] Got a second opinion from Codex (no correctness findings)

🤖 Prepared with Claude Code