### PR TITLE
feat: auto-tune inner repeats for fixed benchmarks (issue #58)

### DIFF
--- a/LeanBench/Child.lean
+++ b/LeanBench/Child.lean
@@ -241,10 +241,11 @@ isolation machinery applies unchanged. -/
 
 /-- Render one fixed-benchmark JSONL row. The schema overlaps the
     parametric row but adds `kind:"fixed"` and a `repeat_index`
-    field; `param` / `inner_repeats` are absent because they're
-    meaningless for a fixed benchmark. -/
+    field; `param` is absent (no parameter sweep). `inner_repeats`
+    is the auto-tuned count chosen inside this child (issue #58),
+    `0` on synthesized error rows. -/
 def emitFixedRow
-    (function : Lean.Name) (repeatIndex totalNanos : Nat)
+    (function : Lean.Name) (repeatIndex innerRepeats totalNanos : Nat)
     (resultHash : Option UInt64) (status : Status) (env : Env)
     (mem : MemStats := {})
     (errorMsg? : Option String := none) :
@@ -255,6 +256,7 @@ def emitFixedRow
       s!"\"kind\":{jsonStr Schema.kindFixed}",
       s!"\"function\":{jsonStr function.toString}",
       s!"\"repeat_index\":{repeatIndex}",
+      s!"\"inner_repeats\":{innerRepeats}",
       s!"\"total_nanos\":{totalNanos}",
       s!"\"result_hash\":{jsonOptHash resultHash}",
       s!"\"status\":{jsonStr status.toJsonString}",
@@ -265,30 +267,65 @@ def emitFixedRow
     ] ++ "}"
   IO.println row
 
+/-- Auto-tuner for fixed benchmarks (issue #58). Mirrors the parametric
+    `autoTune` in spirit but with a simpler control flow: there's no
+    "halve target" trick — we just want total wall time at or above
+    `minTotalNanos` so the measurement clears the clock-noise floor.
+
+    Strategy: probe with `count := 1`, then double until the batch's
+    wall time crosses the floor. Each probe re-runs the body from
+    scratch, so the per-iteration time stays a clean `total / count`
+    on the final batch. The `expectedHash` semantics from issue #55
+    apply to the *first iteration*'s hash, which the runner returns
+    on every batch — and which is by construction the same value
+    across batches for any deterministic benchmark.
+
+    `minTotalNanos == 0` short-circuits to a single invocation, which
+    matches pre-#58 behaviour for callers that want to opt out. The
+    parent's `maxSecondsPerCall` cap is the hard ceiling: when the
+    body is genuinely fast and the floor isn't reachable inside the
+    cap, the parent kills the child and reports `killedAtCap`. -/
+partial def autoTuneFixed
+    (loop : Nat → IO (Nat × Option UInt64))
+    (minTotalNanos : Nat) :
+    IO (Nat × Nat × Option UInt64) := do
+  let mut count : Nat := 1
+  let (t₀, h₀) ← loop count
+  if minTotalNanos == 0 || t₀ ≥ minTotalNanos then
+    return (count, t₀, h₀)
+  let mut total : Nat := t₀
+  let mut hash : Option UInt64 := h₀
+  while total < minTotalNanos do
+    count := count * 2
+    let (t', h') ← loop count
+    total := t'
+    hash := h'
+  return (count, total, hash)
+
 /-- Top-level entry point for fixed-benchmark child runs. Looks the
-    name up in the fixed runtime registry, performs one timed
-    invocation, emits one JSONL row, exits 0 on success or 1 on
-    error. -/
+    name up in the fixed runtime registry, runs the auto-tuner with
+    the parent-supplied `minTotalNanos` floor, emits one JSONL row,
+    exits 0 on success or 1 on error. Issue #58. -/
 def runFixedChildMode (benchName : Lean.Name) (repeatIndex : Nat)
-    (env? : Option Env := none) : IO UInt32 := do
+    (minTotalNanos : Nat) (env? : Option Env := none) : IO UInt32 := do
   let env ← match env? with
     | some env => pure env
     | none     => RunEnv.capture
   match ← findFixedRuntimeEntry benchName with
   | none =>
-    emitFixedRow benchName repeatIndex 0 none
+    emitFixedRow benchName repeatIndex 0 0 none
       (.error s!"unregistered fixed benchmark: {benchName}") env
       (errorMsg? := some s!"unregistered fixed benchmark: {benchName}")
     return 1
   | some entry =>
     try
-      let (total, hash) ← entry.runner
+      let (count, total, hash) ← autoTuneFixed entry.runner minTotalNanos
       let mem ← MemStats.capture
-      emitFixedRow benchName repeatIndex total hash .ok env (mem := mem)
+      emitFixedRow benchName repeatIndex count total hash .ok env (mem := mem)
       return (0 : UInt32)
     catch e =>
       let msg := s!"runner threw: {e.toString}"
-      emitFixedRow benchName repeatIndex 0 none (.error msg) env
+      emitFixedRow benchName repeatIndex 0 0 none (.error msg) env
         (errorMsg? := some msg)
       return (1 : UInt32)
 

--- a/LeanBench/Cli.lean
+++ b/LeanBench/Cli.lean
@@ -85,6 +85,7 @@ Each missing flag leaves the declared value untouched."
     "signal-floor-multiplier" : Float; "Parametric only: per-spawn signal-floor multiplier (default 10.0; ≥ 1.0). Rows whose totalNanos is below `multiplier × spawnFloor` are flagged `[<floor]` and excluded from the verdict. `1.0` disables the filter; useful in CI smoke tests on slow runners. Issue #47."
     "auto-fit";                      "Parametric only: after the verdict, fit a fixed catalog of complexity models (1, n, n*log n, n^2, n^3, 2^n) to the observed per-call timings and print a ranked suggestion. Heuristic, not a proof. See doc/quickstart.md#auto-fit."
     "repeats" : Nat;                 "Fixed only: number of measured invocations after the warmup call (default 5)."
+    "min-total-seconds" : Float;     "Fixed only: auto-tune floor on inner repeats per spawn (s; default 0.001 = 1 ms). The child runs the body once, then doubles the inner-repeat count until total wall time clears this floor. Per-iteration time is reported as total/inner_repeats. Issue #58."
     "ignore-expected-hash";          "Fixed only: clear any declared `expectedHash` for this run, so a hash mismatch no longer fails. For local experimentation when the result is intentionally changing. Issue #55."
     "export-file" : String;           "Write results to FILE in machine-readable JSON format (issue #3)."
     baseline : String;               "Compare against a previous export FILE; report regressions and improvements. Exit code is non-zero when any regression exceeds the threshold."
@@ -105,8 +106,9 @@ def childSub : Cmd := `[Cli|
     "target-nanos" : Nat;  "Parametric: inner-tuning target wall-time (ns)."
     "cache-mode" : LeanBench.CacheMode;
                            "Parametric: warm (default — auto-tune inside this child) or cold (single untuned invocation; parent respawns per rung)."
-    fixed;                 "Fixed: dispatch the fixed-benchmark single-invocation runner instead of the parametric autotuner."
+    fixed;                 "Fixed: dispatch the fixed-benchmark auto-tuned runner instead of the parametric autotuner."
     "repeat-index" : Nat;  "Fixed: 0-based repeat index to record on the emitted JSONL row."
+    "min-total-nanos" : Nat; "Fixed: auto-tune floor on inner repeats inside this spawn (ns). Issue #58."
     "env-json" : String;   "Issue #11: parent's pre-captured env JSON, propagated so all children stamp identical env on their rows. Falls back to fresh capture when absent or malformed."
 ]
 
@@ -145,6 +147,7 @@ explicit names are used."
     "signal-floor-multiplier" : Float; "Parametric only: per-spawn signal-floor multiplier (default 10.0; ≥ 1.0). Rows whose totalNanos is below `multiplier × spawnFloor` are flagged `[<floor]` and excluded from the verdict. `1.0` disables the filter; useful in CI smoke tests on slow runners. Issue #47."
     "auto-fit";                      "Parametric only: after each per-function verdict, fit a fixed catalog of complexity models to the observed timings and print a ranked suggestion. Heuristic, not a proof. See doc/quickstart.md#auto-fit."
     "repeats" : Nat;                 "Fixed only: number of measured invocations after the warmup call (default 5)."
+    "min-total-seconds" : Float;     "Fixed only: auto-tune floor on inner repeats per spawn (s; default 0.001 = 1 ms). The child runs the body once, then doubles the inner-repeat count until total wall time clears this floor. Per-iteration time is reported as total/inner_repeats. Issue #58."
     "ignore-expected-hash";          "Fixed only: clear any declared `expectedHash` for this run, so a hash mismatch no longer fails. For local experimentation when the result is intentionally changing. Issue #55."
     "export-file" : String;           "Write results to FILE in machine-readable JSON format (issue #3)."
 

--- a/LeanBench/Cli/Handlers.lean
+++ b/LeanBench/Cli/Handlers.lean
@@ -382,7 +382,9 @@ def runChildCmd (p : Cli.Parsed) : IO UInt32 := do
       match parsedFlag? p "repeat-index" Nat with
       | some n => n
       | none   => 0
-    LeanBench.runFixedChildMode benchStr.toName repeatIdx env?
+    let minTotalNanos : Nat :=
+      (parsedFlag? p "min-total-nanos" Nat).getD 1_000_000
+    LeanBench.runFixedChildMode benchStr.toName repeatIdx minTotalNanos env?
   else
     let param := (p.flag! "param").as! Nat
     let targetNanos := (p.flag! "target-nanos").as! Nat

--- a/LeanBench/Cli/Parse.lean
+++ b/LeanBench/Cli/Parse.lean
@@ -100,6 +100,7 @@ since they have no meaning for a fixed benchmark. -/
 def fixedConfigOverrideFromParsed (p : Cli.Parsed) : FixedConfigOverride :=
   { repeats?            := parsedFlag? p "repeats" Nat
     maxSecondsPerCall?  := parsedFlag? p "max-seconds-per-call" Float
+    minTotalSeconds?    := parsedFlag? p "min-total-seconds" Float
     ignoreExpectedHash  := p.hasFlag "ignore-expected-hash" }
 
 /-! ## Benchmark filtering (issue #10)

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -738,6 +738,15 @@ structure FixedBenchmarkConfig where
   /-- Whether to perform a single discarded warmup call before the
       measured calls. Defaults to true. -/
   warmup            : Bool  := true
+  /-- Auto-tune floor for inner repeats inside one child (s). The child
+      runs the registered callable once; if total wall time is below
+      this floor, it doubles the inner-repeat count and re-runs the
+      batch until total wall time clears the floor (or the parent's
+      `maxSecondsPerCall` cap kills the child). Per-iteration time is
+      reported as `total / inner_repeats`. Default `0.001` = 1 ms,
+      matching the parametric `targetInnerNanos / 2` signal-floor
+      convention. Issue #58. -/
+  minTotalSeconds   : Float := 0.001
   /-- Expected `Hashable` hash of the benchmark's result. When `some H`,
       the harness compares the first `ok` repeat's hash against `H`
       and fails on mismatch. Catches the "regressed to a stable but
@@ -760,6 +769,7 @@ structure FixedConfigOverride where
   maxSecondsPerCall? : Option Float := none
   killGraceMs?       : Option Nat   := none
   warmup?            : Option Bool  := none
+  minTotalSeconds?   : Option Float := none
   /-- When `true`, drops `expectedHash` for this run (CLI:
       `--ignore-expected-hash`). Local-experimentation escape hatch
       for the issue #55 correctness gate. -/
@@ -774,6 +784,7 @@ def FixedConfigOverride.apply (o : FixedConfigOverride)
     maxSecondsPerCall := o.maxSecondsPerCall?.getD c.maxSecondsPerCall
     killGraceMs       := o.killGraceMs?.getD       c.killGraceMs
     warmup            := o.warmup?.getD            c.warmup
+    minTotalSeconds   := o.minTotalSeconds?.getD   c.minTotalSeconds
     expectedHash      := if o.ignoreExpectedHash then none else c.expectedHash }
 
 def FixedBenchmarkConfig.validate (c : FixedBenchmarkConfig) : Except String Unit := do
@@ -781,6 +792,10 @@ def FixedBenchmarkConfig.validate (c : FixedBenchmarkConfig) : Except String Uni
     .error s!"FixedBenchmarkConfig.maxSecondsPerCall must be > 0; got {c.maxSecondsPerCall}"
   unless c.repeats ≥ 1 do
     .error s!"FixedBenchmarkConfig.repeats must be ≥ 1; got {c.repeats}"
+  unless c.minTotalSeconds ≥ 0.0 do
+    .error s!"FixedBenchmarkConfig.minTotalSeconds must be ≥ 0; got {c.minTotalSeconds}"
+  unless c.minTotalSeconds < c.maxSecondsPerCall do
+    .error s!"FixedBenchmarkConfig.minTotalSeconds ({c.minTotalSeconds}s) must be less than maxSecondsPerCall ({c.maxSecondsPerCall}s); the auto-tuner would never converge"
   pure ()
 
 /-- One entry in the fixed-benchmark registry. -/
@@ -798,6 +813,11 @@ structure FixedDataPoint where
   /-- 0-based index across the `repeats` measured calls. The single
       warmup call is not recorded. -/
   repeatIndex : Nat
+  /-- Auto-tuned inner-repeat count chosen by the child (issue #58).
+      `totalNanos` covers all `innerRepeats` invocations together;
+      per-call time is `totalNanos / innerRepeats`. `0` on synthesized
+      error / killed-at-cap rows. -/
+  innerRepeats : Nat := 1
   totalNanos  : Nat
   /-- Present iff the benchmark's value type has `Hashable`. -/
   resultHash  : Option UInt64

--- a/LeanBench/Env.lean
+++ b/LeanBench/Env.lean
@@ -95,13 +95,17 @@ Runtime registry for fixed-problem benchmarks declared with
 `setup_fixed_benchmark`. Cross-cutting code (`list`, `compare`,
 `verify`) iterates over both registries explicitly. -/
 
-/-- Runtime entry for a fixed benchmark. The `runner` performs one
-    timed invocation: starts the timer, runs the registered value
-    (forcing it via `blackBox`), stops the timer, and returns
-    `(totalNanos, resultHash?)`. -/
+/-- Runtime entry for a fixed benchmark. The `runner` runs the
+    registered value `count` times in one timed batch: starts the
+    timer, invokes the registered callable `count` times (forcing
+    each result via `blackBox`), stops the timer, and returns
+    `(totalNanos, firstHash?)`. The hash is from the *first* iteration
+    (issue #55 "first-iteration's result hash" semantics carried over
+    when the auto-tuner runs many iterations); `count = 0` is a no-op
+    that returns `(0, none)`. Issue #58. -/
 structure FixedRuntimeEntry where
   spec   : FixedSpec
-  runner : IO (Nat × Option UInt64)
+  runner : Nat → IO (Nat × Option UInt64)
   deriving Inhabited
 
 initialize fixedRuntimeRegistry : IO.Ref (Std.HashMap Name FixedRuntimeEntry) ←
@@ -113,7 +117,8 @@ def findFixedRuntimeEntry (name : Name) : IO (Option FixedRuntimeEntry) := do
 def allFixedRuntimeEntries : IO (Array FixedRuntimeEntry) := do
   return (← fixedRuntimeRegistry.get).valuesArray
 
-def registerFixed (spec : FixedSpec) (runner : IO (Nat × Option UInt64)) : IO Unit :=
+def registerFixed (spec : FixedSpec)
+    (runner : Nat → IO (Nat × Option UInt64)) : IO Unit :=
   fixedRuntimeRegistry.modify (·.insert spec.name { spec, runner })
 
 end LeanBench

--- a/LeanBench/Export.lean
+++ b/LeanBench/Export.lean
@@ -148,13 +148,14 @@ def fixedDataPointToJson (dp : FixedDataPoint) : Json :=
     | .error msg => jStr msg
     | _ => Json.null
   Json.mkObj [
-    ("repeat_index", jNat dp.repeatIndex),
-    ("total_nanos",  jNat dp.totalNanos),
-    ("status",       jStr (statusToString dp.status)),
-    ("result_hash",  jOptHash dp.resultHash),
-    ("error",        errorJson),
-    ("alloc_bytes",  jOptNat dp.allocBytes),
-    ("peak_rss_kb",  jOptNat dp.peakRssKb)
+    ("repeat_index",  jNat dp.repeatIndex),
+    ("inner_repeats", jNat dp.innerRepeats),
+    ("total_nanos",   jNat dp.totalNanos),
+    ("status",        jStr (statusToString dp.status)),
+    ("result_hash",   jOptHash dp.resultHash),
+    ("error",         errorJson),
+    ("alloc_bytes",   jOptNat dp.allocBytes),
+    ("peak_rss_kb",   jOptNat dp.peakRssKb)
   ]
 
 def benchmarkConfigToJson (c : BenchmarkConfig) : Json :=
@@ -177,6 +178,7 @@ def fixedBenchmarkConfigToJson (c : FixedBenchmarkConfig) : Json :=
     ("repeats",              jNat c.repeats),
     ("max_seconds_per_call", jFloat c.maxSecondsPerCall),
     ("warmup",               jBool c.warmup),
+    ("min_total_seconds",    jFloat c.minTotalSeconds),
     ("expected_hash",        jOptHash c.expectedHash)
   ]
 
@@ -385,12 +387,17 @@ def dataPointFromJson (j : Json) : Except String DataPoint := do
 
 def fixedDataPointFromJson (j : Json) : Except String FixedDataPoint := do
   let repeatIndex ← requireNatField j "repeat_index"
+  -- `inner_repeats` arrived in issue #58. Older exports omit it;
+  -- treat them as `1` (the pre-#58 effective count, since each spawn
+  -- ran exactly one invocation).
+  let innerRepeats : Nat := getNat j "inner_repeats" 1
   let totalNanos ← requireNatField j "total_nanos"
   let statusStr ← requireStringField j "status"
   let errorMsg? := getOptStr j "error"
   let resultHash ← optionalHashFromJson j "result_hash"
   return {
     repeatIndex
+    innerRepeats
     totalNanos
     status      := parseStatus statusStr errorMsg?
     resultHash
@@ -434,6 +441,10 @@ def fixedBenchmarkConfigFromJson (j : Json) : Except String FixedBenchmarkConfig
     repeats           := ← requireNatField j "repeats"
     maxSecondsPerCall := ← requireFloatField j "max_seconds_per_call"
     warmup            := ← requireBoolField j "warmup"
+    -- `min_total_seconds` arrived in issue #58. Default to today's
+    -- `FixedBenchmarkConfig.minTotalSeconds` default when absent so
+    -- pre-#58 baseline files round-trip cleanly.
+    minTotalSeconds   := getFloat j "min_total_seconds" 0.001
     expectedHash      := ← optionalHashFromJson j "expected_hash" }
 
 def trialSummaryFromJson (j : Json) : Except String TrialSummary := do

--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -568,17 +568,24 @@ def fmtFixedResult (r : FixedResult) (includeEnv : Bool := true) : String := Id.
     if includeEnv then
       lines := lines.push s!"  env: {RunEnv.fmtConcise env}"
   | none => pure ()
+  -- Auto-tune (issue #58) means each row's `totalNanos` covers
+  -- `innerRepeats` iterations; display per-call so the user reads
+  -- the actual cost of one invocation, then surface the batch total
+  -- and chosen N alongside.
+  let perCallNanos (dp : FixedDataPoint) : Nat :=
+    let n := if dp.innerRepeats == 0 then 1 else dp.innerRepeats
+    dp.totalNanos / n
   let mut idx : Nat := 0
   let nums := r.points.map fun dp =>
     match dp.status with
     | .ok =>
-      let (n, _) := fmtNanos dp.totalNanos
+      let (n, _) := fmtNanos (perCallNanos dp)
       n
     | _ => "—"
   let aligned := alignDecimals nums
   let units := r.points.map fun dp =>
     match dp.status with
-    | .ok => (fmtNanos dp.totalNanos).2
+    | .ok => (fmtNanos (perCallNanos dp)).2
     | _ => ""
   let wUnit := units.foldl (fun m u => max m u.length) 0
   for dp in r.points do
@@ -590,7 +597,16 @@ def fmtFixedResult (r : FixedResult) (includeEnv : Bool := true) : String := Id.
     let num := aligned[idx]!
     let unit := units[idx]!
     let perCall := num ++ " " ++ rightpad unit wUnit
-    lines := lines.push s!"  repeat {idx}  {perCall}{suffix}"
+    -- Show the auto-tuned count and batch total when N > 1 so the
+    -- raw measurement is visible behind the per-call computation.
+    let repeatsTag : String :=
+      match dp.status with
+      | .ok =>
+        if dp.innerRepeats > 1 then
+          s!"  ({fmtRepeats dp.innerRepeats}, total {fmtNanosStr dp.totalNanos})"
+        else ""
+      | _ => ""
+    lines := lines.push s!"  repeat {idx}  {perCall}{repeatsTag}{suffix}"
     idx := idx + 1
   let summary := match r.medianNanos?, r.minNanos?, r.maxNanos? with
     | some med, some lo, some hi =>

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -657,6 +657,7 @@ def parseFixedChildRow (line : String) : Except String FixedDataPoint := do
   Schema.checkKind Schema.kindFixed json
   let _ ← json.getObjValAs? String "function"
   let repeatIndex ← json.getObjValAs? Nat "repeat_index"
+  let innerRepeats ← json.getObjValAs? Nat "inner_repeats"
   let totalNanos ← json.getObjValAs? Nat "total_nanos"
   let parseOptionalHash (j : Json) : Except String (Option UInt64) := do
     match j.getObjVal? "result_hash" with
@@ -681,11 +682,12 @@ def parseFixedChildRow (line : String) : Except String FixedDataPoint := do
     match json.getObjValAs? Nat "peak_rss_kb" with
     | .ok n => some n
     | .error _ => none
-  return { repeatIndex, totalNanos, resultHash, status,
+  return { repeatIndex, innerRepeats, totalNanos, resultHash, status,
            allocBytes, peakRssKb }
 
 private def synthFixedRow (idx : Nat) (status : Status) : FixedDataPoint :=
-  { repeatIndex := idx, totalNanos := 0, resultHash := none, status }
+  { repeatIndex := idx, innerRepeats := 0, totalNanos := 0,
+    resultHash := none, status }
 
 /-- Pure classifier for the post-spawn outcome of a fixed-benchmark
     child run. Mirrors `classifyChildOutcome` for the parametric path. -/
@@ -721,11 +723,17 @@ def runFixedOneBatch (spec : FixedSpec) (cfg : FixedBenchmarkConfig)
   let exe ← ownExe
   let deadlineMs : UInt32 :=
     (cfg.maxSecondsPerCall * 1000.0 + cfg.killGraceMs.toFloat).toUInt32
+  -- Auto-tuner floor in nanoseconds. Saturates at 2^63 - 1 if a user
+  -- declares an absurd value; the validator already rejects the case
+  -- where the floor exceeds `maxSecondsPerCall`.
+  let minTotalNanos : Nat :=
+    (cfg.minTotalSeconds * 1_000_000_000.0).toUInt64.toNat
   let args := withEnvArg #[
     "_child",
     "--bench", spec.name.toString (escape := false),
     "--fixed",
-    "--repeat-index", toString repeatIndex
+    "--repeat-index", toString repeatIndex,
+    "--min-total-nanos", toString minTotalNanos
   ] env?
   let (exit, stdout, stderrText, wasKilled) ← spawnWithCap exe args deadlineMs
   return classifyFixedChildOutcome repeatIndex exit stdout stderrText wasKilled
@@ -791,9 +799,16 @@ def runFixedBenchmark (name : Lean.Name)
       break
     let dp ← runFixedOneBatch entry.spec cfg i (some env)
     points := points.push dp
+  -- Auto-tune (issue #58) means each spawn measures `innerRepeats`
+  -- iterations in one batch; report per-iteration time so the median
+  -- describes a single invocation regardless of the auto-tuned count.
+  -- `innerRepeats == 0` only on synthesized error rows, which are
+  -- already filtered out by the `.ok` match above.
   let okNanos : Array Nat := points.filterMap fun dp =>
     match dp.status with
-    | .ok => some dp.totalNanos
+    | .ok =>
+      let n := if dp.innerRepeats == 0 then 1 else dp.innerRepeats
+      some (dp.totalNanos / n)
     | _   => none
   let sorted := okNanos.qsort (· < ·)
   let medianNanos? := medianNat sorted

--- a/LeanBench/Schema.lean
+++ b/LeanBench/Schema.lean
@@ -48,9 +48,11 @@ def requiredParametricKeys : Array String :=
   #["param", "inner_repeats"]
 
 /-- Required keys on a fixed row, in addition to
-    `requiredCommonKeys`. -/
+    `requiredCommonKeys`. `inner_repeats` arrived in issue #58:
+    fixed children now auto-tune inner repeats per spawn, mirroring
+    parametric warm-mode, so the count must travel with every row. -/
 def requiredFixedKeys : Array String :=
-  #["repeat_index"]
+  #["repeat_index", "inner_repeats"]
 
 /-- Optional keys emitted on every row today. Absence is equivalent
     to `null`.

--- a/LeanBench/Setup.lean
+++ b/LeanBench/Setup.lean
@@ -385,59 +385,88 @@ where
     let rIdent := mkIdent rName
     let cfgIdent := mkIdent cfgDeclName
     -- Six shapes from `(shape, isHashable)`. All bracket the timer
-    -- around one invocation and force the result via `blackBox` to
-    -- defeat DCE, like the parametric path.
+    -- around one batch of `count` invocations and force each result
+    -- via `blackBox` to defeat DCE, like the parametric path. The
+    -- *first* iteration's hash is captured and returned, matching
+    -- the issue #55 "first-iteration's result hash" semantics under
+    -- the issue #58 auto-tuner: subsequent iterations within a
+    -- batch aren't separately hashed — the cross-repeat (cross-
+    -- spawn) agreement check handles non-determinism detection.
     let mkRunner : CommandElabM (TSyntax `command) :=
       match shape, isHashable with
       | .pureUnit, true =>
         `(command|
-          @[inline] def $rIdent : IO (Nat × Option UInt64) := do
+          @[inline] def $rIdent (count : Nat) :
+              IO (Nat × Option UInt64) := do
+            if count == 0 then return (0, none)
             let t₀ ← IO.monoNanosNow
-            let r := $fnId ()
-            let h := Hashable.hash r
-            LeanBench.blackBox h
+            let r₀ := $fnId ()
+            let h₀ := Hashable.hash r₀
+            LeanBench.blackBox h₀
+            for _ in [1:count] do
+              let r := $fnId ()
+              LeanBench.blackBox (Hashable.hash r)
             let t₁ ← IO.monoNanosNow
-            return (t₁ - t₀, some h))
+            return (t₁ - t₀, some h₀))
       | .pureUnit, false =>
         `(command|
-          @[inline] def $rIdent : IO (Nat × Option UInt64) := do
+          @[inline] def $rIdent (count : Nat) :
+              IO (Nat × Option UInt64) := do
+            if count == 0 then return (0, none)
             let t₀ ← IO.monoNanosNow
-            let r := $fnId ()
-            LeanBench.blackBox (Hashable.hash (sizeOf r))
+            for _ in [0:count] do
+              let r := $fnId ()
+              LeanBench.blackBox (Hashable.hash (sizeOf r))
             let t₁ ← IO.monoNanosNow
             return (t₁ - t₀, none))
       | .ioUnit, true =>
         `(command|
-          @[inline] def $rIdent : IO (Nat × Option UInt64) := do
+          @[inline] def $rIdent (count : Nat) :
+              IO (Nat × Option UInt64) := do
+            if count == 0 then return (0, none)
             let t₀ ← IO.monoNanosNow
-            let r ← (($fnId : Unit → IO _) ())
-            let h := Hashable.hash r
-            LeanBench.blackBox h
+            let r₀ ← (($fnId : Unit → IO _) ())
+            let h₀ := Hashable.hash r₀
+            LeanBench.blackBox h₀
+            for _ in [1:count] do
+              let r ← (($fnId : Unit → IO _) ())
+              LeanBench.blackBox (Hashable.hash r)
             let t₁ ← IO.monoNanosNow
-            return (t₁ - t₀, some h))
+            return (t₁ - t₀, some h₀))
       | .ioUnit, false =>
         `(command|
-          @[inline] def $rIdent : IO (Nat × Option UInt64) := do
+          @[inline] def $rIdent (count : Nat) :
+              IO (Nat × Option UInt64) := do
+            if count == 0 then return (0, none)
             let t₀ ← IO.monoNanosNow
-            let r ← (($fnId : Unit → IO _) ())
-            LeanBench.blackBox (Hashable.hash (sizeOf r))
+            for _ in [0:count] do
+              let r ← (($fnId : Unit → IO _) ())
+              LeanBench.blackBox (Hashable.hash (sizeOf r))
             let t₁ ← IO.monoNanosNow
             return (t₁ - t₀, none))
       | .io, true =>
         `(command|
-          @[inline] def $rIdent : IO (Nat × Option UInt64) := do
+          @[inline] def $rIdent (count : Nat) :
+              IO (Nat × Option UInt64) := do
+            if count == 0 then return (0, none)
             let t₀ ← IO.monoNanosNow
-            let r ← ($fnId : IO _)
-            let h := Hashable.hash r
-            LeanBench.blackBox h
+            let r₀ ← ($fnId : IO _)
+            let h₀ := Hashable.hash r₀
+            LeanBench.blackBox h₀
+            for _ in [1:count] do
+              let r ← ($fnId : IO _)
+              LeanBench.blackBox (Hashable.hash r)
             let t₁ ← IO.monoNanosNow
-            return (t₁ - t₀, some h))
+            return (t₁ - t₀, some h₀))
       | .io, false =>
         `(command|
-          @[inline] def $rIdent : IO (Nat × Option UInt64) := do
+          @[inline] def $rIdent (count : Nat) :
+              IO (Nat × Option UInt64) := do
+            if count == 0 then return (0, none)
             let t₀ ← IO.monoNanosNow
-            let r ← ($fnId : IO _)
-            LeanBench.blackBox (Hashable.hash (sizeOf r))
+            for _ in [0:count] do
+              let r ← ($fnId : IO _)
+              LeanBench.blackBox (Hashable.hash (sizeOf r))
             let t₁ ← IO.monoNanosNow
             return (t₁ - t₀, none))
     elabCommand (← mkRunner)

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -664,10 +664,11 @@ sanity-check spawn per registration.
 
 | Field | Default | Purpose |
 |-------|---------|---------|
-| `repeats` | `5` | Number of measured invocations after the warmup |
-| `maxSecondsPerCall` | `60.0` | Hard wallclock cap per invocation (seconds) |
+| `repeats` | `5` | Number of measured spawns after the warmup |
+| `maxSecondsPerCall` | `60.0` | Hard wallclock cap per spawn (seconds) |
 | `killGraceMs` | `100` | Grace ms between SIGTERM and SIGKILL |
 | `warmup` | `true` | Whether to perform a single discarded warmup call |
+| `minTotalSeconds` | `0.001` | Auto-tune floor on inner repeats per spawn (issue #58); the child doubles `inner_repeats` until total wall time clears the floor, then reports `total / inner_repeats` as per-call time |
 | `expectedHash` | `none` | Pin the result hash; mismatch fails the run (issue #55) |
 
 The hash-agreement check across repeats only verifies "all measured

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -86,6 +86,7 @@ key on the integer only.
 | key              | type    | meaning |
 |------------------|---------|---------|
 | `repeat_index`   | integer | 0-based index across the configured `repeats`. |
+| `inner_repeats`  | integer | Auto-tuned inner repeat count chosen inside the child (issue #58). The child runs the body once; if total wall time is below `FixedBenchmarkConfig.minTotalSeconds` the count doubles until the floor is cleared. Per-iteration time is `total_nanos / inner_repeats`. `0` on synthesized error rows. |
 
 ### Optional fields (both kinds)
 

--- a/test/LeanBenchTestChildOutcome.lean
+++ b/test/LeanBenchTestChildOutcome.lean
@@ -39,8 +39,8 @@ private def okJsonlRow : String :=
 /-- A canonical fixed `ok` JSONL row. -/
 private def okFixedJsonlRow : String :=
   "{\"schema_version\":1,\"kind\":\"fixed\",\"function\":\"foo.bar\"," ++
-  "\"repeat_index\":2,\"total_nanos\":1234567,\"result_hash\":\"0xcafebabe\"," ++
-  "\"status\":\"ok\",\"error\":null}"
+  "\"repeat_index\":2,\"inner_repeats\":1,\"total_nanos\":1234567," ++
+  "\"result_hash\":\"0xcafebabe\",\"status\":\"ok\",\"error\":null}"
 
 private def expect (label : String) (cond : Bool) : IO UInt32 := do
   if cond then return 0

--- a/test/LeanBenchTestFixed.lean
+++ b/test/LeanBenchTestFixed.lean
@@ -86,6 +86,16 @@ setup_fixed_benchmark cheapPureRegressed where {
   -- `Hashable.hash (cheapPure ())`, so the check must fail.
   expectedHash := some ((Hashable.hash (cheapPure ())) ^^^ 0xffffffffffffffff) }
 
+/-- Tiny synonym used for the issue #58 auto-tune test: `cheapPure`
+    runs a 50-step Fibonacci loop, well under 1µs, so the auto-tuner
+    must pick `inner_repeats > 1` to clear the default 1ms floor. -/
+def autoTuneTarget : Unit → UInt64 := cheapPure
+
+setup_fixed_benchmark autoTuneTarget where {
+  repeats := 1
+  warmup := false
+  minTotalSeconds := 0.005 }
+
 end LeanBench.Test.Fixed
 
 open LeanBench
@@ -100,6 +110,8 @@ private def cheapPureCorrectName   : Lean.Name :=
   `LeanBench.Test.Fixed.cheapPureCorrect
 private def cheapPureRegressedName : Lean.Name :=
   `LeanBench.Test.Fixed.cheapPureRegressed
+private def autoTuneTargetName     : Lean.Name :=
+  `LeanBench.Test.Fixed.autoTuneTarget
 
 /-- Substring helper. -/
 private def stringContains (haystack needle : String) : Bool :=
@@ -108,8 +120,8 @@ private def stringContains (haystack needle : String) : Bool :=
 def testRoundtrip : IO UInt32 := do
   let row :=
     "{\"schema_version\":1,\"kind\":\"fixed\",\"function\":\"foo.bar\"," ++
-    "\"repeat_index\":2,\"total_nanos\":1234567,\"result_hash\":\"0xcafebabe\"," ++
-    "\"status\":\"ok\",\"error\":null}"
+    "\"repeat_index\":2,\"inner_repeats\":4,\"total_nanos\":1234567," ++
+    "\"result_hash\":\"0xcafebabe\",\"status\":\"ok\",\"error\":null}"
   match parseFixedChildRow row with
   | .error e =>
     IO.eprintln s!"parse failure: {e}"
@@ -117,6 +129,7 @@ def testRoundtrip : IO UInt32 := do
   | .ok dp =>
     let ok :=
       dp.repeatIndex == 2 ∧
+      dp.innerRepeats == 4 ∧
       dp.totalNanos == 1234567 ∧
       dp.resultHash == some 0xcafebabe ∧
       dp.status == .ok
@@ -422,6 +435,76 @@ def testFormat : IO UInt32 := do
     return 1
   return 0
 
+/-- Issue #58: a sub-microsecond fixed body runs through the
+    auto-tuner, which doubles `inner_repeats` until total wall time
+    crosses `minTotalSeconds`. Pin three observable invariants:
+    (a) the row's `inner_repeats` field is `> 1` (auto-tune fired),
+    (b) `total_nanos` cleared the configured floor, and
+    (c) `inner_repeats` is a power of two (the doubling shape). -/
+def testAutoTuneFiresOnFastBody : IO UInt32 := do
+  let result ← runFixedBenchmark autoTuneTargetName
+  if result.points.size != 1 then
+    IO.eprintln s!"expected 1 repeat, got {result.points.size}"
+    return 1
+  let dp := result.points[0]!
+  unless dp.status == .ok do
+    IO.eprintln s!"unexpected status: {repr dp.status}"
+    return 1
+  unless dp.innerRepeats > 1 do
+    IO.eprintln s!"expected inner_repeats > 1 (auto-tune); got {dp.innerRepeats}"
+    return 1
+  -- Floor is 5 ms = 5_000_000 ns; the autotuner exits when total
+  -- *crosses* the floor, so we should see at least that.
+  unless dp.totalNanos ≥ 5_000_000 do
+    IO.eprintln s!"expected total_nanos ≥ 5ms (floor); got {dp.totalNanos} ns"
+    return 1
+  -- Power of two — the doubling probe never lands on anything else.
+  let isPow2 := dp.innerRepeats > 0 ∧ (dp.innerRepeats &&& (dp.innerRepeats - 1)) == 0
+  unless isPow2 do
+    IO.eprintln s!"expected inner_repeats to be a power of two; got {dp.innerRepeats}"
+    return 1
+  return 0
+
+/-- Issue #58: with `--min-total-seconds` overridden to 0, the
+    auto-tuner short-circuits to a single invocation, restoring
+    pre-#58 behaviour for callers that opt out. -/
+def testAutoTuneFloorOverrideZero : IO UInt32 := do
+  let result ← runFixedBenchmark autoTuneTargetName
+    (override := { minTotalSeconds? := some 0.0 })
+  if result.points.size != 1 then
+    IO.eprintln s!"override floor=0: expected 1 repeat, got {result.points.size}"
+    return 1
+  let dp := result.points[0]!
+  unless dp.status == .ok do
+    IO.eprintln s!"override floor=0: unexpected status: {repr dp.status}"
+    return 1
+  unless dp.innerRepeats == 1 do
+    IO.eprintln s!"override floor=0: expected inner_repeats=1, got {dp.innerRepeats}"
+    return 1
+  return 0
+
+/-- Issue #58: an `expectedHash` declared on a fast (auto-tuned)
+    benchmark still passes its check. The runner returns the *first*
+    iteration's hash, and the checker compares against it. Pin the
+    end-to-end interaction so a refactor that changes which hash the
+    runner returns can't silently break #55 under #58. -/
+def testAutoTuneExpectedHashStillMatches : IO UInt32 := do
+  -- Re-purpose `cheapPureCorrect` (which has the right `expectedHash`
+  -- pinned) under a high floor so auto-tune fires.
+  let result ← runFixedBenchmark cheapPureCorrectName
+    (override := { minTotalSeconds? := some 0.005 })
+  unless result.expectedHashCheck == .match do
+    IO.eprintln s!"expected .match under auto-tune, got {repr result.expectedHashCheck}"
+    return 1
+  -- Verify auto-tune actually fired in at least one repeat (sub-µs
+  -- body, 5 ms floor → must have done many iterations).
+  let firedSomewhere := result.points.any fun dp =>
+    dp.status == .ok ∧ dp.innerRepeats > 1
+  unless firedSomewhere do
+    IO.eprintln s!"expected auto-tune to fire; points={repr result.points}"
+    return 1
+  return 0
+
 /-- `medianNat` reports the upper of the two middle elements for
     even-length arrays — the conservative choice for regression
     detection. Pin that contract so a future "lower-middle" change
@@ -433,18 +516,23 @@ def testEvenRepeatsMedian : IO UInt32 := do
   if result.points.size != 2 then
     IO.eprintln s!"expected 2 repeats, got {result.points.size}"
     return 1
-  let okNanos : Array Nat := result.points.filterMap fun dp =>
+  -- Per-call (issue #58): the median is computed against
+  -- `totalNanos / innerRepeats`, so the test fixture has to mirror
+  -- that derivation rather than fall back to raw totals.
+  let okPerCall : Array Nat := result.points.filterMap fun dp =>
     match dp.status with
-    | .ok => some dp.totalNanos
+    | .ok =>
+      let n := if dp.innerRepeats == 0 then 1 else dp.innerRepeats
+      some (dp.totalNanos / n)
     | _   => none
-  if okNanos.size != 2 then
-    IO.eprintln s!"expected 2 ok repeats; got nanos {okNanos}"
+  if okPerCall.size != 2 then
+    IO.eprintln s!"expected 2 ok repeats; got per-call nanos {okPerCall}"
     return 1
-  let upper := if okNanos[0]! > okNanos[1]! then okNanos[0]! else okNanos[1]!
+  let upper := if okPerCall[0]! > okPerCall[1]! then okPerCall[0]! else okPerCall[1]!
   match result.medianNanos? with
   | some m =>
     unless m == upper do
-      IO.eprintln s!"expected upper-median {upper}, got {m} (raw nanos {okNanos})"
+      IO.eprintln s!"expected upper-median {upper}, got {m} (per-call nanos {okPerCall})"
       return 1
     return 0
   | none =>
@@ -468,7 +556,10 @@ def runTests : IO UInt32 := do
      ("expectedHashRoundtrip", testExpectedHashRoundtrip),
      ("expectedHashCheckProjection", testExpectedHashCheckProjection),
      ("ignoreExpectedHashOverride", testIgnoreExpectedHashOverride),
-     ("expectedHashVerify", testExpectedHashVerify)]
+     ("expectedHashVerify", testExpectedHashVerify),
+     ("autoTuneFiresOnFastBody", testAutoTuneFiresOnFastBody),
+     ("autoTuneFloorOverrideZero", testAutoTuneFloorOverrideZero),
+     ("autoTuneExpectedHashStillMatches", testAutoTuneExpectedHashStillMatches)]
   do
     let code ← t
     if code != 0 then

--- a/test/LeanBenchTestSchema.lean
+++ b/test/LeanBenchTestSchema.lean
@@ -211,7 +211,7 @@ def testCanonicalKeyConstants : IO UInt32 := do
   let okParametric :=
     Schema.requiredParametricKeys == #["param", "inner_repeats"]
   let okFixed :=
-    Schema.requiredFixedKeys == #["repeat_index"]
+    Schema.requiredFixedKeys == #["repeat_index", "inner_repeats"]
   let okOptCommon :=
     Schema.optionalCommonKeys ==
       #["result_hash", "error", "env", "alloc_bytes", "peak_rss_kb"]
@@ -399,7 +399,8 @@ def testParseRejectsFutureVersion : IO UInt32 := do
 def testFixedParseAcceptsExtraKey : IO UInt32 := do
   let row :=
     "{\"schema_version\":1,\"kind\":\"fixed\",\"function\":\"foo.bar\"," ++
-    "\"repeat_index\":0,\"total_nanos\":1234567,\"result_hash\":\"0xcafe\"," ++
+    "\"repeat_index\":0,\"inner_repeats\":1,\"total_nanos\":1234567," ++
+    "\"result_hash\":\"0xcafe\"," ++
     "\"status\":\"ok\",\"error\":null,\"alloc_bytes\":42}"
   match parseFixedChildRow row with
   | .error e =>
@@ -412,7 +413,7 @@ def testFixedParseAcceptsExtraKey : IO UInt32 := do
 def testFixedParseRejectsFutureVersion : IO UInt32 := do
   let row :=
     "{\"schema_version\":42,\"kind\":\"fixed\",\"function\":\"foo.bar\"," ++
-    "\"repeat_index\":0,\"total_nanos\":1,\"status\":\"ok\"}"
+    "\"repeat_index\":0,\"inner_repeats\":1,\"total_nanos\":1,\"status\":\"ok\"}"
   match parseFixedChildRow row with
   | .ok dp =>
     IO.eprintln s!"expected fixed future-version row to fail, got {repr dp}"
@@ -421,11 +422,11 @@ def testFixedParseRejectsFutureVersion : IO UInt32 := do
     expect s!"fixed future-version mentions '42': {msg}" (containsSub msg "42")
 
 def testFixedParseAcceptsMissingOptional : IO UInt32 := do
-  -- Drop `result_hash` and `error`. `kind` stays — fixed parser
-  -- requires it to discriminate from a misrouted parametric row.
+  -- Drop `result_hash` and `error`. `kind`, `inner_repeats` stay
+  -- — both are required for the fixed parser.
   let row :=
     "{\"schema_version\":1,\"kind\":\"fixed\",\"function\":\"foo.bar\"," ++
-    "\"repeat_index\":2,\"total_nanos\":99,\"status\":\"ok\"}"
+    "\"repeat_index\":2,\"inner_repeats\":1,\"total_nanos\":99,\"status\":\"ok\"}"
   match parseFixedChildRow row with
   | .error e =>
     IO.eprintln s!"fixed missing-optional row failed: {e}"
@@ -472,7 +473,7 @@ private def baseValidParametricRow : String :=
 
 private def baseValidFixedRow : String :=
   "{\"schema_version\":1,\"kind\":\"fixed\",\"function\":\"foo.bar\"," ++
-  "\"repeat_index\":0,\"total_nanos\":1,\"result_hash\":null," ++
+  "\"repeat_index\":0,\"inner_repeats\":1,\"total_nanos\":1,\"result_hash\":null," ++
   "\"status\":\"ok\",\"error\":null}"
 
 def testParseRejectsExplicitOldVersion : IO UInt32 :=
@@ -487,12 +488,12 @@ def testParseRejectsMissingVersion : IO UInt32 :=
 
 def testFixedParseRejectsExplicitOldVersion : IO UInt32 :=
   expectFixedParseError
-    "{\"schema_version\":0,\"kind\":\"fixed\",\"function\":\"foo.bar\",\"repeat_index\":0,\"total_nanos\":1,\"status\":\"ok\"}"
+    "{\"schema_version\":0,\"kind\":\"fixed\",\"function\":\"foo.bar\",\"repeat_index\":0,\"inner_repeats\":1,\"total_nanos\":1,\"status\":\"ok\"}"
     "0" "fixed.explicitOldVersion"
 
 def testFixedParseRejectsMissingVersion : IO UInt32 :=
   expectFixedParseError
-    "{\"kind\":\"fixed\",\"function\":\"foo.bar\",\"repeat_index\":0,\"total_nanos\":1,\"status\":\"ok\"}"
+    "{\"kind\":\"fixed\",\"function\":\"foo.bar\",\"repeat_index\":0,\"inner_repeats\":1,\"total_nanos\":1,\"status\":\"ok\"}"
     "schema_version" "fixed.missingVersion"
 
 def testParseRejectsWrongKind : IO UInt32 :=
@@ -505,13 +506,13 @@ def testFixedParseRejectsWrongKind : IO UInt32 :=
   -- Symmetric: `kind:"parametric"` (or missing, which defaults to
   -- parametric) must not parse via the fixed parser.
   expectFixedParseError
-    "{\"schema_version\":1,\"kind\":\"parametric\",\"function\":\"foo.bar\",\"repeat_index\":0,\"total_nanos\":1,\"status\":\"ok\"}"
+    "{\"schema_version\":1,\"kind\":\"parametric\",\"function\":\"foo.bar\",\"repeat_index\":0,\"inner_repeats\":1,\"total_nanos\":1,\"status\":\"ok\"}"
     "kind" "fixed.wrongKind"
 
 def testFixedParseRejectsMissingKind : IO UInt32 :=
   -- Missing `kind` is rejected on both parsers.
   expectFixedParseError
-    "{\"schema_version\":1,\"function\":\"foo.bar\",\"repeat_index\":0,\"total_nanos\":1,\"status\":\"ok\"}"
+    "{\"schema_version\":1,\"function\":\"foo.bar\",\"repeat_index\":0,\"inner_repeats\":1,\"total_nanos\":1,\"status\":\"ok\"}"
     "kind" "fixed.missingKind"
 
 /-- Drop each required field individually from a known-good
@@ -542,6 +543,7 @@ def testFixedParseRejectsMissingRequired : IO UInt32 := do
   let droppers : List (String × String) :=
     [ ("\"function\":\"foo.bar\",", "function")
     , ("\"repeat_index\":0,",       "repeat_index")
+    , ("\"inner_repeats\":1,",      "inner_repeats")
     , ("\"total_nanos\":1,",        "total_nanos")
     , ("\"status\":\"ok\",",        "status") ]
   for (substr, fieldName) in droppers do
@@ -580,7 +582,7 @@ def testParseAcceptsMemoryMetrics : IO UInt32 := do
 def testFixedParseAcceptsMemoryMetrics : IO UInt32 := do
   let row :=
     "{\"schema_version\":1,\"kind\":\"fixed\",\"function\":\"foo.bar\"," ++
-    "\"repeat_index\":0,\"total_nanos\":1,\"status\":\"ok\"," ++
+    "\"repeat_index\":0,\"inner_repeats\":1,\"total_nanos\":1,\"status\":\"ok\"," ++
     "\"alloc_bytes\":42,\"peak_rss_kb\":100}"
   match parseFixedChildRow row with
   | .error e =>


### PR DESCRIPTION
This PR adds auto-tuned inner repeats to fixed benchmarks, mirroring the parametric warm-mode contract. `setup_fixed_benchmark` now accepts a `minTotalSeconds` config field (default `0.001`); the child runs the registered callable once, then doubles the inner-repeat count until total wall time clears the floor. Per-iteration time is reported as `total_nanos / inner_repeats`. Each fixed JSONL row gains a required `inner_repeats` field; the export schema additively records `min_total_seconds` on the config and `inner_repeats` on every fixed point. The `expectedHash` check (#55) keeps the spec's "first iteration's hash" semantics: the auto-tuned runner returns the first iteration's hash, and the cross-repeat agreement check pivots on it.

The fixed runner shape moved from `IO (Nat × Option UInt64)` to `Nat → IO (...)` in the runtime registry; the `setup_fixed_benchmark` macro now emits a count-parameterised loop body for all six `(shape × hashable)` combinations. `FixedResult.medianNanos? / minNanos? / maxNanos?` are computed against per-call values, which keeps the contract consistent with the pre-#58 single-invocation case (where `total == per-call`). A `--min-total-seconds` flag (and a child-side `--min-total-nanos`) flow through the same plumbing as the existing fixed flags. Validation rejects `minTotalSeconds ≥ maxSecondsPerCall` so the auto-tuner can't loop into the kill-cap.

A second-opinion pass surfaced four design points: (1) probe batches share state with the final batch — same as parametric warm-mode and explicitly in scope per the issue; (2) per-call median semantics are unchanged from pre-#58 (single-invocation per spawn was already per-call); (3) JSONL is in-process child↔parent IPC, so adding a required key without bumping `schema_version` is safe (binaries always match); (4) within-batch hash divergence isn't separately checked — the issue's "out of scope" rationale.

🤖 Prepared with Claude Code