### PR TITLE
fix: reject bare-α targets in setup_fixed_benchmark (#54)

### DIFF
--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -619,6 +619,19 @@ def fmtFixedResult (r : FixedResult) (includeEnv : Bool := true) : String := Id.
     lines := lines.push s!"  expected hash: FAIL — expected {fmtHashHex expected}, but repeats disagreed (see hash line above); pin a deterministic benchmark first"
   for line in fmtFixedMemorySummary r.points do
     lines := lines.push line
+  -- Defense-in-depth (issue #54): sub-microsecond medians on a
+  -- fixed benchmark almost always mean the body was folded into a
+  -- compile-time constant — surface a clear advisory rather than
+  -- silently reporting the noise floor.
+  match r.medianNanos? with
+  | some med =>
+    if med < 1000 then
+      lines := lines.push <|
+        "  ‼ median wall time below 1µs — possibly a compile-time-folded constant \
+         rather than work. If the workload is genuinely tiny this is fine; otherwise \
+         thread inputs through runtime state (e.g. `IO.Ref`, disk) so the body isn't \
+         closed at compile time. See issue #54."
+  | none => pure ()
   return "\n".intercalate lines.toList
 
 /-- `0xDEADBEEF` rendering for an `Option UInt64`; `—` when absent

--- a/LeanBench/Setup.lean
+++ b/LeanBench/Setup.lean
@@ -282,45 +282,78 @@ setup_fixed_benchmark MyBench.lllReduce30 where {
 }
 ```
 
-The registered name must resolve to a value of type `α` (pure) or
-`IO α` (effectful). There is no parameter and no complexity model —
-the benchmark exists to record an absolute wall-clock time on a
-canonical input. The harness performs one warmup call followed by
-`config.repeats` measured calls and reports median / min / max plus
-a hash-agreement check across repeats.
+The registered name must resolve to a callable: `Unit → α`,
+`Unit → IO α`, or `IO α`. A bare value of type `α` is rejected at
+elaboration — the Lean compiler folds closed pure expressions into
+a compile-time constant, so the harness would measure a constant
+load instead of the intended work (issue #54). `IO α` is accepted
+but `pure <closedExpr>` bodies have the same problem; prefer the
+unit-parameter forms.
 
-If `α` has a `Hashable` instance, every measured call's result is
-hashed; cross-repeat agreement guards against non-determinism. The
-optional `expectedHash` field adds correctness on top: the first
-`ok` repeat's hash must equal the declared value, catching
-regressions that produce a different-but-stable hash (e.g. a `Bool`
+There is no parameter and no complexity model — the benchmark
+records an absolute wall-clock time on a canonical input. The
+harness does one warmup call, then `config.repeats` measured
+calls, and reports median / min / max plus cross-repeat hash
+agreement (when the result type is `Hashable`). The optional
+`expectedHash` field adds correctness on top: the first `ok`
+repeat's hash must equal the declared value, catching regressions
+that produce a different-but-stable hash (e.g. a `Bool`
 flipping). Without `Hashable`, neither check applies. -/
 
-/-- Inspect a registered name's type. Returns `(elementTy, isIO)`
-where `elementTy` is `α` for both `α` and `IO α` cases. The IO check
-is semantic, not syntactic: we try to unify the declared type against
-`IO ?α`, which means `EIO IO.Error α`, `BaseIO α` (after reducible
-unfolding), and any reducible alias of `IO` are all accepted. A bare
-syntactic `isAppOfArity ``IO 1` would miss those and silently
-benchmark the IO action as a pure value (a serious correctness bug),
-so we use full `isDefEq`.
+/-- Shape of a registered fixed-benchmark target.
+- `pureUnit` : `Unit → α`
+- `ioUnit`   : `Unit → IO α`
+- `io`       : `IO α` -/
+inductive FixedShape where
+  | pureUnit
+  | ioUnit
+  | io
+  deriving Inhabited, Repr, BEq
 
-Rejects anything with an unbound function arrow — fixed benchmarks
-are values, not functions. -/
+/-- Inspect a registered name's type. Returns `(elementTy, shape)`
+where `elementTy` is the element type `α`. Accepted shapes:
+`Unit → α`, `Unit → IO α`, `IO α`. Bare values and other function
+arrows are rejected (issue #54).
+
+The IO check uses `isDefEq` against `IO ?α` rather than syntactic
+head matching, so `EIO IO.Error α`, `BaseIO α`, and reducible
+aliases of `IO` are all accepted. -/
 def expectFixedValue (env : Environment) (declName : Name) :
-    CommandElabM (Expr × Bool) := do
+    CommandElabM (Expr × FixedShape) := do
   let some ci := env.find? declName
     | throwError "setup_fixed_benchmark: name `{declName}` is not defined"
   let ty := ci.type
-  if ty.isForall then
-    throwError "setup_fixed_benchmark: name `{declName}` must be a value or `IO α`; got function type `{ty}`"
+  -- Each shape probe runs against a saved state and restores it on
+  -- failure, so a partial unification from a failing probe can't
+  -- pre-bind metavariables used by the next one.
   liftTermElabM do
+    -- Probe 1: `Unit → β`, then check whether `β = IO γ`.
+    let s ← Meta.saveState
+    let β ← Meta.mkFreshExprMVar (mkSort Level.one)
+    let unitToβ := mkForall `_ .default (.const ``Unit []) β
+    if (← Meta.isDefEq ty unitToβ) then
+      let resTy ← instantiateMVars β
+      let γ ← Meta.mkFreshExprMVar (mkSort Level.one)
+      let ioγ ← Meta.mkAppM ``IO #[γ]
+      if (← Meta.isDefEq resTy ioγ) then
+        return ((← instantiateMVars γ), FixedShape.ioUnit)
+      return (resTy, FixedShape.pureUnit)
+    s.restore
+    -- Probe 2: `IO α`.
     let α ← Meta.mkFreshExprMVar (mkSort Level.one)
     let ioα ← Meta.mkAppM ``IO #[α]
     if (← Meta.isDefEq ty ioα) then
-      let elemTy ← instantiateMVars α
-      return (elemTy, true)
-    return (ty, false)
+      return ((← instantiateMVars α), FixedShape.io)
+    s.restore
+    -- Anything else is rejected. The error message names the three
+    -- accepted shapes and points at the compile-time-folding
+    -- footgun for pure values.
+    if ty.isForall then
+      throwError
+        "setup_fixed_benchmark: name `{declName}` has unsupported function type `{ty}`; \
+         the target must be `Unit → α`, `Unit → IO α`, or `IO α`"
+    throwError
+      m!"setup_fixed_benchmark: name `{declName}` has type `{ty}`, which is not a callable.\n\nBare-value registrations are rejected (issue #54): closed pure expressions get folded into a compile-time constant, so the harness would measure a ~100ns constant load rather than the intended work. Use one of:\n  • `Unit → α`     (recommended)\n  • `Unit → IO α`\n  • `IO α`         (caveat: `pure <closedExpr>` is also folded)"
 
 syntax (name := setupFixedBenchmark) "setup_fixed_benchmark "
   ident (setupBenchmarkWhere)? : command
@@ -340,7 +373,7 @@ where
     let env ← getEnv
     let ns ← getCurrNamespace
     let fnName := resolveDecl env ns fnId
-    let (resTy, isIO) ← expectFixedValue env fnName
+    let (resTy, shape) ← expectFixedValue env fnName
     let isHashable ← hasHashable resTy
     let configTerm? : Option Term ← match whereClause? with
       | none => pure none
@@ -351,42 +384,59 @@ where
     let cfgDeclName := fnName.str "_leanBench_fixedConfig"
     let rIdent := mkIdent rName
     let cfgIdent := mkIdent cfgDeclName
-    -- Four shapes from `(isIO, isHashable)`. All bracket the timer
-    -- around one invocation; the result is forced via `blackBox` to
-    -- defeat dead-code elimination, like the parametric path.
+    -- Six shapes from `(shape, isHashable)`. All bracket the timer
+    -- around one invocation and force the result via `blackBox` to
+    -- defeat DCE, like the parametric path.
     let mkRunner : CommandElabM (TSyntax `command) :=
-      match isIO, isHashable with
-      | true, true =>
+      match shape, isHashable with
+      | .pureUnit, true =>
         `(command|
           @[inline] def $rIdent : IO (Nat × Option UInt64) := do
             let t₀ ← IO.monoNanosNow
-            let r ← ($fnId : IO _)
+            let r := $fnId ()
             let h := Hashable.hash r
             LeanBench.blackBox h
             let t₁ ← IO.monoNanosNow
             return (t₁ - t₀, some h))
-      | true, false =>
+      | .pureUnit, false =>
         `(command|
           @[inline] def $rIdent : IO (Nat × Option UInt64) := do
             let t₀ ← IO.monoNanosNow
-            let r ← ($fnId : IO _)
+            let r := $fnId ()
             LeanBench.blackBox (Hashable.hash (sizeOf r))
             let t₁ ← IO.monoNanosNow
             return (t₁ - t₀, none))
-      | false, true =>
+      | .ioUnit, true =>
         `(command|
           @[inline] def $rIdent : IO (Nat × Option UInt64) := do
             let t₀ ← IO.monoNanosNow
-            let r := $fnId
+            let r ← (($fnId : Unit → IO _) ())
             let h := Hashable.hash r
             LeanBench.blackBox h
             let t₁ ← IO.monoNanosNow
             return (t₁ - t₀, some h))
-      | false, false =>
+      | .ioUnit, false =>
         `(command|
           @[inline] def $rIdent : IO (Nat × Option UInt64) := do
             let t₀ ← IO.monoNanosNow
-            let r := $fnId
+            let r ← (($fnId : Unit → IO _) ())
+            LeanBench.blackBox (Hashable.hash (sizeOf r))
+            let t₁ ← IO.monoNanosNow
+            return (t₁ - t₀, none))
+      | .io, true =>
+        `(command|
+          @[inline] def $rIdent : IO (Nat × Option UInt64) := do
+            let t₀ ← IO.monoNanosNow
+            let r ← ($fnId : IO _)
+            let h := Hashable.hash r
+            LeanBench.blackBox h
+            let t₁ ← IO.monoNanosNow
+            return (t₁ - t₀, some h))
+      | .io, false =>
+        `(command|
+          @[inline] def $rIdent : IO (Nat × Option UInt64) := do
+            let t₀ ← IO.monoNanosNow
+            let r ← ($fnId : IO _)
             LeanBench.blackBox (Hashable.hash (sizeOf r))
             let t₁ ← IO.monoNanosNow
             return (t₁ - t₀, none))

--- a/README.md
+++ b/README.md
@@ -105,9 +105,13 @@ takes ~1.2 s; the FLINT equivalent takes ~0.8 s" — there's a second
 registration form with no parameter sweep:
 
 ```lean
-def factorXOverFTwo : Polynomial Bool := …
+def factorXOverFTwo : Unit → Polynomial Bool := fun () => …
 setup_fixed_benchmark factorXOverFTwo
 ```
+
+(Bare `def : α` registrations are rejected — closed pure
+expressions get folded into compile-time constants. See issue #54
+and the [quickstart](doc/quickstart.md#fixed-problem-benchmarks).)
 
 The runner does one warmup call followed by `repeats` measured calls
 (default 5), reports median / min / max wall time, and hash-checks

--- a/doc/pitfalls.md
+++ b/doc/pitfalls.md
@@ -325,6 +325,14 @@ things to watch for:
   be slower than the rest. Reading the median rather than the mean
   defends against this naturally; raise `repeats` if min/max
   spread on your hardware is too wide for a 5-sample median.
+- **Closed pure expressions get folded into compile-time
+  constants.** Bare `def f : α := <expr>` registrations are
+  rejected at elaboration (issue #54); the macro requires a
+  callable shape (`Unit → α`, `Unit → IO α`, or `IO α`). Even
+  these can fold if the body is closed — the reliable mitigation
+  is to thread inputs through runtime state (`IO.Ref`, disk, CLI
+  argument). The report appends a `‼` advisory whenever the
+  median wall time is below 1 µs.
 
 ## Summary
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -614,13 +614,15 @@ either to compare against an external reference (FLINT, fpLLL, …) or
 to catch absolute-performance regressions over time. The
 `setup_fixed_benchmark` macro registers a benchmark of this shape.
 
-The function name *is* the benchmark name and must resolve to either
-`α` (a pure value) or `IO α` (an effectful computation, useful when
-the workload reads input from disk or shells out to an external
-tool):
+The function name *is* the benchmark name and must resolve to a
+*callable*:
+
+- `Unit → α`     — invoked as `f ()` once per measured repeat (recommended);
+- `Unit → IO α`  — invoked as `f ()` and then `←`-bound;
+- `IO α`         — `←`-bound directly (legacy; see caveat below).
 
 ```lean
-def factorXOverFTwo : Polynomial Bool := -- ... single hard problem
+def factorXOverFTwo : Unit → Polynomial Bool := fun () => -- ... single hard problem
 setup_fixed_benchmark factorXOverFTwo
 
 def runFplll : IO LLLOutput := -- ... shell out
@@ -629,6 +631,23 @@ setup_fixed_benchmark runFplll where {
   maxSecondsPerCall := 30.0
 }
 ```
+
+> **Why `Unit →` matters (issue #54).** A bare-`α` registration —
+> `def x : α := <closedExpr>` — gets folded by the Lean compiler
+> into a constant baked into the binary, so the harness would
+> measure a ~100–250 ns constant load instead of work. The macro
+> rejects that shape.
+>
+> `IO α` is accepted for compatibility, but `pure <closedExpr>`
+> bodies have the same problem; prefer `Unit → α` or
+> `Unit → IO α`. Even those are not bullet-proof — if the body
+> itself is closed (`fun () => goodFib 60`) the back-end can still
+> fold it. The reliable mitigation is to thread inputs through
+> runtime state (read from `IO.Ref`, disk, or a CLI argument).
+>
+> Defense-in-depth: when a fixed benchmark's median wall time is
+> below 1 µs, the report appends a `‼` advisory pointing at this
+> trap.
 
 There is no `Nat` parameter, no complexity expression, and no verdict.
 The runner does one warmup call, then `repeats` measured calls, and

--- a/examples/Fixed/LeanBenchExampleFixed.lean
+++ b/examples/Fixed/LeanBenchExampleFixed.lean
@@ -10,21 +10,19 @@ no parameter sweep, no complexity model, and no verdict — the goal
 is to record an absolute number to compare against external
 references or to catch absolute-performance regressions.
 
-- `tightFib60`  — `goodFib 60` as a pure value (returns `UInt64`).
-   Demonstrates the bare `setup_fixed_benchmark` form on a pure
-   computation.
-- `tightFibIO60` — same workload wrapped in `IO`. Demonstrates the
-   `setup_fixed_benchmark` form on an `IO α` value, useful when the
-   benchmarked workload reads input from disk or shells out to an
-   external tool.
+- `tightFib1M`   — `Unit → IO UInt64`, the recommended shape.
+- `tightFibIO1M` — `IO UInt64`, the legacy shape.
+
+Both read the iteration count from an `IO.Ref` so the back-end
+can't constant-fold the work away (issue #54).
 
 Run them with:
 
 ```
 lake exe fixed_benchmark_example list
-lake exe fixed_benchmark_example run LeanBench.Examples.Fixed.tightFib60
+lake exe fixed_benchmark_example run LeanBench.Examples.Fixed.tightFib1M
 lake exe fixed_benchmark_example compare \
-  LeanBench.Examples.Fixed.tightFib60 LeanBench.Examples.Fixed.tightFibIO60
+  LeanBench.Examples.Fixed.tightFib1M LeanBench.Examples.Fixed.tightFibIO1M
 ```
 -/
 
@@ -42,22 +40,26 @@ def goodFib (n : Nat) : UInt64 := Id.run do
     b := c
   return a
 
-/-- A pure fixed benchmark: compute `goodFib 60` once, return the
-    `UInt64` result. The benchmark name is the function name. -/
-def tightFib60 : UInt64 := goodFib 60
+/-- Iteration count read at runtime so the back-end can't fold
+    `goodFib n` to a constant (issue #54). -/
+initialize fibCountRef : IO.Ref Nat ← IO.mkRef 1_000_000
 
-/-- An `IO` fixed benchmark: same workload but inside `IO`. The
-    `setup_fixed_benchmark` macro detects the `IO α` head shape and
-    emits a runner that uses `←` to extract the value. -/
-def tightFibIO60 : IO UInt64 := return goodFib 60
+/-- Recommended shape: `Unit → IO α`. The `Unit` parameter forces
+    re-invocation each repeat; the `IO.Ref` read defeats folding. -/
+def tightFib1M : Unit → IO UInt64 := fun () => do
+  return goodFib (← fibCountRef.get)
 
-setup_fixed_benchmark tightFib60 where {
+/-- Legacy shape: bare `IO α`. Same workload as `tightFib1M`. -/
+def tightFibIO1M : IO UInt64 := do
+  return goodFib (← fibCountRef.get)
+
+setup_fixed_benchmark tightFib1M where {
   -- Pin the result hash so the run fails on a silent regression
   -- (issue #55). On the first run, copy the printed `observed hash:`
   -- value into the `where` clause.
-  expectedHash := some (Hashable.hash (goodFib 60))
+  expectedHash := some (Hashable.hash (goodFib 1_000_000))
 }
-setup_fixed_benchmark tightFibIO60 where {
+setup_fixed_benchmark tightFibIO1M where {
   -- Override declared defaults; the `repeats` knob has no parametric
   -- analogue, hence the dedicated fixed-only field on
   -- `FixedBenchmarkConfig`.

--- a/test/LeanBenchTestFixed.lean
+++ b/test/LeanBenchTestFixed.lean
@@ -28,9 +28,9 @@ parent / child path:
 
 namespace LeanBench.Test.Fixed
 
-/-- A trivial pure fixed benchmark. Uses a small computation so
-    test runtime is short. -/
-def cheapPure : UInt64 := Id.run do
+/-- A trivial fixed benchmark. The `Unit →` wrapper is required
+    by `setup_fixed_benchmark` (issue #54). -/
+def cheapPure : Unit → UInt64 := fun () => Id.run do
   let mut a : UInt64 := 0
   let mut b : UInt64 := 1
   for _ in [0:50] do
@@ -40,21 +40,24 @@ def cheapPure : UInt64 := Id.run do
   return a
 
 /-- Same workload, but exposed as an `IO` action. -/
-def cheapIO : IO UInt64 := return cheapPure
+def cheapIO : IO UInt64 := return cheapPure ()
 
 /-- Same workload, but exposed as an `EIO IO.Error` action — the
     fully-spelled-out form that `IO α` reduces to. The macro must
     detect this as IO via semantic isDefEq, not raw head-syntax. -/
-def cheapEIO : EIO IO.Error UInt64 := return cheapPure
+def cheapEIO : EIO IO.Error UInt64 := return cheapPure ()
 
 /-- Same workload, but exposed via a reducible alias of `IO`. The
     macro must reduce the alias before checking the IO shape. -/
 @[reducible] def MyIO (α : Type) : Type := IO α
-def cheapMyIO : MyIO UInt64 := return cheapPure
+def cheapMyIO : MyIO UInt64 := return cheapPure ()
+
+/-- `Unit → IO α` shape — the third accepted callable form. -/
+def cheapIOUnit : Unit → IO UInt64 := fun () => return cheapPure ()
 
 /-- Deliberately-slow workload for the kill-on-cap test. Loops long
     enough to exceed the 0-cap reliably. -/
-def slowPure : UInt64 := Id.run do
+def slowPure : Unit → UInt64 := fun () => Id.run do
   let mut x : UInt64 := 0
   for _ in [0:1_000_000] do
     for _ in [0:1000] do
@@ -63,34 +66,36 @@ def slowPure : UInt64 := Id.run do
 
 /-- Synonym for the correct-`expectedHash` test (issue #55); a second
     registration of `cheapPure` needs a distinct name. -/
-def cheapPureCorrect : UInt64 := cheapPure
+def cheapPureCorrect : Unit → UInt64 := cheapPure
 
 /-- Synonym for the wrong-`expectedHash` test (issue #55). -/
-def cheapPureRegressed : UInt64 := cheapPure
+def cheapPureRegressed : Unit → UInt64 := cheapPure
 
-setup_fixed_benchmark cheapPure where { repeats := 3 }
-setup_fixed_benchmark cheapIO   where { repeats := 3 }
-setup_fixed_benchmark cheapEIO  where { repeats := 2 }
-setup_fixed_benchmark cheapMyIO where { repeats := 2 }
-setup_fixed_benchmark slowPure  where { repeats := 1, maxSecondsPerCall := 5.0 }
+setup_fixed_benchmark cheapPure   where { repeats := 3 }
+setup_fixed_benchmark cheapIO     where { repeats := 3 }
+setup_fixed_benchmark cheapEIO    where { repeats := 2 }
+setup_fixed_benchmark cheapMyIO   where { repeats := 2 }
+setup_fixed_benchmark cheapIOUnit where { repeats := 2 }
+setup_fixed_benchmark slowPure    where { repeats := 1, maxSecondsPerCall := 5.0 }
 setup_fixed_benchmark cheapPureCorrect where {
   repeats := 2
-  expectedHash := some (Hashable.hash cheapPure) }
+  expectedHash := some (Hashable.hash (cheapPure ())) }
 setup_fixed_benchmark cheapPureRegressed where {
   repeats := 2
   -- Deliberately wrong: bit-flipped expected hash. The runner produces
-  -- `Hashable.hash cheapPure`, so the check must fail.
-  expectedHash := some ((Hashable.hash cheapPure) ^^^ 0xffffffffffffffff) }
+  -- `Hashable.hash (cheapPure ())`, so the check must fail.
+  expectedHash := some ((Hashable.hash (cheapPure ())) ^^^ 0xffffffffffffffff) }
 
 end LeanBench.Test.Fixed
 
 open LeanBench
 
-private def cheapPureName : Lean.Name := `LeanBench.Test.Fixed.cheapPure
-private def cheapIOName   : Lean.Name := `LeanBench.Test.Fixed.cheapIO
-private def cheapEIOName  : Lean.Name := `LeanBench.Test.Fixed.cheapEIO
-private def cheapMyIOName : Lean.Name := `LeanBench.Test.Fixed.cheapMyIO
-private def slowPureName  : Lean.Name := `LeanBench.Test.Fixed.slowPure
+private def cheapPureName          : Lean.Name := `LeanBench.Test.Fixed.cheapPure
+private def cheapIOName            : Lean.Name := `LeanBench.Test.Fixed.cheapIO
+private def cheapEIOName           : Lean.Name := `LeanBench.Test.Fixed.cheapEIO
+private def cheapMyIOName          : Lean.Name := `LeanBench.Test.Fixed.cheapMyIO
+private def cheapIOUnitName        : Lean.Name := `LeanBench.Test.Fixed.cheapIOUnit
+private def slowPureName           : Lean.Name := `LeanBench.Test.Fixed.slowPure
 private def cheapPureCorrectName   : Lean.Name :=
   `LeanBench.Test.Fixed.cheapPureCorrect
 private def cheapPureRegressedName : Lean.Name :=
@@ -161,7 +166,7 @@ def testIOPath : IO UInt32 := do
     with `Hashable` results — both impossible if the macro mis-routed
     these as pure values. -/
 def testIOAliasDetection : IO UInt32 := do
-  for name in [cheapEIOName, cheapMyIOName] do
+  for name in [cheapEIOName, cheapMyIOName, cheapIOUnitName] do
     let result ← runFixedBenchmark name
     unless result.points.all (·.status == .ok) do
       IO.eprintln s!"{name}: expected all ok, got {repr result.points}"
@@ -253,7 +258,7 @@ def testObservedHashSurfaced : IO UInt32 := do
   -- But the observed hash must be populated and match the canonical
   -- `Hashable.hash cheapPure` value (the runner is `let r := fnId; let
   -- h := Hashable.hash r`).
-  unless result.observedHash? == some (Hashable.hash LeanBench.Test.Fixed.cheapPure) do
+  unless result.observedHash? == some (Hashable.hash (LeanBench.Test.Fixed.cheapPure ())) do
     IO.eprintln s!"observedHash? mismatch: got {result.observedHash?}"
     return 1
   -- The expected-hash check should be `.unset` when nothing was
@@ -288,8 +293,8 @@ def testExpectedHashMatch : IO UInt32 := do
     formatter renders a FAIL line. Issue #55. -/
 def testExpectedHashMismatch : IO UInt32 := do
   let result ← runFixedBenchmark cheapPureRegressedName
-  let expected := (Hashable.hash LeanBench.Test.Fixed.cheapPure) ^^^ 0xffffffffffffffff
-  let got := Hashable.hash LeanBench.Test.Fixed.cheapPure
+  let expected := (Hashable.hash (LeanBench.Test.Fixed.cheapPure ())) ^^^ 0xffffffffffffffff
+  let got := Hashable.hash (LeanBench.Test.Fixed.cheapPure ())
   unless result.expectedHashCheck == .mismatch expected got do
     IO.eprintln s!"expected .mismatch {expected} {got}, got {repr result.expectedHashCheck}"
     return 1

--- a/test/LeanBenchTestFormat.lean
+++ b/test/LeanBenchTestFormat.lean
@@ -283,6 +283,36 @@ def testFmtFixedResult : IO UInt32 := do
     "  hash: all repeats agree"
   snapshot "fmtFixedResult" expected (Format.fmtFixedResult sampleFixedResult)
 
+/-- A sub-µs median should produce a `‼` advisory line warning that
+    the measurement may be a compile-time-folded constant (issue #54). -/
+def testFmtFixedResultSubMicroAdvisory : IO UInt32 := do
+  let fastPoints : Array FixedDataPoint := #[
+    { repeatIndex := 0, totalNanos := 100, resultHash := some 0xfeed, status := .ok },
+    { repeatIndex := 1, totalNanos := 200, resultHash := some 0xfeed, status := .ok },
+    { repeatIndex := 2, totalNanos := 150, resultHash := some 0xfeed, status := .ok }]
+  let fastResult : FixedResult :=
+    { sampleFixedResult with
+      points := fastPoints
+      medianNanos? := some 150
+      minNanos? := some 100
+      maxNanos? := some 200 }
+  let rendered := Format.fmtFixedResult fastResult
+  unless (rendered.splitOn "below 1µs").length > 1 do
+    IO.eprintln s!"fmtFixedResult.subMicroAdvisory: missing advisory line\n{rendered}"
+    return 1
+  IO.println "  ok  fmtFixedResult.subMicroAdvisory"
+  return 0
+
+/-- A normal-µs median should NOT produce the advisory line. The
+    `sampleFixedResult` fixture's median is 1.050 ms. -/
+def testFmtFixedResultNoAdvisoryAboveThreshold : IO UInt32 := do
+  let rendered := Format.fmtFixedResult sampleFixedResult
+  if (rendered.splitOn "below 1µs").length > 1 then
+    IO.eprintln s!"fmtFixedResult.noAdvisory: unexpected advisory at 1.050 ms median\n{rendered}"
+    return 1
+  IO.println "  ok  fmtFixedResult.noAdvisoryAboveThreshold"
+  return 0
+
 def testFmtFixedComparison : IO UInt32 := do
   let expected :=
     "Sample.cheap    [fixed] repeats=3\n" ++
@@ -440,6 +470,8 @@ def main : IO UInt32 := do
       ("fmtComparison.multi", testFmtComparisonMulti),
       ("fmtComparison.hashUnavailable", testFmtComparisonHashUnavailable),
       ("fmtFixedResult", testFmtFixedResult),
+      ("fmtFixedResult.subMicroAdvisory", testFmtFixedResultSubMicroAdvisory),
+      ("fmtFixedResult.noAdvisoryAboveThreshold", testFmtFixedResultNoAdvisoryAboveThreshold),
       ("fmtFixedComparison", testFmtFixedComparison),
       ("fmtVerifyReport.pass", testFmtVerifyPass),
       ("fmtVerifyReport.fail", testFmtVerifyFail),

--- a/test/LeanBenchTestSchema.lean
+++ b/test/LeanBenchTestSchema.lean
@@ -34,8 +34,8 @@ setup_benchmark schemaProbe n => n + 1 where {
 }
 
 /-- A fixed-benchmark counterpart so the fixed-emit path is exercised
-    by `verify`. -/
-def schemaFixedProbe : UInt64 := 7
+    by `verify`. Wrapped in `Unit →` per issue #54. -/
+def schemaFixedProbe : Unit → UInt64 := fun () => 7
 
 setup_fixed_benchmark schemaFixedProbe where { repeats := 1, warmup := false }
 

--- a/test/LeanBenchTestSetupErrors.lean
+++ b/test/LeanBenchTestSetupErrors.lean
@@ -73,4 +73,36 @@ Hint: Type class instance resolution failures can be inspected with the `set_opt
 #guard_msgs in
 setup_benchmark whereBad n => n where 42
 
+-- Test 7: `setup_fixed_benchmark` rejects a bare pure value (issue #54).
+-- The Lean compiler folds closed pure expressions into a compile-time
+-- constant, so registering `def x : UInt64 := <expr>` would silently
+-- measure a constant load rather than the intended work.
+def fixedBarePure : UInt64 := 42
+
+/--
+error: setup_fixed_benchmark: name `LeanBench.Test.SetupErrors.fixedBarePure` has type `UInt64`, which is not a callable.
+
+Bare-value registrations are rejected (issue #54): closed pure expressions get folded into a compile-time constant, so the harness would measure a ~100ns constant load rather than the intended work. Use one of:
+  • `Unit → α`     (recommended)
+  • `Unit → IO α`
+  • `IO α`         (caveat: `pure <closedExpr>` is also folded)
+-/
+#guard_msgs in
+setup_fixed_benchmark fixedBarePure
+
+-- Test 8: `setup_fixed_benchmark` rejects a function that doesn't take Unit.
+def fixedNatToNat (n : Nat) : Nat := n + 1
+
+/--
+error: setup_fixed_benchmark: name `LeanBench.Test.SetupErrors.fixedNatToNat` has unsupported function type `Nat →
+  Nat`; the target must be `Unit → α`, `Unit → IO α`, or `IO α`
+-/
+#guard_msgs in
+setup_fixed_benchmark fixedNatToNat
+
+-- Test 9: `setup_fixed_benchmark` accepts the recommended `Unit → α` shape.
+-- (No expected error.)
+def fixedUnitOk : Unit → UInt64 := fun () => 7
+setup_fixed_benchmark fixedUnitOk
+
 end LeanBench.Test.SetupErrors


### PR DESCRIPTION
This PR rejects bare-value (\`def f : α := <expr>\`) registrations in \`setup_fixed_benchmark\` and adds a runtime advisory for sub-microsecond fixed benchmarks. Closed pure expressions get folded into a compile-time constant by the Lean back-end, so the harness used to measure a ~100 ns constant load rather than the intended computation. Closes #54.

The macro now accepts only callable shapes: \`Unit → α\`, \`Unit → IO α\`, or \`IO α\`. The bare-value path produces a clear elaboration error pointing at the alternatives. As defense-in-depth — \`IO α\` bodies of the form \`pure <closedExpr>\` are still vulnerable to the same fold — \`fmtFixedResult\` appends a \`‼\` line whenever the median wall time is below 1 µs, suggesting the user thread inputs through runtime state (\`IO.Ref\`, disk, CLI argument) so the body isn't closed at compile time.

The example fixed benchmark in \`examples/Fixed\` is rewritten to read the iteration count from an \`IO.Ref\`, which is the reliable mitigation; \`tightFib1M\` now records ~8 ms per repeat instead of ~150 ns.

A second-opinion review (Codex) flagged the \`Meta.isDefEq\` probes as needing explicit save/restore so a partial unification can't pre-bind metavariables for the next probe; that's now done. It also asked for explicit format-regression tests for the advisory line at the threshold; \`fmtFixedResult.subMicroAdvisory\` and \`fmtFixedResult.noAdvisoryAboveThreshold\` cover both directions.

🤖 Prepared with Claude Code