### PR TITLE
feat: exit code 2 on no verdict-eligible rows (issue #47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,15 @@ jobs:
       # invocation pins `--param-schedule doubling` so the new flag
       # is exercised end-to-end on every CI run, not just the
       # parser-level test.
+      #
+      # `--signal-floor-multiplier 1.0` disables the per-spawn floor
+      # filter for this smoke test (issue #47): on slow runners
+      # (Windows GHA in particular has a ~50ms spawn floor) the
+      # default 10× multiplier flags every rung at --param-ceiling
+      # 1024 as `[<floor]`, which now correctly produces exit 2 — but
+      # this step is testing the override-flag pipeline, not floor
+      # filtering. Disabling the filter keeps the smoke test honest
+      # about what it covers.
       - name: fib example run with CLI overrides
         shell: bash
         run: |
@@ -119,24 +128,26 @@ jobs:
             LeanBench.Examples.Fib.goodFib \
             --max-seconds-per-call 0.5 \
             --param-ceiling 1024 \
-            --slope-tolerance 0.5
+            --slope-tolerance 0.5 \
+            --signal-floor-multiplier 1.0
           ./.lake/build/bin/fib_benchmark_example run \
             LeanBench.Examples.Fib.goodFib \
             --max-seconds-per-call 0.5 \
             --param-ceiling 256 \
             --param-schedule doubling \
-            --slope-tolerance 0.5
+            --slope-tolerance 0.5 \
+            --signal-floor-multiplier 1.0
 
       # End-to-end smoke test for issue #8: --auto-fit must execute
       # against a real benchmark, exit cleanly, and append the
       # heuristic block. The unit-test exe (auto_fit_benchmark_test)
       # pins the ranking logic on synthetic data; this step just
-      # validates the flag plumbing across the spawn pipeline. We
-      # don't assert the winner row because CI runner spawn-floor
-      # noise (especially Windows / macOS) can drag enough rungs
-      # below the signal floor that no model lands a verdict-eligible
-      # rung — that's a measurement edge case, not a regression in
-      # the auto-fit code.
+      # validates the flag plumbing across the spawn pipeline.
+      #
+      # `--signal-floor-multiplier 1.0` disables the per-spawn floor
+      # filter (issue #47): on slow runners every rung would otherwise
+      # land below floor and the run would correctly exit 2. This
+      # step is testing --auto-fit plumbing, not floor handling.
       - name: fib example run with --auto-fit
         shell: bash
         run: |
@@ -145,6 +156,7 @@ jobs:
             --max-seconds-per-call 0.5 \
             --param-ceiling 1024 \
             --slope-tolerance 0.5 \
+            --signal-floor-multiplier 1.0 \
             --auto-fit)
           echo "$out"
           echo "$out" | grep -q "auto-fit (heuristic" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,10 @@ jobs:
         shell: bash
         run: ./.lake/build/bin/profile_benchmark_test
 
