### PR TITLE
fix: upload _site/html-multi as Pages artifact

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,11 @@ jobs:
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: _site
+          # Verso's `manualMain --output _site` writes to
+          # `_site/html-multi/` (the multi-page renderer); upload that
+          # subdir so `index.html` lands at the artifact root and the
+          # site serves at <url>/ rather than <url>/html-multi/.
+          path: _site/html-multi
 
   deploy:
     if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Site went live at https://kim-em.github.io/lean-bench/html-multi/ instead of the root because Verso's multi-page output goes to `_site/html-multi/` and the workflow uploaded the parent `_site`. Setting `path: _site/html-multi` puts `index.html` at the artifact root, matching every URL the README and source-comment links already use.

🤖 Prepared with Claude Code