### PR TITLE
feat: add `warmupFirstIter` flag to FixedBenchmarkConfig

### DIFF
--- a/LeanBench/Child.lean
+++ b/LeanBench/Child.lean
@@ -334,6 +334,15 @@ def runFixedChildMode (benchName : Lean.Name) (repeatIndex : Nat)
     return 1
   | some entry =>
     try
+      -- Optional pre-warmup so module-level lazy state (persistent
+      -- subprocess drivers, cached inputs, JIT) is initialised
+      -- before the auto-tuner takes a timing read. Without this,
+      -- the runner's first iteration absorbs that cost and the
+      -- auto-tuner converges to it, reporting startup time as
+      -- per-iteration time. The discarded result is on the
+      -- benchmark's normal IO path so any error surfaces here.
+      if entry.spec.config.warmupFirstIter then
+        let _ ← entry.runner 1
       let (count, total, hash) ← autoTuneFixed entry.runner minTotalNanos
       let mem ← MemStats.capture
       emitFixedRow benchName repeatIndex count total hash .ok env (mem := mem)

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -756,6 +756,19 @@ structure FixedBenchmarkConfig where
       copy the printed `observed hash:` value into the `where` clause.
       Issue #55. -/
   expectedHash      : Option UInt64 := none
+  /-- When `true`, the child invokes the registered runner once
+      (`count := 1`) **before** the auto-tuner takes over, and
+      discards the result. Use for benchmarks whose first call
+      lazily initialises module-level state (persistent subprocess
+      drivers, JIT caches, lazy `IO.Ref`s) at significant cost: a
+      single one-shot inner repeat then includes that startup in
+      its timing and the auto-tuner converges to it, producing a
+      per-iteration median that is mostly the startup rather than
+      the steady-state algorithm cost. With this flag the timed
+      region only contains steady-state iterations.
+      Defaults to `false`. The pre-warmup call counts against the
+      `maxSecondsPerCall` cap. -/
+  warmupFirstIter   : Bool := false
   /-- User-defined tags for organizing benchmarks. Same semantics as
       `BenchmarkConfig.tags` — see issue #10. -/
   tags              : Array String := #[]

--- a/LeanBench/Export.lean
+++ b/LeanBench/Export.lean
@@ -178,6 +178,7 @@ def fixedBenchmarkConfigToJson (c : FixedBenchmarkConfig) : Json :=
     ("repeats",              jNat c.repeats),
     ("max_seconds_per_call", jFloat c.maxSecondsPerCall),
     ("warmup",               jBool c.warmup),
+    ("warmup_first_iter",    jBool c.warmupFirstIter),
     ("min_total_seconds",    jFloat c.minTotalSeconds),
     ("expected_hash",        jOptHash c.expectedHash)
   ]
@@ -441,6 +442,10 @@ def fixedBenchmarkConfigFromJson (j : Json) : Except String FixedBenchmarkConfig
     repeats           := ← requireNatField j "repeats"
     maxSecondsPerCall := ← requireFloatField j "max_seconds_per_call"
     warmup            := ← requireBoolField j "warmup"
+    -- `warmup_first_iter` is post-#63; default to today's
+    -- `FixedBenchmarkConfig.warmupFirstIter` default when absent so
+    -- pre-warmupFirstIter baseline files round-trip cleanly.
+    warmupFirstIter   := getBool j "warmup_first_iter" false
     -- `min_total_seconds` arrived in issue #58. Default to today's
     -- `FixedBenchmarkConfig.minTotalSeconds` default when absent so
     -- pre-#58 baseline files round-trip cleanly.

--- a/test/LeanBenchTestFixed.lean
+++ b/test/LeanBenchTestFixed.lean
@@ -96,6 +96,29 @@ setup_fixed_benchmark autoTuneTarget where {
   warmup := false
   minTotalSeconds := 0.005 }
 
+/-- Shared invocation counter for the `warmupFirstIter` tests.
+    Module-level `IO.Ref` simulating lazy setup state that a
+    persistent-subprocess driver or cached input would occupy. -/
+initialize warmupCounter : IO.Ref Nat ← IO.mkRef 0
+
+/-- Test target that records how many times it has been invoked
+    inside this child process. The return value is the count after
+    the increment, hashed so the `Hashable` path stays exercised. -/
+def warmupCountedTarget : Unit → IO UInt64 := fun () => do
+  warmupCounter.modify (· + 1)
+  return (← warmupCounter.get).toUInt64
+
+setup_fixed_benchmark warmupCountedTarget where {
+  repeats := 1
+  warmup := false
+  warmupFirstIter := true
+  -- Force a single timed inner iteration so the observed hash is
+  -- the count *after* the warmup has run. With autoTune doubling,
+  -- the hash would be the count after iteration 1 of the timed
+  -- batch — still > 1 with warmup — but pinning count=1 makes the
+  -- assertion mechanical.
+  minTotalSeconds := 0.0 }
+
 end LeanBench.Test.Fixed
 
 open LeanBench