+      - name: no-usable-data exit-code test (issue #47)
+        shell: bash
+        run: ./.lake/build/bin/no_usable_data_benchmark_test
+
       # End-to-end smoke tests: `list` exercises the registry +
       # `initialize` blocks; `verify` spawns each registered benchmark's
       # child path against `f 0` / `f 1` and is bounded by the spec's

--- a/LeanBench/Cli.lean
+++ b/LeanBench/Cli.lean
@@ -246,8 +246,18 @@ def runListCmd (p : Cli.Parsed) : IO UInt32 := do
     IO.println (Format.fmtFixedSpec e.spec)
   return 0
 
+/-- Names of parametric benchmarks in `parametric` that produced no
+    verdict-eligible rows. Used to emit a single-line stderr summary
+    so CI logs surface the calibration failure without having to
+    parse the per-result advisories. Issue #47. -/
+private def noUsableDataNames (parametric : Array BenchmarkResult) :
+    Array Lean.Name :=
+  parametric.filterMap fun r => if r.noUsableData then some r.function else none
+
 /-- Shared post-run logic: baseline comparison + export. Returns
-the exit code (non-zero on regressions). Issue #3. -/
+the exit code: `exitNoUsableData` (2) if any parametric run produced
+zero verdict-eligible rows, else `1` on baseline regressions, else `0`.
+Issue #3, issue #47. -/
 private def handleBaselineAndExport
     (parametric : Array BenchmarkResult)
     (fixed : Array FixedResult)
@@ -280,6 +290,16 @@ private def handleBaselineAndExport
     IO.FS.writeFile ep (json.pretty ++ "\n")
     IO.println s!"exported to {ep}"
   | none => pure ()
+  -- Issue #47: a parametric run with zero verdict-eligible rows is a
+  -- hard calibration failure of the registration. Surface it via a
+  -- dedicated exit code (`exitNoUsableData = 2`) that supersedes the
+  -- baseline-regression code (`1`): if the harness has no data, the
+  -- regression check itself was meaningless.
+  let noData := noUsableDataNames parametric
+  unless noData.isEmpty do
+    let names := String.intercalate ", " (noData.toList.map toString)
+    IO.eprintln s!"run: {noData.size} benchmark(s) produced zero verdict-eligible rows: {names}"
+    exitCode := exitNoUsableData
   return exitCode
 
 /-- Dispatch `run` by explicit names and/or filters. When explicit
@@ -460,6 +480,13 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
       Export.exportToFile ep report.results #[] env?
       IO.println s!"exported to {ep}"
     | none => pure ()
+    -- Issue #47: propagate the no-usable-data exit code if any
+    -- constituent run produced zero verdict-eligible rows.
+    let noData := noUsableDataNames report.results
+    unless noData.isEmpty do
+      let names := String.intercalate ", " (noData.toList.map toString)
+      IO.eprintln s!"compare: {noData.size} benchmark(s) produced zero verdict-eligible rows: {names}"
+      return exitNoUsableData
     return 0
   if allFixed then
     let report ← LeanBench.compareFixed resolved

--- a/LeanBench/Cli.lean
+++ b/LeanBench/Cli.lean
@@ -112,7 +112,8 @@ def configOverrideFromParsed (p : Cli.Parsed) : ConfigOverride :=
     slopeTolerance?        := parsedFlag? p "slope-tolerance" Float
     paramSchedule?         := parsedFlag? p "param-schedule" LeanBench.ParamSchedule
     cacheMode?             := parsedFlag? p "cache-mode" LeanBench.CacheMode
-    outerTrials?           := parsedFlag? p "outer-trials" Nat }
+    outerTrials?           := parsedFlag? p "outer-trials" Nat
+    signalFloorMultiplier? := parsedFlag? p "signal-floor-multiplier" Float }
 
 /-- Build a `FixedConfigOverride` from override flags. Only fields
 that share a flag namespace with parametric (`max-seconds-per-call`)
@@ -623,6 +624,7 @@ Each missing flag leaves the declared value untouched."
     "param-schedule" : LeanBench.ParamSchedule;  "Parametric only: ladder shape (auto, doubling, or linear). Default auto picks doubling for polynomial growth, linear for exponential."
     "cache-mode" : LeanBench.CacheMode;           "Parametric only: warm (default) auto-tunes inner repeats inside one child; cold respawns per measurement so cache state is not preserved across rungs. See doc/advanced.md#cache-modes."
     "outer-trials" : Nat;            "Parametric only: number of independent outer trials per ladder rung (default 1). Bumping this above 1 runs N child spawns per param and reports per-param median / min / max / spread; trades runtime for stability. See doc/advanced.md#outer-trials."
