### PR TITLE
refactor: migrate LeanBench library to the Lean module system

### DIFF
--- a/LeanBench.lean
+++ b/LeanBench.lean
@@ -1,20 +1,24 @@
-import LeanBench.Core
-import LeanBench.Schema
-import LeanBench.Env
-import LeanBench.MemStats
-import LeanBench.RunEnv
-import LeanBench.Setup
-import LeanBench.Child
-import LeanBench.Run
-import LeanBench.Stats
-import LeanBench.AutoFit
-import LeanBench.Compare
-import LeanBench.Verify
-import LeanBench.Format
-import LeanBench.Export
-import LeanBench.Profile
-import LeanBench.TimedRegions
-import LeanBench.Cli
+module
+
+public import LeanBench.Core
+public import LeanBench.Schema
+public import LeanBench.Env
+public import LeanBench.MemStats
+public import LeanBench.RunEnv
+public import LeanBench.Setup
+public import LeanBench.Child
+public import LeanBench.Run
+public import LeanBench.Stats
+public import LeanBench.AutoFit
+public import LeanBench.Compare
+public import LeanBench.Verify
+public import LeanBench.Format
+public import LeanBench.Export
+public import LeanBench.Profile
+public import LeanBench.TimedRegions
+public import LeanBench.Cli
+
+public section
 
 /-!
 # `LeanBench` — microbenchmarks for Lean 4

--- a/LeanBench/AutoFit.lean
+++ b/LeanBench/AutoFit.lean
@@ -1,4 +1,8 @@
-import LeanBench.Core
+module
+
+public import LeanBench.Core
+
+public section
 
 /-!
 # `LeanBench.AutoFit` — heuristic complexity model selection (issue #8)

--- a/LeanBench/Child.lean
+++ b/LeanBench/Child.lean
@@ -1,10 +1,14 @@
-import Lean
-import LeanBench.Core
-import LeanBench.Env
-import LeanBench.MemStats
-import LeanBench.RunEnv
-import LeanBench.Schema
-import LeanBench.TimedRegions
+module
+
+public import Lean
+public import LeanBench.Core
+public import LeanBench.Env
+public import LeanBench.MemStats
+public import LeanBench.RunEnv
+public import LeanBench.Schema
+public import LeanBench.TimedRegions
+
+public section
 
 /-!
 # `LeanBench.Child` — child-mode runner

--- a/LeanBench/Cli.lean
+++ b/LeanBench/Cli.lean
@@ -1,6 +1,10 @@
-import Cli
-import LeanBench.Cli.Parse
-import LeanBench.Cli.Handlers
+module
+
+public import Cli
+public import LeanBench.Cli.Parse
+public import LeanBench.Cli.Handlers
+
+public section
 
 /-!
 # `LeanBench.Cli` — Cmd tree and `dispatch`

--- a/LeanBench/Cli/Handlers.lean
+++ b/LeanBench/Cli/Handlers.lean
@@ -1,15 +1,19 @@
-import Cli
-import Lean.Data.Json
-import LeanBench.Core
-import LeanBench.Env
-import LeanBench.Run
-import LeanBench.Child
-import LeanBench.Compare
-import LeanBench.Verify
-import LeanBench.Format
-import LeanBench.Export
-import LeanBench.Profile
-import LeanBench.Cli.Parse
+module
+
+public import Cli
+public import Lean.Data.Json
+public import LeanBench.Core
+public import LeanBench.Env
+public import LeanBench.Run
+public import LeanBench.Child
+public import LeanBench.Compare
+public import LeanBench.Verify
+public import LeanBench.Format
+public import LeanBench.Export
+public import LeanBench.Profile
+public import LeanBench.Cli.Parse
+
+public section
 
 /-!
 # `LeanBench.Cli.Handlers` — subcommand handler implementations

--- a/LeanBench/Cli/Parse.lean
+++ b/LeanBench/Cli/Parse.lean
@@ -1,7 +1,11 @@
-import Cli
-import Lean.Data.Json
-import LeanBench.Core
-import LeanBench.Env
+module
+
+public import Cli
+public import Lean.Data.Json
+public import LeanBench.Core
+public import LeanBench.Env
+
+public section
 
 /-!
 # `LeanBench.Cli.Parse` — flag parsers, override builders, filtering

--- a/LeanBench/Compare.lean
+++ b/LeanBench/Compare.lean
@@ -1,7 +1,11 @@
-import LeanBench.Core
-import LeanBench.Env
-import LeanBench.Run
-import LeanBench.Format
+module
+
+public import LeanBench.Core
+public import LeanBench.Env
+public import LeanBench.Run
+public import LeanBench.Format
+
+public section
 
 /-!
 # `LeanBench.Compare` — cross-implementation comparison