@@ -112,6 +135,8 @@ private def cheapPureRegressedName : Lean.Name :=
   `LeanBench.Test.Fixed.cheapPureRegressed
 private def autoTuneTargetName     : Lean.Name :=
   `LeanBench.Test.Fixed.autoTuneTarget
+private def warmupCountedTargetName : Lean.Name :=
+  `LeanBench.Test.Fixed.warmupCountedTarget
 
 /-- Substring helper. -/
 private def stringContains (haystack needle : String) : Bool :=
@@ -539,6 +564,32 @@ def testEvenRepeatsMedian : IO UInt32 := do
     IO.eprintln "expected medianNanos? to be some _"
     return 1
 
+/-- `warmupFirstIter := true` runs one untimed call before the
+    auto-tuner takes over. The target's observed hash on the timed
+    iteration must reflect a counter value > 1: warmup increments
+    once, then the timed inner iteration increments again. Without
+    the flag, the first invocation IS the timed one; the hash would
+    be 1. -/
+def testWarmupFirstIter : IO UInt32 := do
+  let result ← runFixedBenchmark warmupCountedTargetName
+  if result.points.size != 1 then
+    IO.eprintln s!"expected 1 repeat, got {result.points.size}"
+    return 1
+  let dp := result.points[0]!
+  unless dp.status == .ok do
+    IO.eprintln s!"unexpected status: {repr dp.status}"
+    return 1
+  -- minTotalSeconds=0 → autoTuneFixed returns at count=1.
+  unless dp.innerRepeats == 1 do
+    IO.eprintln s!"expected inner_repeats=1, got {dp.innerRepeats}"
+    return 1
+  -- Inside the child: warmup is invocation 1, timed iter is 2.
+  -- Hash returned is the count after the timed iter's increment.
+  unless dp.resultHash == some (Hashable.hash (2 : UInt64)) do
+    IO.eprintln s!"expected hash of 2 (1 warmup + 1 timed); got {dp.resultHash}"
+    return 1
+  return 0
+
 def runTests : IO UInt32 := do
   for (label, t) in
     [("roundtrip", testRoundtrip),
@@ -559,7 +610,8 @@ def runTests : IO UInt32 := do
      ("expectedHashVerify", testExpectedHashVerify),
      ("autoTuneFiresOnFastBody", testAutoTuneFiresOnFastBody),
      ("autoTuneFloorOverrideZero", testAutoTuneFloorOverrideZero),
-     ("autoTuneExpectedHashStillMatches", testAutoTuneExpectedHashStillMatches)]
+     ("autoTuneExpectedHashStillMatches", testAutoTuneExpectedHashStillMatches),
+     ("warmupFirstIter", testWarmupFirstIter)]
   do
     let code ← t
     if code != 0 then


### PR DESCRIPTION
This PR adds a per-target opt-in `FixedBenchmarkConfig.warmupFirstIter : Bool := false`. When set, the child runs one untimed `entry.runner 1` before the auto-tuner takes over, so lazy module-level setup (persistent subprocess drivers, cached inputs, JIT initialisation) is paid for before timing starts.

Without the flag, the auto-tuner's first probe absorbs that setup cost and trivially clears the floor at `count := 1`. The reported per-iteration median is then mostly setup, not the steady-state work.

For example, an `IO α` target wrapping a persistent CPython subprocess: first call ~150 ms (interpreter startup + `import`), subsequent calls ~50 µs (one stdin/stdout roundtrip + a small algorithm). Without `warmupFirstIter`, auto-tune returns `(1, 150 ms)` and reports 150 ms per call. With `warmupFirstIter := true`, auto-tune sees ~50 µs per probe and doubles `count` until the floor is cleared honestly.

Default is `false`; the pre-warm counts against `maxSecondsPerCall`. A targeted test pins the contract: a stateful counter target with the flag set and a single timed inner iteration returns hash 2 (one warmup + one timed iteration), not hash 1.

🤖 Prepared with Claude Code