+    "signal-floor-multiplier" : Float; "Parametric only: per-spawn signal-floor multiplier (default 10.0; ≥ 1.0). Rows whose totalNanos is below `multiplier × spawnFloor` are flagged `[<floor]` and excluded from the verdict. `1.0` disables the filter; useful in CI smoke tests on slow runners. Issue #47."
     "auto-fit";                      "Parametric only: after the verdict, fit a fixed catalog of complexity models (1, n, n*log n, n^2, n^3, 2^n) to the observed per-call timings and print a ranked suggestion. Heuristic, not a proof. See doc/quickstart.md#auto-fit."
     "repeats" : Nat;                 "Fixed only: number of measured invocations after the warmup call (default 5)."
     "export-file" : String;           "Write results to FILE in machine-readable JSON format (issue #3)."
@@ -673,6 +675,7 @@ explicit names are used."
     "param-schedule" : LeanBench.ParamSchedule;  "Parametric only: ladder shape (auto, doubling, or linear). Default auto picks doubling for polynomial growth, linear for exponential."
     "cache-mode" : LeanBench.CacheMode;           "Parametric only: warm (default) auto-tunes inner repeats inside one child; cold respawns per measurement so cache state is not preserved across rungs. See doc/advanced.md#cache-modes."
     "outer-trials" : Nat;            "Parametric only: number of independent outer trials per ladder rung (default 1). Bumping this above 1 runs N child spawns per param and reports per-param median / min / max / spread; trades runtime for stability. See doc/advanced.md#outer-trials."
+    "signal-floor-multiplier" : Float; "Parametric only: per-spawn signal-floor multiplier (default 10.0; ≥ 1.0). Rows whose totalNanos is below `multiplier × spawnFloor` are flagged `[<floor]` and excluded from the verdict. `1.0` disables the filter; useful in CI smoke tests on slow runners. Issue #47."
     "auto-fit";                      "Parametric only: after each per-function verdict, fit a fixed catalog of complexity models to the observed timings and print a ranked suggestion. Heuristic, not a proof. See doc/quickstart.md#auto-fit."
     "repeats" : Nat;                 "Fixed only: number of measured invocations after the warmup call (default 5)."
     "export-file" : String;           "Write results to FILE in machine-readable JSON format (issue #3)."

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -628,6 +628,33 @@ structure BenchmarkResult where
   budgetTruncated : Bool := false
   deriving Inhabited, Repr
 
+/-- The benchmark produced no verdict-eligible rows: every measurement
+    was below the per-spawn signal floor, every measurement hit the
+    wallclock cap, every measurement errored, or only param-0/1 rows
+    landed. The declared schedule + wallclock cap + inner-tuning budget
+    failed to produce any data the harness can use to compute a
+    verdict — a hard calibration failure of the registration, not a
+    soft "we tried our best." Issue #47.
+
+    `ratios` is built by `Stats.ratiosFromPoints`, which already filters
+    out non-`ok`, doubling-probe, below-floor, and `param < 2` rows, so
+    "no verdict-eligible rows" is exactly `ratios.isEmpty`.
+
+    Budget-truncated runs (`--total-seconds`, issue #9) are excluded:
+    those are user-requested early stops, not calibration bugs. The
+    budget summary already surfaces "completed/skipped/truncated"
+    counts on stdout and in the JSON export, which is the right
+    signal for that case. -/
+def BenchmarkResult.noUsableData (r : BenchmarkResult) : Bool :=
+  r.ratios.isEmpty && !r.budgetTruncated
+
+/-- Process exit code that signals "the parametric run produced no
+    verdict-eligible rows" — see `BenchmarkResult.noUsableData`. Chosen
+    distinct from `1` so scripts and CI can distinguish a calibration
+    bug (the harness has nothing to compare) from a baseline
+    regression (the harness compared and found a mismatch). Issue #47. -/
+def exitNoUsableData : UInt32 := 2
+
 /-- One diverging param in a `compare`: the param at which results
 disagreed, the full hash table of each compared function at that
 param (in CLI argument order, so reports can render an "all

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -372,6 +372,13 @@ structure ConfigOverride where
   /-- Override the number of outer trials per measured rung. CLI
       exposes this as `--outer-trials N`. Issue #4. -/
   outerTrials?           : Option Nat := none
+  /-- Override the per-spawn signal-floor multiplier. CLI exposes
+      this as `--signal-floor-multiplier`. `1.0` disables the filter
+      entirely (no rows are flagged `[<floor]`); higher values are
+      more aggressive about excluding cold rungs. Useful in CI smoke
+      tests on slow runners where the per-spawn floor would otherwise
+      swallow every rung at the chosen `--param-ceiling`. Issue #47. -/
+  signalFloorMultiplier? : Option Float := none
   deriving Inhabited, Repr
 
 /-- Merge a CLI `paramSchedule` override on top of a declared
@@ -405,7 +412,8 @@ def ConfigOverride.apply (o : ConfigOverride) (c : BenchmarkConfig) :
     killGraceMs           := o.killGraceMs?.getD           c.killGraceMs
     paramSchedule         := mergeParamSchedule o.paramSchedule? c.paramSchedule
     cacheMode             := o.cacheMode?.getD             c.cacheMode
-    outerTrials           := o.outerTrials?.getD           c.outerTrials }
+    outerTrials           := o.outerTrials?.getD           c.outerTrials
+    signalFloorMultiplier := o.signalFloorMultiplier?.getD c.signalFloorMultiplier }
 
 /-- Validate a `BenchmarkConfig`. The macro accepts arbitrary user
 expressions and the CLI accepts arbitrary JSON-style numbers, so

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -314,6 +314,22 @@ weren't covered this time.
 per-benchmark `--max-seconds-per-call` already bounds individual
 calls.
 