--- a/LeanBench/Core.lean
+++ b/LeanBench/Core.lean
@@ -1,5 +1,9 @@
-import Lean.Data.Name
-import Std.Data.HashSet
+module
+
+public import Lean.Data.Name
+public import Std.Data.HashSet
+
+public section
 
 /-!
 # `LeanBench.Core` — shared types

--- a/LeanBench/Env.lean
+++ b/LeanBench/Env.lean
@@ -1,5 +1,9 @@
-import Lean
-import LeanBench.Core
+module
+
+public import Lean
+public import LeanBench.Core
+
+public section
 
 /-!
 # `LeanBench.Env` — registry plumbing

--- a/LeanBench/Export.lean
+++ b/LeanBench/Export.lean
@@ -1,9 +1,13 @@
-import Lean
-import LeanBench.Core
-import LeanBench.Env
-import LeanBench.RunEnv
-import LeanBench.Schema
-import LeanBench.Format
+module
+
+public import Lean
+public import LeanBench.Core
+public import LeanBench.Env
+public import LeanBench.RunEnv
+public import LeanBench.Schema
+public import LeanBench.Format
+
+public section
 
 /-!
 # `LeanBench.Export` -- machine-readable export and baseline comparison

--- a/LeanBench/Format.lean
+++ b/LeanBench/Format.lean
@@ -1,8 +1,12 @@
-import LeanBench.Core
-import LeanBench.AutoFit
-import LeanBench.Env
-import LeanBench.RunEnv
-import LeanBench.Verify
+module
+
+public import LeanBench.Core
+public import LeanBench.AutoFit
+public import LeanBench.Env
+public import LeanBench.RunEnv
+public import LeanBench.Verify
+
+public section
 
 /-!
 # `LeanBench.Format` — printers

--- a/LeanBench/MemStats.lean
+++ b/LeanBench/MemStats.lean
@@ -1,3 +1,7 @@
+module
+
+public section
+
 /-!
 # `LeanBench.MemStats` — memory metrics capture (issue #6)
 

--- a/LeanBench/Profile.lean
+++ b/LeanBench/Profile.lean
@@ -1,6 +1,10 @@
-import Lean
-import LeanBench.Core
-import LeanBench.Run
+module
+
+public import Lean
+public import LeanBench.Core
+public import LeanBench.Run
+
+public section
 
 /-!
 # `LeanBench.Profile` — wrap a single child invocation under an external profiler

--- a/LeanBench/Run.lean
+++ b/LeanBench/Run.lean
@@ -1,10 +1,14 @@
-import Lean
-import Std.Sync.Mutex
-import LeanBench.Core
-import LeanBench.Env
-import LeanBench.RunEnv
-import LeanBench.Schema
-import LeanBench.Stats
+module
+
+public import Lean
+public import Std.Sync.Mutex
+public import LeanBench.Core
+public import LeanBench.Env
+public import LeanBench.RunEnv
+public import LeanBench.Schema
+public import LeanBench.Stats
+
+public section
 
 /-!
 # `LeanBench.Run` — parent-side orchestration

--- a/LeanBench/RunEnv.lean
+++ b/LeanBench/RunEnv.lean
@@ -1,6 +1,10 @@
-import Lean
-import Std.Time
-import LeanBench.Core
+module
+
+public import Lean
+public import Std.Time
+public import LeanBench.Core
+
+public section
 
 /-!
 # `LeanBench.RunEnv` — capture reproducibility metadata (issue #11)

--- a/LeanBench/Schema.lean
+++ b/LeanBench/Schema.lean
@@ -1,5 +1,9 @@
-import Lean.Data.Json
-import LeanBench.Core
+module
+
+public import Lean.Data.Json
+public import LeanBench.Core
+
+public section
 
 /-!
 # `LeanBench.Schema` — versioned result schema

--- a/LeanBench/Setup.lean
+++ b/LeanBench/Setup.lean
@@ -1,6 +1,10 @@
-import Lean
-import LeanBench.Core
-import LeanBench.Env
+module
+
+public import Lean
+public import LeanBench.Core
+public import LeanBench.Env
+
+public section
 
 /-!
 # `LeanBench.Setup` — the `setup_benchmark` command
@@ -85,7 +89,7 @@ syntax (name := setupBenchmark) "setup_benchmark "
                           (setupBenchmarkWhere)? : command
 
 /-- Look up the type of a constant; return `(argTy, resTy)`. -/
