### PR TITLE
build: precompileModules for LeanBench so module-exe consumers link register

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -30,6 +30,7 @@ rev = "main"
 
 [[lean_lib]]
 name = "LeanBench"
+precompileModules = true
 
 # --- examples ---
 # Lib and exe names are deliberately verbose so they don't collide


### PR DESCRIPTION
This PR enables `precompileModules` on the `LeanBench` library so that module-based executable consumers can call `LeanBench.register` from top-level `initialize` blocks. Without it, such a consumer fails to build with "could not find native implementation of external declaration `LeanBench.register`". `LeanBench` has no FFI of its own, and the library, examples, and tests all build green.

🤖 Prepared with Claude Code