+### Exit codes
+
+`run` and `compare` use distinct non-zero codes so CI can react
+without parsing stdout:
+
+| code | meaning |
+|------|---------|
+| `0`  | success — the run completed and (with `--baseline`) no regressions were flagged |
+| `1`  | a regression vs. the baseline was flagged, or argument validation / dispatch errored |
+| `2`  | the parametric run produced **zero verdict-eligible rows** — every measurement was below the per-spawn signal floor, every measurement hit the wallclock cap, or every measurement errored. The schedule, the `maxSecondsPerCall` cap, or the inner-tuning budget did not produce timing data the harness can use. This is a calibration failure of the registration, not a soft "we tried our best." `compare` propagates the same code if at least one constituent is in this state. Runs cut short by `--total-seconds` are excluded — that's a user-requested early stop, surfaced by the budget summary instead. |
+
+Code `2` is the right signal to fail-loud on rather than swallow:
+the verdict text would otherwise read `inconclusive (cMin=—,
+cMax=—, β=—)` and look like a benign "couldn't decide", masking
+the underlying calibration bug.
+
 ## Configuring a benchmark
 
 `BenchmarkConfig` carries the knobs the harness reads at run time:

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -18,6 +18,7 @@ defaultTargets = [
   "auto_fit_benchmark_test",
   "profile_benchmark_test",
   "budget_benchmark_test",
+  "no_usable_data_benchmark_test",
 ]
 
 [[require]]
@@ -158,3 +159,8 @@ root = "LeanBenchTestProfile"
 name = "budget_benchmark_test"
 srcDir = "test"
 root = "LeanBenchTestBudget"
+
+[[lean_exe]]
+name = "no_usable_data_benchmark_test"
+srcDir = "test"
+root = "LeanBenchTestNoUsableData"