-def expectFunction (env : Environment) (declName : Name) :
+meta def expectFunction (env : Environment) (declName : Name) :
     CommandElabM (Expr × Expr) := do
   let some ci := env.find? declName
     | throwError "setup_benchmark: function `{declName}` is not defined"
@@ -96,7 +100,7 @@ def expectFunction (env : Environment) (declName : Name) :
   return (argTy, resTy)
 
 /-- Look up the type of a constant; assert it is `Nat → α` and return `α`. -/
-def expectNatToAlpha (env : Environment) (declName : Name) :
+meta def expectNatToAlpha (env : Environment) (declName : Name) :
     CommandElabM Expr := do
   let (argTy, resTy) ← expectFunction env declName
   unless argTy.isConstOf ``Nat do
@@ -104,7 +108,7 @@ def expectNatToAlpha (env : Environment) (declName : Name) :
   return resTy
 
 /-- True iff `Hashable α` synthesizes. -/
-def hasHashable (alphaExpr : Expr) : CommandElabM Bool := do
+meta def hasHashable (alphaExpr : Expr) : CommandElabM Bool := do
   liftTermElabM do
     let goal ← Meta.mkAppM ``Hashable #[alphaExpr]
     match ← (Meta.synthInstance? goal) with
@@ -115,7 +119,7 @@ def hasHashable (alphaExpr : Expr) : CommandElabM Bool := do
 namespace, falling back to the bare name. Returns the candidate even
 on failure so the eventual error message names the user-visible
 qualified form rather than the bare identifier. -/
-def resolveDecl (env : Environment) (ns : Name) (id : Ident) : Name :=
+meta def resolveDecl (env : Environment) (ns : Name) (id : Ident) : Name :=
   let bare := id.getId
   let candidate := ns ++ bare
   if env.contains candidate then candidate
@@ -123,7 +127,7 @@ def resolveDecl (env : Environment) (ns : Name) (id : Ident) : Name :=
   else candidate
 
 @[command_elab setupBenchmark]
-def elabSetupBenchmark : CommandElab := fun stx => do
+meta def elabSetupBenchmark : CommandElab := fun stx => do
   match stx with
   | `(command| setup_benchmark $fnId:ident $argId:ident => $complexityTerm) =>
     elabCore fnId argId complexityTerm none none
@@ -318,7 +322,7 @@ arrows are rejected (issue #54).
 The IO check uses `isDefEq` against `IO ?α` rather than syntactic
 head matching, so `EIO IO.Error α`, `BaseIO α`, and reducible
 aliases of `IO` are all accepted. -/
-def expectFixedValue (env : Environment) (declName : Name) :
+meta def expectFixedValue (env : Environment) (declName : Name) :
     CommandElabM (Expr × FixedShape) := do
   let some ci := env.find? declName
     | throwError "setup_fixed_benchmark: name `{declName}` is not defined"
@@ -359,7 +363,7 @@ syntax (name := setupFixedBenchmark) "setup_fixed_benchmark "
   ident (setupBenchmarkWhere)? : command
 
 @[command_elab setupFixedBenchmark]
-def elabSetupFixedBenchmark : CommandElab := fun stx => do
+meta def elabSetupFixedBenchmark : CommandElab := fun stx => do
   match stx with
   | `(command| setup_fixed_benchmark $fnId:ident) =>
     elabCore fnId none

--- a/LeanBench/Stats.lean
+++ b/LeanBench/Stats.lean
@@ -1,5 +1,9 @@
-import Lean
-import LeanBench.Core
+module
+
+public import Lean
+public import LeanBench.Core
+
+public section
 
 /-!
 # `LeanBench.Stats` — ratios + verdict

--- a/LeanBench/TimedRegions.lean
+++ b/LeanBench/TimedRegions.lean
@@ -1,4 +1,8 @@
-import Lean
+module
+
+public import Lean
+
+public section
 
 /-!
 # `LeanBench.TimedRegions` — opt-in sidecar emission of timed region boundaries

--- a/LeanBench/Verify.lean
+++ b/LeanBench/Verify.lean
@@ -1,6 +1,10 @@
-import Lean
-import LeanBench.Core
-import LeanBench.Env
+module
+
+public import Lean
+public import LeanBench.Core
+public import LeanBench.Env
+
+public section
 
 /-!
 # `LeanBench.Verify` — registration sanity checks


### PR DESCRIPTION
This PR migrates the `LeanBench` library to the Lean 4 module system (`module` + `public section` + `public import`), keeping all `private` modifiers and marking the command-elaborator cluster in `Setup.lean` `meta`. Test, example, and docs files stay legacy and build against the now-module library; the full `lake build` is green.

🤖 Prepared with Claude Code