### PR TITLE
ci: switch docs workflow to macos-latest

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -63,7 +63,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR switches the docs build+deploy workflow from `ubuntu-latest` to `macos-latest`. The Ubuntu runner pool is currently unavailable for this account — confirmed by checking older runs (Ubuntu jobs queued 4+ hours, macOS/Windows complete in 7 min). Without this, the post-merge docs deploy from #53 stays pending indefinitely and the GitHub Pages site never goes live.

The docs workflow doesn't depend on anything Linux-specific (Lean's elaborator + lake, plus Verso's HTML emitter, run identically on macOS), so the switch has no functional impact.

🤖 Prepared with Claude Code