--- a/test/LeanBenchTestNoUsableData.lean
+++ b/test/LeanBenchTestNoUsableData.lean
@@ -1,0 +1,224 @@
+import LeanBench
+
+/-!
+# Issue #47: `run` exits non-zero on zero-verdict-eligible-rows runs
+
+The repro from the issue: a parametric `run` whose schedule lands every
+rung below the per-spawn signal floor still emits a "verdict:
+inconclusive" report and exits 0, masking a calibration bug. The fix is
+a dedicated exit code (`exitNoUsableData = 2`) that surfaces the
+condition to scripts and CI without parsing stdout.
+
+What's pinned:
+
+- Pure unit test: `BenchmarkResult.noUsableData` returns `true` exactly
+  when `ratios` is empty.
+- Pure unit test: a hand-built `BenchmarkResult` with
+  `belowSignalFloor` advisory and empty `ratios` is classified as
+  no-usable-data.
+- Integration test: `Cli.dispatch ["run", FAST_BENCH]` against a
+  benchmark whose `signalFloorMultiplier` is large enough to flag
+  every row exits `exitNoUsableData` (= 2).
+- Integration test: `Cli.dispatch ["compare", A, B]` propagates the
+  same exit code when at least one constituent has no usable data.
+- Negative control: a normal benchmark (`littleFnNormal`) exits 0 — so
+  the test isn't passing because every run trips the new code path.
+-/
+
+open LeanBench
+
+private def expectEq {α} [BEq α] [Repr α] (label : String) (got want : α) :
+    IO Unit := do
+  unless got == want do
+    throw <| .userError
+      s!"{label}: expected {repr want}, got {repr got}"
+
+namespace LeanBench.Test.NoUsableData
+
+/-! ## Pure unit tests on the `noUsableData` predicate -/
+
+private def mkResult (ratios : Array Ratio) (advisories : Array Advisory) :
+    BenchmarkResult :=
+  { function := `Sample.fast
+  , complexityFormula := "n"
+  , hashable := true
+  , config := {}
+  , points := #[]
+  , ratios
+  , verdict := .inconclusive
+  , cMin? := none
+  , cMax? := none
+  , verdictDroppedLeading := 0
+  , slope? := none
+  , spawnFloorNanos? := some 1
+  , advisories }
+
+def testPredicateEmptyRatios : IO UInt32 := do
+  let r := mkResult #[] #[.belowSignalFloor]
+  expectEq "noUsableData.allBelowFloor" r.noUsableData true
+  return 0
+
+def testPredicateAllCappedNoOk : IO UInt32 := do
+  let r := mkResult #[] #[.allCapped]
+  expectEq "noUsableData.allCapped" r.noUsableData true
+  return 0
+
+def testPredicateNonEmptyRatios : IO UInt32 := do
+  let r := mkResult #[(4, 25.0), (8, 25.0), (16, 25.0)] #[]
+  expectEq "noUsableData.healthy" r.noUsableData false
+  return 0
+
+def testPredicateOneRatioStillNoData : IO UInt32 := do
+  -- A run with a single below-resolution row but `ratios = #[]`
+  -- (warmup-trim + floor filter wiped everything out) is still
+  -- classified as no-usable-data. With a single surviving row in
+  -- `ratios`, however, the run produced *some* data — the slope fit
+  -- can't proceed, but issue #47 explicitly scopes the new exit code
+  -- to "zero verdict-eligible rows."
+  let r1 := mkResult #[] #[.tooFewVerdictRows 0]
+  expectEq "noUsableData.tooFew0" r1.noUsableData true
+  let r2 := mkResult #[(4, 25.0)] #[.tooFewVerdictRows 1]
+  expectEq "noUsableData.tooFew1" r2.noUsableData false
+  return 0
+
+def testPredicateAllErrored : IO UInt32 := do
+  -- The harness can hit "no usable data" via several disjoint paths:
+  -- below-floor, all-capped, all-errored. The predicate sees them
+  -- uniformly through `ratios.isEmpty`. Pin the all-errored case
+  -- explicitly so a future regression in advisory composition can't
+  -- silently break it.
+  let r := mkResult #[] #[]
+  expectEq "noUsableData.allErrored" r.noUsableData true
+  return 0
+
+def testPredicateBudgetTruncatedExcluded : IO UInt32 := do
+  -- Budget-truncated runs (`--total-seconds`, issue #9) are user-
+  -- requested early stops, not calibration bugs — the harness would
+  -- have produced data given more time. Don't surface them via the
+  -- new exit code; the budget summary is the right signal.
+  let r := { mkResult #[] #[.belowSignalFloor] with budgetTruncated := true }
+  expectEq "noUsableData.budgetTruncated" r.noUsableData false
+  return 0
+
+/-! ## Integration: `run` against a benchmark with no usable data -/
+
+/-- Trivial XOR loop — same shape as the e2e test's `littleFn`. -/
+def fastFn (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 1
+  for _ in [0:n] do
+    x := x ^^^ n.toUInt64
+  return x
+
+/-- Identical body — used to exercise the `compare` propagation path. -/
+def fastFnTwin (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 1
+  for _ in [0:n] do
+    x := x ^^^ n.toUInt64
+  return x
+
+-- `signalFloorMultiplier := 1.0e9` blows the per-spawn floor up so far
+-- above any real measurement that every row gets flagged
+-- `belowSignalFloor`, `ratios` ends up empty, and the run is classified
+-- `noUsableData`. The schedule is small / the cap is short so the test
+-- runs in ~1s on CI.
+setup_benchmark fastFn n => n where {
+  maxSecondsPerCall := 0.5
+  paramCeiling := 8
+  targetInnerNanos := 50_000_000
+  signalFloorMultiplier := 1.0e9
+}
+
+setup_benchmark fastFnTwin n => n where {
+  maxSecondsPerCall := 0.5
+  paramCeiling := 8
+  targetInnerNanos := 50_000_000
+  signalFloorMultiplier := 1.0e9
+}
+
+-- A second registration on the same `fastFn` body but with the floor
+-- filter disabled, so we can negative-control the exit-code change
+-- against an ordinary run.
+def normalFn (n : Nat) : UInt64 := Id.run do
+  let mut x : UInt64 := 1
+  for _ in [0:n] do
+    x := x ^^^ n.toUInt64
+  return x
+
+setup_benchmark normalFn n => n where {
+  maxSecondsPerCall := 0.5
+  paramCeiling := 8
+  targetInnerNanos := 50_000_000
+  signalFloorMultiplier := 1.0
+}
+
+private def fastName : String := "LeanBench.Test.NoUsableData.fastFn"
+private def fastTwinName : String := "LeanBench.Test.NoUsableData.fastFnTwin"
+private def normalName : String := "LeanBench.Test.NoUsableData.normalFn"
+
+/-- `run NAME` against a benchmark with every rung below floor returns
+    `exitNoUsableData` (= 2), distinguishing it from `0` (success) and
+    from `1` (baseline regression / handler error). -/
+def testRunBelowFloorExitsTwo : IO UInt32 := do
+  let code ← LeanBench.Cli.dispatch ["run", fastName]
+  if code == LeanBench.exitNoUsableData then
+    IO.println "  ok  run.belowFloor.exitsTwo"
+    return 0
+  IO.eprintln s!"FAIL: run.belowFloor.exitsTwo: expected exit {LeanBench.exitNoUsableData}, got {code}"
+  return 1
+
+/-- A normal benchmark (floor filter disabled) keeps exiting 0. -/
+def testRunNormalStillZero : IO UInt32 := do
+  let code ← LeanBench.Cli.dispatch ["run", normalName]
+  if code == 0 then
+    IO.println "  ok  run.normal.exitsZero"
+    return 0
+  IO.eprintln s!"FAIL: run.normal.exitsZero: expected exit 0, got {code}"
+  return 1
+
+/-- `compare` with at least one constituent in the no-usable-data
+    state propagates `exitNoUsableData`. -/
+def testCompareBelowFloorPropagates : IO UInt32 := do
+  let code ← LeanBench.Cli.dispatch ["compare", fastName, fastTwinName]
+  if code == LeanBench.exitNoUsableData then
+    IO.println "  ok  compare.belowFloor.exitsTwo"
+    return 0
+  IO.eprintln s!"FAIL: compare.belowFloor.exitsTwo: expected exit {LeanBench.exitNoUsableData}, got {code}"
+  return 1
+
+/-! ## Driver -/
+
+def runTests : IO UInt32 := do
+  let mut anyFail : UInt32 := 0
+  for (label, t) in
+    [ ("predicate.emptyRatios",      testPredicateEmptyRatios),
+      ("predicate.allCappedNoOk",    testPredicateAllCappedNoOk),
+      ("predicate.nonEmptyRatios",   testPredicateNonEmptyRatios),
+      ("predicate.oneRatioStillNoData", testPredicateOneRatioStillNoData),
+      ("predicate.allErrored",         testPredicateAllErrored),
+      ("predicate.budgetTruncatedExcluded", testPredicateBudgetTruncatedExcluded),
+      ("run.belowFloor.exitsTwo",    testRunBelowFloorExitsTwo),
+      ("run.normal.exitsZero",       testRunNormalStillZero),
+      ("compare.belowFloor.exitsTwo", testCompareBelowFloorPropagates) ]
+  do
+    let code ←
+      try t
+      catch e => do
+        IO.eprintln s!"FAIL: {label}: {e.toString}"
+        pure 1
+    if code != 0 then
+      IO.eprintln s!"FAIL: {label}"
+      anyFail := 1
+    else
+      IO.println s!"  ok  {label}"
+  if anyFail == 0 then
+    IO.println "no-usable-data exit-code tests passed"
+  return anyFail
+
+end LeanBench.Test.NoUsableData
+
+/-- Same compiled binary is parent and child; `_child` first arg
+    distinguishes them for the spawned ladder rungs. -/
+def main (args : List String) : IO UInt32 :=
+  match args with
+  | "_child" :: _ => LeanBench.Cli.dispatch args
+  | _ => LeanBench.Test.NoUsableData.runTests


### PR DESCRIPTION
## Summary

A parametric `run` whose every rung was filtered out by the warmup-trim or signal-floor filter still exited 0, masking a calibration bug behind a benign `verdict: inconclusive (cMin=—, cMax=—, β=—)` report. This PR adds a dedicated exit code (`2`) so scripts and CI can fail loudly without parsing stdout. Closes #47.

- New `BenchmarkResult.noUsableData : Bool := r.ratios.isEmpty && !r.budgetTruncated` and `exitNoUsableData : UInt32 := 2` in `LeanBench/Core.lean`. `ratios` is the canonical filtered set produced by `Stats.ratiosFromPoints` (already drops non-`ok`, doubling-probe, below-floor, and `param < 2` rows), so "zero verdict-eligible rows" is exactly `ratios.isEmpty`.
- `runRunCmd` (via `handleBaselineAndExport`) and `runCompareCmd` return `exitNoUsableData` when any parametric result is in this state, and emit a one-line stderr summary listing the offending benchmarks. This supersedes the baseline-regression code `1` — if the harness has no data, the regression check itself was meaningless.
- Budget-truncated runs (`--total-seconds`) are excluded: those are user-requested early stops, surfaced by the budget summary instead — not calibration bugs.
- New `LeanBenchTestNoUsableData.lean` test exe wired into `lakefile.toml` and the CI workflow. Pure unit tests on the predicate (incl. the budget-truncated and all-errored edge cases), plus integration tests using a `signalFloorMultiplier := 1.0e9` benchmark to force every row below floor and assert `Cli.dispatch ["run", NAME]` returns `2`. A negative control with the floor disabled still returns `0`. `compare` propagates the same code.
- Quickstart docs gain an exit-code table.

I asked Codex for a second opinion on the predicate choice (`ratios.isEmpty` vs. an advisory-based check); it agreed `ratios` is the better source of truth (advisories are presentation-oriented; `ratios` is the actual verdict input) and that the `2`-beats-`1` precedence is coherent.

## Test plan

- [x] `lake build` — all 120 targets build clean
- [x] `no_usable_data_benchmark_test` — new test exe passes (predicate unit tests + run/compare integration with both below-floor and clean negative-control cases)
- [x] `budget_benchmark_test` — still passes after the budget-truncated exclusion
- [x] `cli_errors_benchmark_test`, `e2e_benchmark_test`, `format_benchmark_test`, `export_benchmark_test`, `advisory_benchmark_test` — all unchanged behavior

🤖 Prepared with Claude Code